### PR TITLE
Add uuid5 identifiers to temporal FHS specs

### DIFF
--- a/priority_variables_transform/temporal/FHS/bdy_wgt.yaml
+++ b/priority_variables_transform/temporal/FHS/bdy_wgt.yaml
@@ -2,12 +2,10 @@
     MeasurementObservation:
       populated_from: pht000031
       slot_derivations:
-        age_at_observation:
         associated_participant:
           populated_from: phv00008379
         associated_visit:
-          value: FHS OFFSPRING EXAM 2
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008379}) + ":EXAM 2")'
         observation_type:
           value: OBA:VT0001259
           range: string

--- a/priority_variables_transform/temporal/FHS/visit.yaml
+++ b/priority_variables_transform/temporal/FHS/visit.yaml
@@ -2,6 +2,11 @@
     Visit:
       populated_from: pht003099
       slot_derivations:
+        id:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00177926}) + ":EXAM 1")'
+        name:
+          value: EXAM 1
+          range: string
         associated_participant:
           populated_from: phv00177926
         age_at_visit_start:
@@ -11,6 +16,11 @@
     Visit:
       populated_from: pht003099
       slot_derivations:
+        id:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00177926}) + ":EXAM 2")'
+        name:
+          value: EXAM 2
+          range: string
         associated_participant:
           populated_from: phv00177926
         age_at_visit_start:
@@ -20,8 +30,13 @@
     Visit:
       populated_from: pht003099
       slot_derivations:
+        id:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00177926}) + ":EXAM 3")'
+        name:
+          value: EXAM 3
+          range: string
         associated_participant:
           populated_from: phv00177926
         age_at_visit_start:
           #age at exam 3
-          populated_from: phv00177934          
+          populated_from: phv00177934


### PR DESCRIPTION
## Summary

- **visit.yaml**: Add deterministic `id` via `uuid5()` and `name` field to each Visit block
- **bdy_wgt.yaml**: Replace string-based `associated_visit` with `uuid5()` expression that produces matching Visit references; remove empty `age_at_observation` that caused `ValueError`

## How it works

Both specs use `uuid5("https://w3id.org/bdchm/Visit", str(participant_id) + ":EXAM N")` to generate deterministic UUIDs. Since uuid5 is deterministic, the Visit `id` and the MeasurementObservation `associated_visit` will produce matching identifiers for the same participant + exam combination, even though they're processed independently from different source tables.

## Dependencies

- Requires linkml-map `uuid5-expr-function` branch (linkml/linkml-map#116)
- Tested with dm-bip `skip-missing-data-files` branch (linkml/dm-bip#263)

## Test plan

- [x] Run temporal FHS specs through dm-bip pipeline on BDC Data Studio
- [x] Verify Visit entities have uuid5 `id` values
- [x] Verify MeasurementObservation `associated_visit` matches corresponding Visit `id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)