### PR TITLE
Fix v35 participant PHV regression in FHS-ingest

### DIFF
--- a/priority_variables_transform/FHS-ingest/afib.yaml
+++ b/priority_variables_transform/FHS-ingest/afib.yaml
@@ -469,9 +469,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         condition_concept:
           value: MONDO:0004981
           range: string

--- a/priority_variables_transform/FHS-ingest/albumin_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/albumin_bld.yaml
@@ -75,9 +75,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         observation_type:
           value: OMOP:2212186
           range: string
@@ -123,9 +123,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OMOP:2212186
           range: string

--- a/priority_variables_transform/FHS-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/FHS-ingest/albumin_urine.yaml
@@ -262,9 +262,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation: 
           expr: case(({phv00227024} == 1, {pht003099.phv00177944} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/alt_sgpt.yaml
+++ b/priority_variables_transform/FHS-ingest/alt_sgpt.yaml
@@ -66,9 +66,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/angina.yaml
+++ b/priority_variables_transform/FHS-ingest/angina.yaml
@@ -3,9 +3,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         condition_concept:
           value: HP:0001681
           range: string

--- a/priority_variables_transform/FHS-ingest/apnea_hypop_index.yaml
+++ b/priority_variables_transform/FHS-ingest/apnea_hypop_index.yaml
@@ -3,9 +3,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'
         observation_type:
@@ -27,9 +27,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/ast_sgot.yaml
+++ b/priority_variables_transform/FHS-ingest/ast_sgot.yaml
@@ -99,9 +99,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00081047} == 7, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/asthma.yaml
+++ b/priority_variables_transform/FHS-ingest/asthma.yaml
@@ -1396,9 +1396,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         condition_concept:
           value: MONDO:0004979
           range: string
@@ -1670,9 +1670,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0004979
           range: string
@@ -1693,9 +1693,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0004979
           range: string
@@ -1850,9 +1850,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         condition_concept:
           value: MONDO:0004979
           range: string

--- a/priority_variables_transform/FHS-ingest/basophil_ncnc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/basophil_ncnc_bld.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/FHS-ingest/bdy_hgt.yaml
@@ -723,9 +723,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'  
         observation_type:
@@ -891,9 +891,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -1035,9 +1035,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'     
         observation_type:
@@ -1059,9 +1059,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'   
         observation_type:
@@ -1905,9 +1905,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -1929,9 +1929,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'    
         observation_type:
@@ -1953,9 +1953,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'    
         observation_type:
@@ -1977,9 +1977,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'    
         observation_type:

--- a/priority_variables_transform/FHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/FHS-ingest/bdy_wgt.yaml
@@ -27,9 +27,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -51,9 +51,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -1107,9 +1107,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'
         observation_type:
@@ -1131,9 +1131,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'
         observation_type:
@@ -1155,9 +1155,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'
         observation_type:
@@ -1179,9 +1179,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/bilirubin_tot.yaml
+++ b/priority_variables_transform/FHS-ingest/bilirubin_tot.yaml
@@ -111,9 +111,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/bmi.yaml
+++ b/priority_variables_transform/FHS-ingest/bmi.yaml
@@ -3,9 +3,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/bun.yaml
+++ b/priority_variables_transform/FHS-ingest/bun.yaml
@@ -75,9 +75,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
           range: string
         observation_type:
           value: OBA:VT0005265

--- a/priority_variables_transform/FHS-ingest/cig_smok.yaml
+++ b/priority_variables_transform/FHS-ingest/cig_smok.yaml
@@ -111,9 +111,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -349,9 +349,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'  
         observation_type:
@@ -387,9 +387,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'   
         observation_type:
@@ -405,9 +405,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'   
         observation_type:
@@ -423,9 +423,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'   
         observation_type:
@@ -441,9 +441,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'   
         observation_type:
@@ -459,9 +459,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'   
         observation_type:
@@ -477,9 +477,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'   
         observation_type:

--- a/priority_variables_transform/FHS-ingest/copd.yaml
+++ b/priority_variables_transform/FHS-ingest/copd.yaml
@@ -95,9 +95,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0005002
           range: string
@@ -231,9 +231,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         condition_concept:
           value: MONDO:0005002
           range: string

--- a/priority_variables_transform/FHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/creat_bld.yaml
@@ -414,9 +414,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))             
         observation_type:
@@ -510,9 +510,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OBA:2050096
           range: string
@@ -532,9 +532,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -556,9 +556,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -602,9 +602,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -624,9 +624,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -646,9 +646,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -668,9 +668,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -690,9 +690,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -904,9 +904,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -928,9 +928,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'  
         observation_type:
@@ -952,9 +952,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         observation_type:

--- a/priority_variables_transform/FHS-ingest/creat_urin.yaml
+++ b/priority_variables_transform/FHS-ingest/creat_urin.yaml
@@ -173,9 +173,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/crp.yaml
+++ b/priority_variables_transform/FHS-ingest/crp.yaml
@@ -141,9 +141,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/demography.yaml
+++ b/priority_variables_transform/FHS-ingest/demography.yaml
@@ -198,9 +198,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         sex:
           expr: 'case(({phv00254030} == 1, "OMOP:8507"), (True, "OMOP:8532"))'
 - class_derivations:
@@ -208,9 +208,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1-3''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1-3''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1-3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1-3''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1-3''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1-3'')))'
         sex:
           populated_from: phv00277017
           value_mappings:
@@ -322,9 +322,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1-10''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1-5'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1-10''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1-5'')))'
         sex:
           populated_from: phv00423870
           value_mappings:

--- a/priority_variables_transform/FHS-ingest/eosinophil_ncnc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/eosinophil_ncnc_bld.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({pht003099.phv00227024} == 7, {phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/fast_gluc_bld.yaml
@@ -27,9 +27,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'
         observation_type:
@@ -51,9 +51,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'
         observation_type:
@@ -97,9 +97,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
           range: string
@@ -119,9 +119,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
           range: string
@@ -141,9 +141,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
           range: string
@@ -163,9 +163,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
           range: string
@@ -185,9 +185,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
           range: string
@@ -207,9 +207,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
           range: string
@@ -229,9 +229,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'
         observation_type:
@@ -253,9 +253,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'
         observation_type:
@@ -277,9 +277,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'
         observation_type:
@@ -301,9 +301,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/fev1.yaml
+++ b/priority_variables_transform/FHS-ingest/fev1.yaml
@@ -123,9 +123,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/fvc.yaml
+++ b/priority_variables_transform/FHS-ingest/fvc.yaml
@@ -147,9 +147,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:

--- a/priority_variables_transform/FHS-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/glucose_bld.yaml
@@ -963,9 +963,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -1083,9 +1083,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1105,9 +1105,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -1129,9 +1129,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -1175,9 +1175,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1197,9 +1197,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1219,9 +1219,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1241,9 +1241,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1263,9 +1263,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1285,9 +1285,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1307,9 +1307,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1329,9 +1329,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1879,9 +1879,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -1903,9 +1903,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -1927,9 +1927,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'  
         observation_type:
@@ -1951,9 +1951,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         observation_type:

--- a/priority_variables_transform/FHS-ingest/hdl.yaml
+++ b/priority_variables_transform/FHS-ingest/hdl.yaml
@@ -408,9 +408,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -546,9 +546,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -667,9 +667,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -694,9 +694,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -746,9 +746,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -771,9 +771,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -796,9 +796,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -821,9 +821,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -846,9 +846,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -871,9 +871,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -896,9 +896,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -921,9 +921,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -1216,9 +1216,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365' 
         observation_type:
@@ -1243,9 +1243,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365' 
         observation_type:
@@ -1270,9 +1270,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365' 
         observation_type:
@@ -1297,9 +1297,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365' 
         observation_type:
@@ -1405,9 +1405,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":FHS OFFSPRING EXAM 9, OMNI 1 EXAM 4")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":FHS OFFSPRING EXAM 9, OMNI 1 EXAM 4")'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'
         observation_type:
@@ -1513,9 +1513,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{phv00277020} * 365'
         observation_type:
@@ -1540,9 +1540,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{phv00277021} * 365'
         observation_type:
@@ -1592,9 +1592,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string

--- a/priority_variables_transform/FHS-ingest/hemat.yaml
+++ b/priority_variables_transform/FHS-ingest/hemat.yaml
@@ -507,9 +507,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 20, {pht003099.phv00177946} * 365), case({phv00227024} == 21, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/hemo.yaml
+++ b/priority_variables_transform/FHS-ingest/hemo.yaml
@@ -195,9 +195,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/FHS-ingest/hemo_a1c.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/hip_circ.yaml
+++ b/priority_variables_transform/FHS-ingest/hip_circ.yaml
@@ -267,9 +267,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -291,9 +291,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))            
         observation_type:
@@ -315,9 +315,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -569,9 +569,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -593,9 +593,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -617,9 +617,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         observation_type:

--- a/priority_variables_transform/FHS-ingest/hist_cor_angio.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_cor_angio.yaml
@@ -138,9 +138,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         procedure_concept:
           populated_from: phv00055299
           value_mappings:

--- a/priority_variables_transform/FHS-ingest/hist_cvd.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_cvd.yaml
@@ -3,9 +3,9 @@
       populated_from: pht003316
       slot_derivations:
         associated_participant:
-          populated_from: phv00190815
+          populated_from: phv00190814
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00190815}) + ":" + case(({phv00190815} == ''0'', ''FHS ORIGINAL SFS''), ({phv00190815} == ''1'', ''FHS OFFSPRING SFS''), ({phv00190815} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00190815} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00190815} == ''7'', ''FHS OMNI 1 SFS''), ({phv00190815} == ''72'', ''FHS OMNI 2 SFS'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00190814}) + ":" + case(({phv00190815} == ''0'', ''FHS ORIGINAL SFS''), ({phv00190815} == ''1'', ''FHS OFFSPRING SFS''), ({phv00190815} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00190815} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00190815} == ''7'', ''FHS OMNI 1 SFS''), ({phv00190815} == ''72'', ''FHS OMNI 2 SFS'')))'
         condition_concept:
           value: MONDO:0005010
           range: string
@@ -70,9 +70,9 @@
       populated_from: pht003316
       slot_derivations:
         associated_participant:
-          populated_from: phv00190815
+          populated_from: phv00190814
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00190815}) + ":" + case(({phv00190815} == ''0'', ''FHS ORIGINAL SFS''), ({phv00190815} == ''1'', ''FHS OFFSPRING SFS''), ({phv00190815} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00190815} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00190815} == ''7'', ''FHS OMNI 1 SFS''), ({phv00190815} == ''72'', ''FHS OMNI 2 SFS'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00190814}) + ":" + case(({phv00190815} == ''0'', ''FHS ORIGINAL SFS''), ({phv00190815} == ''1'', ''FHS OFFSPRING SFS''), ({phv00190815} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00190815} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00190815} == ''7'', ''FHS OMNI 1 SFS''), ({phv00190815} == ''72'', ''FHS OMNI 2 SFS'')))'
         condition_concept:
           value: MONDO:0004995
           range: string
@@ -92,9 +92,9 @@
       populated_from: pht003316
       slot_derivations:
         associated_participant:
-          populated_from: phv00190815
+          populated_from: phv00190814
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00190815}) + ":" + case(({phv00190815} == ''0'', ''FHS ORIGINAL SFS''), ({phv00190815} == ''1'', ''FHS OFFSPRING SFS''), ({phv00190815} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00190815} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00190815} == ''7'', ''FHS OMNI 1 SFS''), ({phv00190815} == ''72'', ''FHS OMNI 2 SFS'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00190814}) + ":" + case(({phv00190815} == ''0'', ''FHS ORIGINAL SFS''), ({phv00190815} == ''1'', ''FHS OFFSPRING SFS''), ({phv00190815} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00190815} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00190815} == ''7'', ''FHS OMNI 1 SFS''), ({phv00190815} == ''72'', ''FHS OMNI 2 SFS'')))'
         condition_concept:
           value: MONDO:0005009
           range: string

--- a/priority_variables_transform/FHS-ingest/hist_hrtdis.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_hrtdis.yaml
@@ -1633,9 +1633,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0006955
           range: string
@@ -1657,9 +1657,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0005267
           range: string

--- a/priority_variables_transform/FHS-ingest/hist_hrtfail.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_hrtfail.yaml
@@ -360,9 +360,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0005252
           range: string

--- a/priority_variables_transform/FHS-ingest/hist_my_inf.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_my_inf.yaml
@@ -1841,9 +1841,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0005068
           range: string
@@ -1865,9 +1865,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0006803
           range: string
@@ -1889,9 +1889,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: MONDO:0005068
           range: string

--- a/priority_variables_transform/FHS-ingest/hrtrt.yaml
+++ b/priority_variables_transform/FHS-ingest/hrtrt.yaml
@@ -1286,9 +1286,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OBA:1001087
           range: string

--- a/priority_variables_transform/FHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/FHS-ingest/hypert_trt.yaml
@@ -77,9 +77,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: HP:0000822
           range: string
@@ -99,9 +99,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         drug_concept:
           expr: case(({phv00254024} == 1, '''RxCUI:C02'''))
         expsoure_provenance:
@@ -681,9 +681,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055253} == 1, '''RxCUI:C02'''))
         expsoure_provenance:
@@ -694,9 +694,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055341} == 1, '''RxCUI:C02'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/hypertension.yaml
+++ b/priority_variables_transform/FHS-ingest/hypertension.yaml
@@ -25,9 +25,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: HP:0000822
           range: string
@@ -47,9 +47,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: HP:0000822
           range: string
@@ -264,9 +264,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":FHS OFFSPRING BASELINE")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":FHS OFFSPRING BASELINE")'
         condition_concept:
           value: NCIT:C3117
           range: string

--- a/priority_variables_transform/FHS-ingest/ldl.yaml
+++ b/priority_variables_transform/FHS-ingest/ldl.yaml
@@ -111,9 +111,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -138,9 +138,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -165,9 +165,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -192,9 +192,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -219,9 +219,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'  
         observation_type:
@@ -246,9 +246,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         observation_type:
@@ -298,9 +298,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -323,9 +323,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -348,9 +348,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -373,9 +373,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -398,9 +398,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -423,9 +423,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -448,9 +448,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -473,9 +473,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string

--- a/priority_variables_transform/FHS-ingest/lvh_ekg.yaml
+++ b/priority_variables_transform/FHS-ingest/lvh_ekg.yaml
@@ -74,9 +74,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: HP:0001712
           range: string
@@ -1558,9 +1558,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         condition_concept:
           value: HP:0001712
           range: string
@@ -1581,9 +1581,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         condition_concept:
           value: HP:0001712
           range: string
@@ -1604,9 +1604,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         condition_concept:
           value: HP:0001712
           range: string
@@ -1627,9 +1627,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         condition_concept:
           value: HP:0001712
           range: string
@@ -1650,9 +1650,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         condition_concept:
           value: HP:0001712
           range: string
@@ -1673,9 +1673,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         condition_concept:
           value: HP:0001712
           range: string

--- a/priority_variables_transform/FHS-ingest/mch.yaml
+++ b/priority_variables_transform/FHS-ingest/mch.yaml
@@ -27,9 +27,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/mchc.yaml
+++ b/priority_variables_transform/FHS-ingest/mchc.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/mcv.yaml
+++ b/priority_variables_transform/FHS-ingest/mcv.yaml
@@ -75,9 +75,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))            
         observation_type:

--- a/priority_variables_transform/FHS-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/monocyte_ncnc_bld.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 1, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/FHS-ingest/platelet_ct.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -75,9 +75,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":FHS OMNI 1 EXAM 1")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":FHS OMNI 1 EXAM 1")'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/pmv.yaml
+++ b/priority_variables_transform/FHS-ingest/pmv.yaml
@@ -27,9 +27,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/FHS-ingest/qrs_ekg.yaml
@@ -99,9 +99,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -963,9 +963,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OMOP:4273021
           range: string
@@ -985,9 +985,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OMOP:4273021
           range: string
@@ -1007,9 +1007,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OMOP:4273021
           range: string

--- a/priority_variables_transform/FHS-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/FHS-ingest/rdbld_ct.yaml
@@ -27,9 +27,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:

--- a/priority_variables_transform/FHS-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/FHS-ingest/sleep_duration_daily.yaml
@@ -147,9 +147,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -171,9 +171,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 7, {pht003099.phv00177936} * 365))            
         observation_type:
@@ -387,9 +387,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'  
         observation_type:
@@ -411,9 +411,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'  
         observation_type:
@@ -435,9 +435,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'  
         observation_type:
@@ -459,9 +459,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":FHS SHHS OFFSPRING")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":FHS SHHS OFFSPRING")'
         age_at_observation:
           expr: '{phv00056587} * 365'
         observation_type:

--- a/priority_variables_transform/FHS-ingest/sodium_blood.yaml
+++ b/priority_variables_transform/FHS-ingest/sodium_blood.yaml
@@ -27,9 +27,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OBA:VT0001776
           range: string

--- a/priority_variables_transform/FHS-ingest/spo2.yaml
+++ b/priority_variables_transform/FHS-ingest/spo2.yaml
@@ -3,9 +3,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         method_type:
           value: lowest of repeated measurements
           range: string

--- a/priority_variables_transform/FHS-ingest/stroke.yaml
+++ b/priority_variables_transform/FHS-ingest/stroke.yaml
@@ -401,9 +401,9 @@
       populated_from: pht006024
       slot_derivations:
         associated_participant:
-          populated_from: phv00276970
+          populated_from: phv00276969
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276970}) + ":" + case(({phv00276970} == ''0'', ''FHS ORIGINAL SFS''), ({phv00276970} == ''1'', ''FHS OFFSPRING SFS''), ({phv00276970} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00276970} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00276970} == ''7'', ''FHS OMNI 1 SFS''), ({phv00276970} == ''72'', ''FHS OMNI 2 SFS'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276969}) + ":" + case(({phv00276970} == ''0'', ''FHS ORIGINAL SFS''), ({phv00276970} == ''1'', ''FHS OFFSPRING SFS''), ({phv00276970} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00276970} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00276970} == ''7'', ''FHS OMNI 1 SFS''), ({phv00276970} == ''72'', ''FHS OMNI 2 SFS'')))'
         condition_concept:
           value: HP:0001297
           range: string
@@ -425,9 +425,9 @@
       populated_from: pht006024
       slot_derivations:
         associated_participant:
-          populated_from: phv00276970
+          populated_from: phv00276969
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276970}) + ":" + case(({phv00276970} == ''0'', ''FHS ORIGINAL SFS''), ({phv00276970} == ''1'', ''FHS OFFSPRING SFS''), ({phv00276970} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00276970} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00276970} == ''7'', ''FHS OMNI 1 SFS''), ({phv00276970} == ''72'', ''FHS OMNI 2 SFS'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276969}) + ":" + case(({phv00276970} == ''0'', ''FHS ORIGINAL SFS''), ({phv00276970} == ''1'', ''FHS OFFSPRING SFS''), ({phv00276970} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00276970} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00276970} == ''7'', ''FHS OMNI 1 SFS''), ({phv00276970} == ''72'', ''FHS OMNI 2 SFS'')))'
         condition_concept:
           populated_from: phv00276972
           value_mappings:
@@ -465,9 +465,9 @@
       populated_from: pht006024
       slot_derivations:
         associated_participant:
-          populated_from: phv00276970
+          populated_from: phv00276969
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276970}) + ":" + case(({phv00276970} == ''0'', ''FHS ORIGINAL SFS''), ({phv00276970} == ''1'', ''FHS OFFSPRING SFS''), ({phv00276970} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00276970} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00276970} == ''7'', ''FHS OMNI 1 SFS''), ({phv00276970} == ''72'', ''FHS OMNI 2 SFS'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276969}) + ":" + case(({phv00276970} == ''0'', ''FHS ORIGINAL SFS''), ({phv00276970} == ''1'', ''FHS OFFSPRING SFS''), ({phv00276970} == ''2'', ''FHS NEW OFFSPRING SPOUSE SFS''), ({phv00276970} == ''3'', ''FHS GENERATION 3 SFS''), ({phv00276970} == ''7'', ''FHS OMNI 1 SFS''), ({phv00276970} == ''72'', ''FHS OMNI 2 SFS'')))'
         condition_concept:
           value: HP:0001297
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_aceinhib.yaml
@@ -3,9 +3,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276805} == 1, '''RxCUI:C09A'''))
         expsoure_provenance:
@@ -225,9 +225,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055377} == 1, '''RxCUI:C09A'''))
         expsoure_provenance:
@@ -238,9 +238,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055378} == 1, '''RxCUI:C09BA'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_aldorecepblk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_aldorecepblk.yaml
@@ -211,9 +211,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276808} == 1, '''RxCUI:9997'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_alphablk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_alphablk.yaml
@@ -133,9 +133,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055363} == 1, '''RxCUI:CV150'''))
         expsoure_provenance:
@@ -146,9 +146,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055364} == 1, '''RxCUI:N0000175562'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_angiorecepblk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_angiorecepblk.yaml
@@ -81,9 +81,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276809} == 1, '''RxCUI:C09C'''))
         expsoure_provenance:
@@ -94,9 +94,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276809} == 1, '''RxCUI:C09C'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_betablk.yaml
@@ -55,9 +55,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276806} == 1, "RxCUI:C07A"))
         expsoure_provenance:
@@ -490,9 +490,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":FHS OFFSPRING BASELINE")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":FHS OFFSPRING BASELINE")'
         drug_concept:
           expr: case(({phv00055374} == 1, "RxCUI:C07A"))
         expsoure_provenance:
@@ -503,9 +503,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":FHS OFFSPRING BASELINE")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":FHS OFFSPRING BASELINE")'
         drug_concept:
           expr: case(({phv00055375} == 1, "RxCUI:C07A"))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_calchanblk.yaml
@@ -350,9 +350,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055376} == 1, "RxCUI:C08"))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_diuret.yaml
@@ -861,9 +861,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055358} == 1, '''RxCUI:CV702'''))
         expsoure_provenance:
@@ -874,9 +874,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055359} == 1, '''RxCUI:N0000175419'''))
         expsoure_provenance:
@@ -887,9 +887,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055381} == 1, '''RxCUI:C03'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_insulin.yaml
@@ -302,9 +302,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055345} == 1, '''RxCUI:D007328'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_med_diab.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_med_diab.yaml
@@ -29,9 +29,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         drug_concept:
           expr: case(({phv00254028} == 1, '''RxCUI:A10'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_nstat_med.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_nstat_med.yaml
@@ -497,9 +497,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055369} == 1, '''RxCUI:N0000180292'''))
         expsoure_provenance:
@@ -510,9 +510,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055370} == 1, '''RxCUI:N0000175594'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_statin.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_statin.yaml
@@ -120,9 +120,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276812} == 1, '''RxCUI:N0000175589'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tak_vasodil.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_vasodil.yaml
@@ -224,9 +224,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055368} == 1, '''RxCUI:C04'''))
         expsoure_provenance:
@@ -237,9 +237,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055379} == 1, '''RxCUI:C01D'''))
         expsoure_provenance:
@@ -250,9 +250,9 @@
       populated_from: pht000395
       slot_derivations:
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         drug_concept:
           expr: case(({phv00055380} == 1, '''RxCUI:C02L'''))
         expsoure_provenance:
@@ -289,9 +289,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         drug_concept:
           expr: case(({phv00276811} == 1, '''RxCUI:5470'''))
         expsoure_provenance:

--- a/priority_variables_transform/FHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/tot_chol_bld.yaml
@@ -105,11 +105,11 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -609,11 +609,11 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -633,11 +633,11 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -768,9 +768,9 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":UNKNOWN")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -1358,11 +1358,11 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -1382,11 +1382,11 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -1406,11 +1406,11 @@
           value: mg/dl
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         value_quantity:
           object_derivations:
           - class_derivations:

--- a/priority_variables_transform/FHS-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/triglyc_bld.yaml
@@ -630,11 +630,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -684,11 +684,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1'')))'
         age_at_observation:
           expr: '{phv00056587} * 365'  
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -711,11 +711,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -738,11 +738,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -765,11 +765,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -792,11 +792,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -819,11 +819,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         method_type:
           value: fasting minimum 12 hrs
           range: string          
@@ -846,11 +846,11 @@
           value: mg/dL
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         method_type:
           value: fasting minimum 12 hrs
           range: string          

--- a/priority_variables_transform/FHS-ingest/troponin.yaml
+++ b/priority_variables_transform/FHS-ingest/troponin.yaml
@@ -43,9 +43,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OMOP:8842
           range: string

--- a/priority_variables_transform/FHS-ingest/valv_hrtdis.yaml
+++ b/priority_variables_transform/FHS-ingest/valv_hrtdis.yaml
@@ -50,9 +50,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         condition_concept:
           value: MONDO:0042981
           range: string
@@ -99,9 +99,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         condition_concept:
           value: MONDO:0005648
           range: string
@@ -148,9 +148,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         condition_concept:
           value: HP:0001653
           range: string
@@ -197,9 +197,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         condition_concept:
           value: HP:0001718
           range: string

--- a/priority_variables_transform/FHS-ingest/visit.yaml
+++ b/priority_variables_transform/FHS-ingest/visit.yaml
@@ -518,11 +518,11 @@
       populated_from: pht000395
       slot_derivations:
         id:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056607}) + ":" + case(({phv00056607} == 1, ''FHS OFFSPRING SHHS''), case({phv00177928} == 7, ''FHS OMNI 1 SHHS'')) + '' BASELINE'')'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == 1, ''FHS OFFSPRING SHHS''), case({phv00177928} == 7, ''FHS OMNI 1 SHHS'')) + '' BASELINE'')'
         name:
           expr: 'case(({phv00056607} == 1, ''FHS OFFSPRING SHHS''), case({phv00177928} == 7, ''FHS OMNI 1 SHHS'')) + '' BASELINE'''
         associated_participant:
-          populated_from: phv00056607
+          populated_from: phv00056635
         age_at_visit_start:
           expr: '{phv00056587} * 365'
         age_at_visit_end:

--- a/priority_variables_transform/FHS-ingest/waist_circ.yaml
+++ b/priority_variables_transform/FHS-ingest/waist_circ.yaml
@@ -171,9 +171,9 @@
       populated_from: pht005140
       slot_derivations:
         associated_participant:
-          populated_from: phv00254011
+          populated_from: phv00254010
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254011}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00254011} == 1, {pht003099.phv00177946} * 365), case({phv00254011} == 1, {pht003099.phv00177936} * 365))
         observation_type:
@@ -483,9 +483,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 1''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -507,9 +507,9 @@
       populated_from: pht006026
       slot_derivations:
         associated_participant:
-          populated_from: phv00277016
+          populated_from: phv00277015
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277016}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00277015}) + ":" + case(({phv00277016} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00277016} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -531,9 +531,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 1''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 1'')))'
         age_at_observation:
           expr: '{pht003099.phv00177930} * 365'  
         observation_type:
@@ -555,9 +555,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 2''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 2'')))'
         age_at_observation:
           expr: '{pht003099.phv00177932} * 365'  
         observation_type:
@@ -579,9 +579,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 3''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 3'')))'
         age_at_observation:
           expr: '{pht003099.phv00177934} * 365'  
         observation_type:
@@ -603,9 +603,9 @@
       populated_from: pht009761
       slot_derivations:
         associated_participant:
-          populated_from: phv00423869
+          populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423869}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 4''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: '{pht003099.phv00177936} * 365'  
         observation_type:

--- a/priority_variables_transform/FHS-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/FHS-ingest/whtbld_ct.yaml
@@ -51,9 +51,9 @@
       populated_from: pht004802
       slot_derivations:
         associated_participant:
-          populated_from: phv00227024
+          populated_from: phv00227023
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227024}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00227023}) + ":" + case(({phv00227024} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00227024} == ''7'', ''FHS OMNI 1 EXAM 4'')))'
         age_at_observation:
           expr: case(({phv00227024} == 1, {pht003099.phv00177946} * 365), case({phv00227024} == 7, {pht003099.phv00177936} * 365))
         observation_type:
@@ -99,9 +99,9 @@
       populated_from: pht006018
       slot_derivations:
         associated_participant:
-          populated_from: phv00276845
+          populated_from: phv00276803
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276845}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF'')))'
         observation_type:
           value: OBA:VT0000217
           range: string


### PR DESCRIPTION
## Summary

- Restores correct `associated_participant.populated_from` PHVs in 234 multi-visit blocks across 71 FHS-ingest YAML files
- Fixes corresponding `str()` references in uuid5 visit expressions to use the participant PHV (not the visit PHV)
- Affects 8 pht tables: pht000395, pht003316, pht004802, pht005140, pht006018, pht006024, pht006026, pht009761

## Background

The v35 merge (PR #358) systematically changed `associated_participant.populated_from` to match `associated_visit.populated_from` in multi-visit blocks, overwriting the correct participant PHV with the visit PHV. The uuid5 addition (PR #359) then propagated these wrong PHVs into `str()` expressions.

**Note:** pht002889 (phv00172159) is excluded — it had a pre-existing duplicate in v33 that needs separate curator review.

## Test plan

- [x] `validate_ingest_yamls.py` passes all files
- [x] Cross-referenced all 8 pht tables against v33 — participant PHVs match exactly
- [x] Verified uuid5 structure: `str()` uses participant PHV, `case()` uses visit PHV
- [x] Verified visit.yaml pht000395 block restored correctly
- [x] Confirmed pht002889 blocks unchanged (phv00172159 preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)