### PR TITLE
FHS: Standardize relationship_to_participant to ONESELF

### DIFF
--- a/priority_variables_transform/FHS-ingest/diabetes.yaml
+++ b/priority_variables_transform/FHS-ingest/diabetes.yaml
@@ -20,7 +20,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -43,7 +43,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -66,7 +66,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -89,7 +89,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -112,7 +112,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -135,7 +135,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -158,7 +158,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -181,7 +181,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -204,7 +204,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -227,7 +227,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -250,7 +250,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -273,7 +273,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -296,7 +296,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -319,7 +319,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -342,7 +342,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -365,7 +365,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -388,7 +388,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -411,7 +411,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -434,7 +434,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -457,7 +457,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -480,7 +480,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -503,7 +503,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -526,7 +526,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -549,7 +549,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -572,7 +572,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -595,7 +595,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -618,7 +618,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -641,7 +641,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -664,7 +664,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -687,7 +687,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -710,7 +710,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -733,7 +733,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -756,7 +756,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -779,7 +779,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -802,7 +802,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -825,7 +825,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -848,7 +848,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -871,7 +871,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -894,7 +894,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -917,7 +917,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -940,7 +940,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -963,7 +963,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -986,7 +986,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1009,7 +1009,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1032,7 +1032,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1055,7 +1055,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1078,7 +1078,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1101,7 +1101,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1124,7 +1124,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1147,7 +1147,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1170,7 +1170,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1193,7 +1193,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1216,7 +1216,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1239,7 +1239,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1262,7 +1262,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1285,7 +1285,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1308,7 +1308,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1331,7 +1331,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1354,7 +1354,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1377,7 +1377,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1400,7 +1400,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1423,7 +1423,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1446,7 +1446,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1469,7 +1469,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1492,7 +1492,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1515,7 +1515,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1538,7 +1538,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1561,7 +1561,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1584,7 +1584,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1607,7 +1607,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1630,7 +1630,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1653,7 +1653,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1676,7 +1676,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1699,7 +1699,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1722,7 +1722,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1746,7 +1746,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1769,7 +1769,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1792,7 +1792,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1815,7 +1815,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1838,5 +1838,5 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string

--- a/priority_variables_transform/FHS-ingest/hypertension.yaml
+++ b/priority_variables_transform/FHS-ingest/hypertension.yaml
@@ -18,7 +18,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -40,7 +40,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -63,7 +63,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -86,7 +86,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -111,7 +111,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -134,7 +134,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -159,7 +159,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -181,7 +181,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -204,7 +204,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -226,7 +226,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -249,7 +249,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -272,7 +272,7 @@
           value: SELF_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -294,5 +294,5 @@
           value: SELF_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string


### PR DESCRIPTION
Fixes #381

Replaces \SELF\ with \ONESELF\ in the \elationship_to_participant\ slot across all Condition blocks in:
- **diabetes.yaml** (80 blocks)
- **hypertension.yaml** (13 blocks)

All other FHS Condition files already use \ONESELF\. This brings these two files into consistency.