### PR TITLE
FHS: Populate associated_evidence on 591 Condition blocks

### DIFF
--- a/priority_variables_transform/FHS-ingest/afib.yaml
+++ b/priority_variables_transform/FHS-ingest/afib.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -38,6 +41,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -61,6 +67,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -82,6 +91,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -105,6 +117,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -126,6 +141,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -149,6 +167,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -170,6 +191,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -193,6 +217,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -214,6 +241,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -237,6 +267,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -258,6 +291,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -281,6 +317,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -302,6 +341,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -325,6 +367,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -347,6 +392,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -368,6 +416,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -392,6 +443,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -414,6 +468,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -438,6 +495,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -461,6 +521,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -483,6 +546,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -504,6 +570,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/angina.yaml
+++ b/priority_variables_transform/FHS-ingest/angina.yaml
@@ -18,6 +18,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string

--- a/priority_variables_transform/FHS-ingest/asthma.yaml
+++ b/priority_variables_transform/FHS-ingest/asthma.yaml
@@ -18,6 +18,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -42,6 +45,9 @@
             '3': HISTORICAL
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -68,6 +74,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -92,6 +101,9 @@
             '9999': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -123,6 +135,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -152,6 +167,9 @@
             '9999': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -183,6 +201,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -206,6 +227,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -227,6 +251,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -250,6 +277,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -271,6 +301,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -294,6 +327,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -315,6 +351,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -338,6 +377,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -359,6 +401,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -382,6 +427,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -404,6 +452,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -425,6 +476,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -449,6 +503,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -470,6 +527,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -493,6 +553,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -514,6 +577,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -537,6 +603,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -559,6 +628,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -580,6 +652,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -604,6 +679,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -626,6 +704,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -647,6 +728,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -671,6 +755,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -692,6 +779,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -716,6 +806,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -737,6 +830,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -761,6 +857,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -783,6 +882,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -807,6 +909,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -829,6 +934,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -853,6 +961,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -876,6 +987,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -897,6 +1011,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -920,6 +1037,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -941,6 +1061,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -964,6 +1087,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -985,6 +1111,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1009,6 +1138,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1030,6 +1162,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1053,6 +1188,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1074,6 +1212,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1097,6 +1238,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1118,6 +1262,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1142,6 +1289,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1163,6 +1313,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1188,6 +1341,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1209,6 +1365,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1233,6 +1392,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1255,6 +1417,9 @@
             '2': HISTORICAL
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1279,6 +1444,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1301,6 +1469,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1322,6 +1493,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1346,6 +1520,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1368,6 +1545,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1387,6 +1567,9 @@
             (True, 'PRESENT'))
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1414,6 +1597,9 @@
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
             '8': PATIENT_SELF-REPORTED_CONDITION
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1433,6 +1619,9 @@
             (True, 'PRESENT'))
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1457,6 +1646,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1479,6 +1671,9 @@
             '2': UKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1506,6 +1701,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1529,6 +1727,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1550,6 +1751,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1574,6 +1778,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1597,6 +1804,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1616,6 +1826,9 @@
             ({phv00251236} == 1, 'PRESENT'))
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1640,6 +1853,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1661,6 +1877,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1685,6 +1904,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1706,6 +1928,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1730,6 +1955,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1751,6 +1979,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1775,6 +2006,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1797,6 +2031,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1818,6 +2055,9 @@
             '1': ABSENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1842,6 +2082,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1864,6 +2107,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1894,6 +2140,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1922,6 +2171,9 @@
             '9999': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/copd.yaml
+++ b/priority_variables_transform/FHS-ingest/copd.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -38,6 +41,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -63,6 +69,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -87,6 +96,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -108,6 +120,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -131,6 +146,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -153,6 +171,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -174,6 +195,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -199,6 +223,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -223,6 +250,9 @@
           value_mappings:
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -245,6 +275,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -266,6 +299,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/diabetes.yaml
+++ b/priority_variables_transform/FHS-ingest/diabetes.yaml
@@ -19,6 +19,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Awareness of Coronary Factors Questionnaire
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -41,6 +44,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -65,6 +71,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -87,6 +96,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -111,6 +123,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -133,6 +148,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -157,6 +175,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -179,6 +200,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -203,6 +227,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -225,6 +252,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -249,6 +279,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -271,6 +304,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -295,6 +331,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -317,6 +356,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -341,6 +383,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -363,6 +408,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -387,6 +435,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -409,6 +460,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -433,6 +487,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -455,6 +512,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -479,6 +539,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -501,6 +564,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -525,6 +591,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -547,6 +616,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -571,6 +643,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -593,6 +668,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -617,6 +695,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -639,6 +720,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -663,6 +747,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -685,6 +772,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -709,6 +799,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -731,6 +824,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -755,6 +851,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -777,6 +876,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -801,6 +903,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -823,6 +928,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -847,6 +955,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -869,6 +980,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -893,6 +1007,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -915,6 +1032,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -939,6 +1059,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -961,6 +1084,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -985,6 +1111,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1007,6 +1136,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1031,6 +1163,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1053,6 +1188,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1077,6 +1215,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1099,6 +1240,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1123,6 +1267,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1145,6 +1292,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1169,6 +1319,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1191,6 +1344,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1215,6 +1371,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1237,6 +1396,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1261,6 +1423,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1283,6 +1448,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1307,6 +1475,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1329,6 +1500,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1353,6 +1527,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1375,6 +1552,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1399,6 +1579,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1421,6 +1604,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1445,6 +1631,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1467,6 +1656,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1491,6 +1683,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1513,6 +1708,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1537,6 +1735,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1559,6 +1760,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1583,6 +1787,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1605,6 +1812,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1629,6 +1839,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1651,6 +1864,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1675,6 +1891,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1698,6 +1917,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1720,6 +1942,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1745,6 +1970,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1767,6 +1995,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -1791,6 +2022,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1814,6 +2048,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -1836,6 +2073,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF

--- a/priority_variables_transform/FHS-ingest/fam_stroke.yaml
+++ b/priority_variables_transform/FHS-ingest/fam_stroke.yaml
@@ -19,6 +19,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Awareness of Coronary Factors Questionnaire
+          range: string
         relationship_to_participant:
           value: NATURAL_FATHER
           range: string
@@ -42,6 +45,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Awareness of Coronary Factors Questionnaire
           range: string
         relationship_to_participant:
           value: NATURAL_MOTHER

--- a/priority_variables_transform/FHS-ingest/hist_cvd.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_cvd.yaml
@@ -18,6 +18,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -39,6 +42,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -62,6 +68,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: RNA sequencing
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -84,6 +93,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -105,6 +117,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/hist_hrtdis.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_hrtdis.yaml
@@ -16,6 +16,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -39,6 +42,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -60,6 +66,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -83,6 +92,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -103,6 +115,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -133,6 +148,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -162,6 +180,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -184,6 +205,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -208,6 +232,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -230,6 +257,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -254,6 +284,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -276,6 +309,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -301,6 +337,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -324,6 +363,9 @@
             '9': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -349,6 +391,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -372,6 +417,9 @@
             '9': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -397,6 +445,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -420,6 +471,9 @@
             '9': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -445,6 +499,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -468,6 +525,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -493,6 +553,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -516,6 +579,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -541,6 +607,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -564,6 +633,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -589,6 +661,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -612,6 +687,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -637,6 +715,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -660,6 +741,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -685,6 +769,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -708,6 +795,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -733,6 +823,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -756,6 +849,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -781,6 +877,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -804,6 +903,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -829,6 +931,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -852,6 +957,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -877,6 +985,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -900,6 +1011,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -925,6 +1039,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -948,6 +1065,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -973,6 +1093,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -996,6 +1119,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1021,6 +1147,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1044,6 +1173,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1069,6 +1201,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1092,6 +1227,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1117,6 +1255,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1140,6 +1281,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1165,6 +1309,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1188,6 +1335,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1213,6 +1363,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1236,6 +1389,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1263,6 +1419,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1289,6 +1448,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1312,6 +1474,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1337,6 +1502,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1360,6 +1528,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1385,6 +1556,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1408,6 +1582,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1433,6 +1610,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1456,6 +1636,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1481,6 +1664,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1504,6 +1690,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1529,6 +1718,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1552,6 +1744,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1577,6 +1772,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1600,6 +1798,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1625,6 +1826,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1648,6 +1852,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1673,6 +1880,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1697,6 +1907,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1720,6 +1933,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/hist_hrtfail.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_hrtfail.yaml
@@ -16,6 +16,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -36,6 +39,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -58,6 +64,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -78,6 +87,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Respiratory Disease Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -100,6 +112,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -120,6 +135,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -142,6 +160,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -162,6 +183,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -184,6 +208,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -204,6 +231,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -226,6 +256,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -246,6 +279,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -268,6 +304,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -288,6 +327,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -310,6 +352,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -330,6 +375,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -352,6 +400,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -372,6 +423,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -394,6 +448,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -414,6 +471,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -436,6 +496,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -456,6 +519,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -478,6 +544,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -498,6 +567,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -520,6 +592,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -540,6 +615,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -562,6 +640,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -582,6 +663,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -604,6 +688,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -624,6 +711,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/hist_my_inf.yaml
+++ b/priority_variables_transform/FHS-ingest/hist_my_inf.yaml
@@ -18,6 +18,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -51,6 +54,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -86,6 +92,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -111,6 +120,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -134,6 +146,9 @@
             '9997': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -162,6 +177,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -188,6 +206,9 @@
             '9999': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -217,6 +238,9 @@
             '9997': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -249,6 +273,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -279,6 +306,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -302,6 +332,9 @@
             '9999': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -327,6 +360,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram and Oscillograph
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -350,6 +386,9 @@
             '9': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -375,6 +414,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -398,6 +440,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -423,6 +468,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -447,6 +495,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -470,6 +521,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -498,6 +552,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -525,6 +582,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -548,6 +608,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -573,29 +636,8 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
-        relationship_to_participant:
-          value: ONESELF
-          range: string
-- class_derivations:
-    Condition:
-      populated_from: pht000021
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00004083
-        associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
-        condition_concept:
-          value: MONDO:0005068
-          range: string
-        condition_status:
-          populated_from: phv00004023
-          value_mappings:
-            '0': ABSENT
-            '1': HISTORICAL
-            '2': UNKNOWN
-            .: UNKNOWN
-        condition_provenance:
-          value: PATIENT_SELF-REPORTED_CONDITION
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -620,6 +662,36 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
+        relationship_to_participant:
+          value: ONESELF
+          range: string
+- class_derivations:
+    Condition:
+      populated_from: pht000021
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00004083
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
+        condition_concept:
+          value: MONDO:0005068
+          range: string
+        condition_status:
+          populated_from: phv00004023
+          value_mappings:
+            '0': ABSENT
+            '1': HISTORICAL
+            '2': UNKNOWN
+            .: UNKNOWN
+        condition_provenance:
+          value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -645,6 +717,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -668,6 +743,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -693,6 +771,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -716,6 +797,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -741,6 +825,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -764,6 +851,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -789,6 +879,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -812,6 +905,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -837,6 +933,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -860,6 +959,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -885,6 +987,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -908,6 +1013,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -933,6 +1041,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -956,6 +1067,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -981,6 +1095,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1004,6 +1121,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1029,6 +1149,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1052,6 +1175,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1077,6 +1203,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1101,29 +1230,8 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
-        relationship_to_participant:
-          value: ONESELF
-          range: string
-- class_derivations:
-    Condition:
-      populated_from: pht000032
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00008742
-        associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
-        condition_concept:
-          value: MONDO:0005068
-          range: string
-        condition_status:
-          populated_from: phv00008653
-          value_mappings:
-            '0': ABSENT
-            '1': HISTORICAL
-            '2': UNKNOWN
-            .: UNKNOWN
-        condition_provenance:
-          value: PATIENT_SELF-REPORTED_CONDITION
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1148,6 +1256,36 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
+        relationship_to_participant:
+          value: ONESELF
+          range: string
+- class_derivations:
+    Condition:
+      populated_from: pht000032
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00008742
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
+        condition_concept:
+          value: MONDO:0005068
+          range: string
+        condition_status:
+          populated_from: phv00008653
+          value_mappings:
+            '0': ABSENT
+            '1': HISTORICAL
+            '2': UNKNOWN
+            .: UNKNOWN
+        condition_provenance:
+          value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1173,6 +1311,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1196,6 +1337,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1221,6 +1365,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1244,6 +1391,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1269,6 +1419,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1292,6 +1445,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1317,6 +1473,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1340,6 +1499,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1365,6 +1527,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1388,6 +1553,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1413,6 +1581,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1436,6 +1607,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1465,6 +1639,9 @@
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
             '2': PATIENT_SELF-REPORTED_CONDITION
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1493,6 +1670,9 @@
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
             '2': PATIENT_SELF-REPORTED_CONDITION
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1521,6 +1701,9 @@
             '0': PATIENT_SELF-REPORTED_CONDITION
             '1': CLINICAL_DIAGNOSIS
             '2': PATIENT_SELF-REPORTED_CONDITION
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1544,6 +1727,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1569,6 +1755,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1592,6 +1781,9 @@
             .: UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1617,6 +1809,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1640,6 +1835,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1665,6 +1863,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1688,6 +1889,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1713,6 +1917,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1736,6 +1943,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1761,6 +1971,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1784,6 +1997,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1809,6 +2025,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1832,6 +2051,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1857,6 +2079,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1880,6 +2105,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1905,6 +2133,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1928,6 +2159,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1953,6 +2187,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1976,6 +2213,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2001,6 +2241,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2024,6 +2267,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2049,6 +2295,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2071,6 +2320,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2096,6 +2348,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2119,6 +2374,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2144,6 +2402,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2167,6 +2428,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2192,6 +2456,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2215,6 +2482,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2240,6 +2510,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2262,6 +2535,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2287,6 +2563,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2310,6 +2589,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2335,6 +2617,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2359,6 +2644,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2382,6 +2670,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2404,6 +2695,9 @@
             .: UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/FHS-ingest/hypert_trt.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -90,6 +93,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -255,6 +261,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -473,6 +482,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -555,6 +567,9 @@
             '1': HISTORICAL
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/hypertension.yaml
+++ b/priority_variables_transform/FHS-ingest/hypertension.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -38,6 +41,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -62,6 +68,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -84,6 +93,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: SELF
@@ -110,6 +122,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -132,6 +147,9 @@
             '2': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: SELF
@@ -158,6 +176,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -179,6 +200,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: SELF
@@ -202,6 +226,9 @@
             '2': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: SELF
@@ -248,6 +275,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -271,6 +301,9 @@
         condition_provenance:
           value: SELF_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Awareness of Coronary Factors Questionnaire
+          range: string
         relationship_to_participant:
           value: SELF
           range: string
@@ -292,6 +325,9 @@
             '1': PRESENT
         condition_provenance:
           value: SELF_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Awareness of Coronary Factors Questionnaire
           range: string
         relationship_to_participant:
           value: SELF

--- a/priority_variables_transform/FHS-ingest/lvh_ekg.yaml
+++ b/priority_variables_transform/FHS-ingest/lvh_ekg.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -66,6 +69,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -89,6 +95,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -114,6 +123,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -137,6 +149,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -162,6 +177,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -186,6 +204,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -208,6 +229,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -232,6 +256,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -254,6 +281,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -278,6 +308,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -300,6 +333,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -324,6 +360,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -346,6 +385,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -370,6 +412,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -392,6 +437,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -416,6 +464,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -438,6 +489,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -462,6 +516,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -484,6 +541,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -508,6 +568,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -530,6 +593,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -554,6 +620,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -601,6 +670,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -624,6 +696,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -649,6 +724,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -673,6 +751,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -694,6 +775,9 @@
             '1': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -719,6 +803,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -741,6 +828,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -765,6 +855,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -787,6 +880,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -811,6 +907,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -833,6 +932,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -857,6 +959,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -879,6 +984,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -903,6 +1011,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -925,6 +1036,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -949,6 +1063,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -971,6 +1088,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -996,6 +1116,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1019,6 +1142,9 @@
             '3': ABSENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1044,6 +1170,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1066,6 +1195,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1090,6 +1222,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1112,6 +1247,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1136,6 +1274,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1158,6 +1299,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1182,6 +1326,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1204,6 +1351,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1228,6 +1378,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1250,6 +1403,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: X-ray
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1274,6 +1430,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1296,6 +1455,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1320,6 +1482,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1342,6 +1507,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1366,6 +1534,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: X-ray
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1388,6 +1559,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1412,6 +1586,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1434,6 +1611,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1458,6 +1638,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1480,6 +1663,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1504,6 +1690,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1526,6 +1715,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1550,6 +1742,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1572,6 +1767,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1596,6 +1794,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1618,6 +1819,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1642,6 +1846,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1665,6 +1872,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1687,6 +1897,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1713,6 +1926,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1738,6 +1954,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1763,6 +1982,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1787,6 +2009,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1813,6 +2038,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1837,6 +2065,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1863,6 +2094,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1888,6 +2122,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1912,6 +2149,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1936,6 +2176,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -1958,6 +2201,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -1982,6 +2228,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2004,6 +2253,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2028,6 +2280,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2050,6 +2305,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2074,6 +2332,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2096,6 +2357,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2120,6 +2384,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2142,6 +2409,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2166,6 +2436,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2188,6 +2461,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2212,6 +2488,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2234,6 +2513,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2258,6 +2540,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2280,6 +2565,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2304,6 +2592,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2326,6 +2617,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2350,6 +2644,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2372,6 +2669,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2396,6 +2696,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2418,6 +2721,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2442,6 +2748,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2464,6 +2773,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2488,6 +2800,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2510,6 +2825,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2534,6 +2852,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2556,6 +2877,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2580,6 +2904,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2602,6 +2929,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -2626,6 +2956,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -2648,6 +2981,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Electrocardiogram
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/pad.yaml
+++ b/priority_variables_transform/FHS-ingest/pad.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string

--- a/priority_variables_transform/FHS-ingest/stroke.yaml
+++ b/priority_variables_transform/FHS-ingest/stroke.yaml
@@ -18,6 +18,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -40,6 +43,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -65,6 +71,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -88,6 +97,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -113,6 +125,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -136,6 +151,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -161,6 +179,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -184,6 +205,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -209,6 +233,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -232,6 +259,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -257,6 +287,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -280,6 +313,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Awareness of Coronary Factors Questionnaire
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -305,6 +341,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -328,6 +367,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -353,6 +395,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -393,6 +438,9 @@
             '17': PRESENT
             '18': PRESENT
             '19': UNKNOWN
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -416,6 +464,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -457,6 +508,9 @@
             '17': PRESENT
             '18': PRESENT
             '19': UNKNOWN
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -480,6 +534,9 @@
             '8': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/valv_hrtdis.yaml
+++ b/priority_variables_transform/FHS-ingest/valv_hrtdis.yaml
@@ -17,6 +17,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Electrocardiogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -42,6 +45,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Laboratory Test
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -65,6 +71,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -91,6 +100,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Laboratory Test
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -114,6 +126,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -140,6 +155,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Laboratory Test
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -163,6 +181,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -189,6 +210,9 @@
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
           range: string
+        associated_evidence:
+          value: Laboratory Test
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -212,6 +236,9 @@
             '3': PRESENT
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -237,6 +264,9 @@
             '9': UNKNOWN
         condition_provenance:
           value: CLINICAL_DIAGNOSIS
+          range: string
+        associated_evidence:
+          value: Laboratory Test
           range: string
         relationship_to_participant:
           value: ONESELF

--- a/priority_variables_transform/FHS-ingest/ven_thromb.yaml
+++ b/priority_variables_transform/FHS-ingest/ven_thromb.yaml
@@ -13,6 +13,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -29,6 +32,9 @@
             '0': ABSENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -48,6 +54,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -70,6 +79,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -88,6 +101,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -106,6 +123,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -124,6 +145,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -142,6 +167,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -175,7 +204,10 @@
 #         condition_provenance:
 #           value: PATIENT_SELF-REPORTED_CONDITION
 #           range: string
-#         relationship_to_participant:
+#         associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+        relationship_to_participant:
 #           value: ONESELF
 #           range: string
 # - class_derivations:
@@ -212,6 +244,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -230,6 +265,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -246,6 +284,9 @@
             '0': ABSENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -265,6 +306,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -282,6 +326,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -301,6 +348,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Medical History
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -318,6 +368,9 @@
             '1': PRESENT
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -338,6 +391,9 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
+        associated_evidence:
+          value: Clinical Diagnostic Impression
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -356,6 +412,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
+          range: string
+        associated_evidence:
+          value: Medical History
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -376,6 +435,9 @@
         condition_provenance:
           value: OMOP:4822126
           range: string
+        associated_evidence:
+          value: Venogram
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -394,6 +456,9 @@
             '2': UNKNOWN
         condition_provenance:
           value: OMOP:4822126
+          range: string
+        associated_evidence:
+          value: Doppler Ultrasound
           range: string
         relationship_to_participant:
           value: ONESELF
@@ -414,6 +479,9 @@
         condition_provenance:
           value: OMOP:4822126
           range: string
+        associated_evidence:
+          value: Impedance Plethysmography
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -433,6 +501,9 @@
         condition_provenance:
           value: OMOP:4822126
           range: string
+        associated_evidence:
+          value: Computed Tomography
+          range: string
         relationship_to_participant:
           value: ONESELF
           range: string
@@ -450,6 +521,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -464,6 +539,10 @@
         condition_provenance:
           value: OMOP:4822160
           range: string
+        associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+
 - class_derivations:
     Condition:
       populated_from: pht000744
@@ -494,7 +573,10 @@
 #         condition_provenance:
 #           value: PATIENT_SELF-REPORTED_CONDITION
 #           range: string
-#         relationship_to_participant:
+#         associated_evidence:
+          value: Final Diagnostic Summary
+          range: string
+        relationship_to_participant:
 #           value: ONESELF
 #           range: string
 # - class_derivations:


### PR DESCRIPTION
Refs #380

Adds the ssociated_evidence slot to **591 Condition blocks** across **17 FHS YAML files**. This is a new slot — no existing values are overwritten (0 Condition blocks previously had ssociated_evidence).

### Source
Anne's curated spreadsheet: \FHS_VariableProperties - associated evidence for virtual team.tsv\ (816 rows, 777 PHVs, 21 distinct evidence types).

### Ambiguity resolutions (per Anne's comments on #380)
- \phv00000853\ -> **X-ray** (not Electrocardiogram)
- \sthma.yaml\ / \pht006005\ multi-value block -> **Respiratory Disease Questionnaire**
- \hist_my_inf.yaml\ / \pht000074\ (3 blocks) -> **Electrocardiogram**

### Coverage
| Metric | Value |
|---|---|
| Condition blocks in FHS | 594 |
| Insertions | 591 (99.5%) |
| Remaining uncovered | 3 |

### Terminology corrections applied to spreadsheet before use
- \Clinical Diagnostic Impression \ -> trimmed trailing space (35 rows)
- \Computed Tomography \ -> trimmed trailing space (2 rows)
- \Echocardigram\ -> \Echocardiogram\ (typo, 1 row)