### PR TITLE
Fix #388: Replace IDTYPE with shareid in FHS creat_bld.yaml Offspring Exam 8 block

### DIFF
--- a/priority_variables_transform/FHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/creat_bld.yaml
@@ -246,9 +246,9 @@
       populated_from: pht000742
       slot_derivations:
         associated_participant:
-          populated_from: phv00071888
+          populated_from: phv00071899
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00071888}) + ":FHS OFFSPRING EXAM 8")'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00071899}) + ":FHS OFFSPRING EXAM 8")'
         age_at_observation:
           expr: '{pht003099.phv00177944} * 365'
         observation_type:


### PR DESCRIPTION
Fixes #388

**Change:** Replace `phv00071888` (`IDTYPE` — cohort identifier) with `phv00071899` (`shareid` — unique participant ID) in the `pht000742` / FHS Offspring Exam 8 block of `creat_bld.yaml`.

**Lines changed (2):**
- `associated_participant.populated_from`: phv00071888 → phv00071899
- `associated_visit.expr`: str({phv00071888}) → str({phv00071899})

**dbGaP verification:** Both variables are in `pht000742` (`fhslab1_8s`, `phs000007.v35.p16`). Same class of error fixed in #384.