### PR TITLE
fix: correct ontology prefixes for non-RxNorm drug class codes (#390)

### DIFF
--- a/priority_variables_transform/ARIC-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/ARIC-ingest/hypert_trt.yaml
@@ -8,7 +8,7 @@
           value: ARIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00204798} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00204798} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: ARIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00204913} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00204913} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: ARIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00207913} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00207913} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: ARIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00208001} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00208001} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: ARIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00208067} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00208067} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: ARIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00208296} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00208296} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: ARIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00209061} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00209061} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: ARIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00506313} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00506313} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: ARIC EXAM 7
           range: string
         drug_concept:
-          expr: 'case(({phv00507343} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00507343} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: ARIC EXAM 7
           range: string
         drug_concept:
-          expr: 'case(({phv00507345} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00507345} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: ARIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00511981} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00511981} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: ARIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00512030} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00512030} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: ARIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00512187} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00512187} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: ARIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00512189} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00512189} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: ARIC EXAM 6
           range: string
         drug_concept:
-          expr: 'case(({phv00512252} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00512252} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: ARIC EXAM 6
           range: string
         drug_concept:
-          expr: 'case(({phv00512253} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00512253} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: ARIC EXAM 6
           range: string
         drug_concept:
-          expr: 'case(({phv00512254} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00512254} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: ARIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00204754} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00204754} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/ARIC-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_aceinhib.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206919} == 1, "RxCUI:C09A"))
+          expr: case(({phv00206919} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206920} == 1, "RxCUI:C09A"))
+          expr: case(({phv00206920} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,7 +31,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507366} == 1, "RxCUI:C09A"))
+          expr: case(({phv00507366} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -43,7 +43,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507367} == 1, "RxCUI:C09A"))
+          expr: case(({phv00507367} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -55,7 +55,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512210} == 1, "RxCUI:C09A"))
+          expr: case(({phv00512210} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -67,7 +67,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512211} == 1, "RxCUI:C09A"))
+          expr: case(({phv00512211} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -79,7 +79,7 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512275} == 1, "RxCUI:C09A"))
+          expr: case(({phv00512275} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -91,6 +91,6 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512276} == 1, "RxCUI:C09A"))
+          expr: case(({phv00512276} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/ARIC-ingest/tak_aldorecepblk.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_aldorecepblk.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507370} == 1, "RxCUI:N0000175557"))
+          expr: case(({phv00507370} == 1, "NDFRT:N0000175557"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507371} == 1, "RxCUI:N0000175557"))
+          expr: case(({phv00507371} == 1, "NDFRT:N0000175557"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,7 +31,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512214} == 1, "RxCUI:N0000175557"))
+          expr: case(({phv00512214} == 1, "NDFRT:N0000175557"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -43,7 +43,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512215} == 1, "RxCUI:N0000175557"))
+          expr: case(({phv00512215} == 1, "NDFRT:N0000175557"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -55,7 +55,7 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512279} == 1, "RxCUI:N0000175557"))
+          expr: case(({phv00512279} == 1, "NDFRT:N0000175557"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -67,6 +67,6 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512280} == 1, "RxCUI:N0000175557"))
+          expr: case(({phv00512280} == 1, "NDFRT:N0000175557"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/ARIC-ingest/tak_alphablk.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_alphablk.yaml
@@ -8,7 +8,7 @@
           value: ARIC EXAM 1
           range: string
         drug_concept:
-          expr: case(({phv00204754} == 1, "RxCUI:C02"))
+          expr: case(({phv00204754} == 1, "ATC:C02"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/ARIC-ingest/tak_angiorecepblk.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_angiorecepblk.yaml
@@ -8,7 +8,7 @@
           value: ARIC Death Event
           range: string
         drug_concept:
-          expr: case(({phv00203803} == 1, "RxCUI:C09C"))
+          expr: case(({phv00203803} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: ARIC Hospital Form
           range: string
         drug_concept:
-          expr: case(({phv00203973} == 1, "RxCUI:C09C"))
+          expr: case(({phv00203973} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: ARIC EXAM 1
           range: string
         drug_concept:
-          expr: case(({phv00204712} == 1, "RxCUI:C09C"))
+          expr: case(({phv00204712} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: ARIC Hospital Form
           range: string
         drug_concept:
-          expr: case(({phv00206921} == 1, "RxCUI:C09C"))
+          expr: case(({phv00206921} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: ARIC Hospital Form
           range: string
         drug_concept:
-          expr: case(({phv00206964} == 1, "RxCUI:C09C"))
+          expr: case(({phv00206964} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: ARIC EXAM 7
           range: string
         drug_concept:
-          expr: case(({phv00507368} == 1, "RxCUI:C09C"))
+          expr: case(({phv00507368} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: ARIC EXAM 7
           range: string
         drug_concept:
-          expr: case(({phv00507369} == 1, "RxCUI:C09C"))
+          expr: case(({phv00507369} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: ARIC EXAM 5
           range: string
         drug_concept:
-          expr: case(({phv00512212} == 1, "RxCUI:C09C"))
+          expr: case(({phv00512212} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: ARIC EXAM 5
           range: string
         drug_concept:
-          expr: case(({phv00512213} == 1, "RxCUI:C09C"))
+          expr: case(({phv00512213} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: ARIC EXAM 6
           range: string
         drug_concept:
-          expr: case(({phv00512277} == 1, "RxCUI:C09C"))
+          expr: case(({phv00512277} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: ARIC EXAM 6
           range: string
         drug_concept:
-          expr: case(({phv00512278} == 1, "RxCUI:C09C"))
+          expr: case(({phv00512278} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/ARIC-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_betablk.yaml
@@ -8,7 +8,7 @@
           value: ARIC Hospital Form
           range: string
         drug_concept:
-          expr: case(({phv00206977} == 1, "RxCUI:C07A"))
+          expr: case(({phv00206977} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: ARIC Hospital Form
           range: string
         drug_concept:
-          expr: case(({phv00206978} == 1, "RxCUI:C07A"))
+          expr: case(({phv00206978} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/ARIC-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_calchanblk.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC Death Event
         drug_concept:
-          expr: case(({phv00203800} == "Y", "RxCUI:C08"))
+          expr: case(({phv00203800} == "Y", "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00203967} == "Y", "RxCUI:C08"))
+          expr: case(({phv00203967} == "Y", "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,7 +31,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206979} == "Y", "RxCUI:C08"))
+          expr: case(({phv00206979} == "Y", "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -43,6 +43,6 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206980} == "Y", "RxCUI:C08"))
+          expr: case(({phv00206980} == "Y", "ATC:C08"))
         exposure_provenance:
           value: PRESCRIPTION WRITTEN

--- a/priority_variables_transform/ARIC-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_diuret.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206983} == "Y", "RxCUI:C03"))
+          expr: case(({phv00206983} == "Y", "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206984} == 1, "RxCUI:C03"))
+          expr: case(({phv00206984} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,7 +31,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206996} == "Y", "RxCUI:C03"))
+          expr: case(({phv00206996} == "Y", "ATC:C03"))
         exposure_provenance:
           value: PRESCRIPTION WRITTEN
 - class_derivations:
@@ -43,7 +43,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507372} == 1, "RxCUI:CV702"))
+          expr: case(({phv00507372} == 1, "VANDF:CV702"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -55,7 +55,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507373} == 1, "RxCUI:CV702"))
+          expr: case(({phv00507373} == 1, "VANDF:CV702"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -67,7 +67,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512216} == 1, "RxCUI:CV702"))
+          expr: case(({phv00512216} == 1, "VANDF:CV702"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -79,7 +79,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512217} == 1, "RxCUI:CV702"))
+          expr: case(({phv00512217} == 1, "VANDF:CV702"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -91,7 +91,7 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512281} == 1, "RxCUI:CV702"))
+          expr: case(({phv00512281} == 1, "VANDF:CV702"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -103,6 +103,6 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512282} == 1, "RxCUI:CV702"))
+          expr: case(({phv00512282} == 1, "VANDF:CV702"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/ARIC-ingest/tak_med_diab.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_med_diab.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC EXAM 4
         drug_concept:
-          expr: case(({phv00206628} == 1, "RxCUI:A10"))
+          expr: case(({phv00206628} == 1, "ATC:A10"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,6 +19,6 @@
         associated_visit:
           value: ARIC EXAM 4
         drug_concept:
-          expr: case(({phv00206636} == 1, "RxCUI:A10"))
+          expr: case(({phv00206636} == 1, "ATC:A10"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/ARIC-ingest/tak_statin.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_statin.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00204156} == 1, "RxCUI:C10A"))
+          expr: case(({phv00204156} == 1, "ATC:C10A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: ARIC EXAM 1
         drug_concept:
-          expr: case(({phv00204695} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00204695} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,7 +31,7 @@
         associated_visit:
           value: ARIC EXAM 3
         drug_concept:
-          expr: case(({phv00204802} == 1, "RxCUI:C10A"))
+          expr: case(({phv00204802} == 1, "ATC:C10A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -43,7 +43,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507346} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00507346} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -55,7 +55,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507347} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00507347} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -67,7 +67,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00511951} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00511951} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -79,7 +79,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512190} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512190} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -91,7 +91,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512191} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512191} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -103,7 +103,7 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512255} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512255} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -115,7 +115,7 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512256} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512256} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -127,7 +127,7 @@
         associated_visit:
           value: ARIC EXAM 1
         drug_concept:
-          expr: case(({phv00204695} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00204695} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -139,7 +139,7 @@
         associated_visit:
           value: ARIC EXAM 7
         drug_concept:
-          expr: case(({phv00507347} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00507347} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -151,7 +151,7 @@
         associated_visit:
           value: ARIC EXAM 4
         drug_concept:
-          expr: case(({phv00507347} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00507347} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -163,7 +163,7 @@
         associated_visit:
           value: ARIC EXAM 5
         drug_concept:
-          expr: case(({phv00512191} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512191} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -175,7 +175,7 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512255} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512255} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -187,6 +187,6 @@
         associated_visit:
           value: ARIC EXAM 6
         drug_concept:
-          expr: case(({phv00512256} == 1, "RxCUI:N0000175589"))
+          expr: case(({phv00512256} == 1, "NDFRT:N0000175589"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/ARIC-ingest/tak_vasodil.yaml
+++ b/priority_variables_transform/ARIC-ingest/tak_vasodil.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206993} == 1, "RxCUI:C04"))
+          expr: case(({phv00206993} == 1, "ATC:C04"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00206994} == 1, "RxCUI:C04"))
+          expr: case(({phv00206994} == 1, "ATC:C04"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,6 +31,6 @@
         associated_visit:
           value: ARIC Hospital Form
         drug_concept:
-          expr: case(({phv00207048} == 1, "RxCUI:C04"))
+          expr: case(({phv00207048} == 1, "ATC:C04"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/CARDIA-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/CARDIA-ingest/hypert_trt.yaml
@@ -8,7 +8,7 @@
           value: CARDIA YEAR 0
           range: string
         drug_concept:
-          expr: case(({phv00113012} == 2, "RxCUI:C02"))
+          expr: case(({phv00113012} == 2, "ATC:C02"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CARDIA YEAR 0
           range: string
         drug_concept:
-          expr: 'case(({phv00113154} == "HBP", "RxCUI:C02"))'
+          expr: 'case(({phv00113154} == "HBP", "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CARDIA-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/CARDIA-ingest/tak_diuret.yaml
@@ -8,7 +8,7 @@
           value: CARDIA EXAM 10
           range: string
         drug_concept:
-          expr: case(({phv00119422} == 2, "RxCUI:C03"))
+          expr: case(({phv00119422} == 2, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CARDIA-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/CARDIA-ingest/tak_insulin.yaml
@@ -7,6 +7,6 @@
         associated_visit:
           value: CARDIA YEAR 10
         drug_concept:
-          expr: case(({phv00118386} == 2, 'RxCUI:D007328'))
+          expr: case(({phv00118386} == 2, 'MeSH:D007328'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/CHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/CHS-ingest/hypert_trt.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099656} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00099656} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00101536} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00101536} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102173} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00102173} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00102684} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00102684} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103146} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00103146} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104464} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00104464} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105094} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00105094} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00105912} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00105912} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106515} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00106515} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106515} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00106515} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107086} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00107086} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107440} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00107440} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00107954} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00107954} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108301} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00108301} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108628} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00108628} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109055} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00109055} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109395} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00109395} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109766} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00109766} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110057} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00110057} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110708} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00110708} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197516} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00197516} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199111} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00199111} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_aceinhib.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099457} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00099457} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099576} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00099576} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099577} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00099577} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100441} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00100441} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100515} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00100515} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100516} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00100516} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102002} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00102002} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102093} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00102093} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102094} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00102094} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00102627} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00102627} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103066} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00103066} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103067} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00103067} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104361} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00104361} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104384} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00104384} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104385} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00104385} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00104767} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00104767} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105014} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00105014} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105015} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00105015} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00105627} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00105627} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106435} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00106435} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106436} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00106436} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107352} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00107352} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107360} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00107360} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107361} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00107361} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00107782} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00107782} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -372,7 +372,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108221} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00108221} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -386,7 +386,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108222} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00108222} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -400,7 +400,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108841} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00108841} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -414,7 +414,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108975} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00108975} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -428,7 +428,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108976} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00108976} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -442,7 +442,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109508} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00109508} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -456,7 +456,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109686} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00109686} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -470,7 +470,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109687} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00109687} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -484,7 +484,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110189} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00110189} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -498,7 +498,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110628} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00110628} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -512,7 +512,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110629} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00110629} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -526,7 +526,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197552} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00197552} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197553} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00197553} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -554,7 +554,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199031} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00199031} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -568,7 +568,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199032} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00199032} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_aldorecepblk.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_aldorecepblk.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_alphablk.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_alphablk.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099580} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00099580} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099581} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00099581} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100519} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00100519} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100520} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00100520} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102097} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00102097} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102098} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00102098} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103070} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00103070} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103071} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00103071} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104388} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00104388} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104389} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00104389} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105018} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00105018} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105019} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00105019} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106439} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00106439} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106440} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00106440} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107364} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00107364} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107365} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00107365} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108225} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00108225} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108226} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00108226} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108979} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00108979} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108980} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00108980} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109690} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00109690} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109691} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00109691} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110632} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00110632} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110633} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00110633} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197538} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00197538} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -372,7 +372,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197539} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00197539} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -386,7 +386,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199035} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00199035} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -400,7 +400,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199036} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00199036} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_angiorecepblk.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_angiorecepblk.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099574} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00099574} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099575} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00099575} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100513} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00100513} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100514} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00100514} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102091} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00102091} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102092} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00102092} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103064} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00103064} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103065} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00103065} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104382} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00104382} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104383} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00104383} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105012} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00105012} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105013} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00105013} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106433} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00106433} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106434} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00106434} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107358} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00107358} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107359} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00107359} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108219} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00108219} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108220} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00108220} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108973} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00108973} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108974} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00108974} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109684} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00109684} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109685} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00109685} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110626} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00110626} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110627} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00110627} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199029} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00199029} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -372,7 +372,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199030} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00199030} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_betablk.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: case(({phv00099332} == 1, "RxCUI:C07A"))
+          expr: case(({phv00099332} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -25,8 +25,8 @@
           populated_from: phv00099333
           range: string
           value_mappings:
-            o: RxCUI:C07A
-            O: RxCUI:C07A
+            o: ATC:C07A
+            O: ATC:C07A
             i: RxCUI:151890
             t: RxCUI:152413
             I: RxCUI:151890
@@ -47,7 +47,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: case(({phv00099455} == 1, "RxCUI:C07A"))
+          expr: case(({phv00099455} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -61,7 +61,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: case(({phv00100439} == 1, "RxCUI:C07A"))
+          expr: case(({phv00100439} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -75,7 +75,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: case(({phv00100595} == 1, "RxCUI:C02"))
+          expr: case(({phv00100595} == 1, "ATC:C02"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -89,7 +89,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: case(({phv00102000} == 1, "RxCUI:C07A"))
+          expr: case(({phv00102000} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -103,7 +103,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: case(({phv00102628} == 1, "RxCUI:C07A"))
+          expr: case(({phv00102628} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -117,7 +117,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: case(({phv00104359} == 1, "RxCUI:C07A"))
+          expr: case(({phv00104359} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -131,7 +131,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: case(({phv00104765} == 1, "RxCUI:C07A"))
+          expr: case(({phv00104765} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -145,7 +145,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: case(({phv00105625} == 1, "RxCUI:C07A"))
+          expr: case(({phv00105625} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -159,7 +159,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: case(({phv00107350} == 1, "RxCUI:C07A"))
+          expr: case(({phv00107350} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -173,7 +173,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: case(({phv00107783} == 1, "RxCUI:C07A"))
+          expr: case(({phv00107783} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -187,7 +187,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: case(({phv00108842} == 1, "RxCUI:C07A"))
+          expr: case(({phv00108842} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -201,7 +201,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: case(({phv00109506} == 1, "RxCUI:C07A"))
+          expr: case(({phv00109506} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -215,7 +215,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: case(({phv00110187} == 1, "RxCUI:C07A"))
+          expr: case(({phv00110187} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -229,7 +229,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: case(({phv00197549} == 1, "RxCUI:C07A"))
+          expr: case(({phv00197549} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -243,7 +243,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: case(({phv00197550} == 1, "RxCUI:C07D"))
+          expr: case(({phv00197550} == 1, "ATC:C07D"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_calchanblk.yaml
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099601} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00099601} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099602} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00099602} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100540} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00100540} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100541} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00100541} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102118} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00102118} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102119} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00102119} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103091} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00103091} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103092} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00103092} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -428,7 +428,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104409} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00104409} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -442,7 +442,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104410} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00104410} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -526,7 +526,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105039} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00105039} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105040} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00105040} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -624,7 +624,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106460} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00106460} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -638,7 +638,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106461} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00106461} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -722,7 +722,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107385} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00107385} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -736,7 +736,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107386} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00107386} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -820,7 +820,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108246} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00108246} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -834,7 +834,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108247} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00108247} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -918,7 +918,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109000} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00109000} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -932,7 +932,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109001} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00109001} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1016,7 +1016,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109711} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00109711} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1030,7 +1030,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109712} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00109712} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1100,7 +1100,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197551} == 1, "RxCUI:C08"))'
+          expr: 'case(({phv00197551} == 1, "ATC:C08"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1128,7 +1128,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199056} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00199056} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1142,7 +1142,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199057} == 1, "RxCUI:N0000175421"))'
+          expr: 'case(({phv00199057} == 1, "NDFRT:N0000175421"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_cenactag.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_cenactag.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_diuret.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099458} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00099458} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099609} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00099609} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099610} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00099610} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099618} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00099618} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099654} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00099654} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100438} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00100438} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100548} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00100548} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100548} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00100548} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100557} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00100557} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100593} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00100593} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00101999} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00101999} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102126} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00102126} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102127} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00102127} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102135} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00102135} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102171} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00102171} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00102630} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00102630} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103099} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00103099} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103100} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00103100} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103108} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00103108} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103144} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00103144} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104358} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00104358} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104417} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00104417} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104418} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00104418} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104426} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00104426} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104462} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00104462} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00104764} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00104764} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -372,7 +372,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105047} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00105047} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -386,7 +386,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105048} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00105048} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -400,7 +400,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105056} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00105056} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -414,7 +414,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105092} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00105092} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -428,7 +428,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00105624} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00105624} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -442,7 +442,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106468} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00106468} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -456,7 +456,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106469} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00106469} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -470,7 +470,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106477} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00106477} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -484,7 +484,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106513} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00106513} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -498,7 +498,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107349} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00107349} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -512,7 +512,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107393} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00107393} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -526,7 +526,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107394} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00107394} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107402} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00107402} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -554,7 +554,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107438} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00107438} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -568,7 +568,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00107785} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00107785} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -582,7 +582,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108254} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00108254} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -596,7 +596,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108255} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00108255} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -610,7 +610,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108263} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00108263} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -624,7 +624,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108299} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00108299} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -638,7 +638,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108844} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00108844} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -652,7 +652,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109008} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00109008} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -666,7 +666,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109009} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00109009} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -680,7 +680,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109017} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00109017} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -694,7 +694,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109053} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00109053} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -708,7 +708,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109505} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00109505} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -722,7 +722,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109719} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00109719} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -736,7 +736,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109720} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00109720} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -750,7 +750,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109728} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00109728} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -764,7 +764,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109764} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00109764} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -778,7 +778,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110186} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00110186} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -792,7 +792,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110661} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00110661} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -806,7 +806,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110662} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00110662} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -820,7 +820,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110670} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00110670} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -834,7 +834,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110706} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00110706} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -848,7 +848,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197533} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00197533} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -862,7 +862,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197534} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00197534} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -876,7 +876,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197535} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00197535} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -890,7 +890,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197556} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00197556} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -904,7 +904,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199064} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00199064} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -918,7 +918,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199065} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00199065} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -932,7 +932,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199073} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00199073} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -946,7 +946,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199109} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00199109} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -960,7 +960,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100595} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00100595} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_insulin.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099346} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00099346} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099612} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00099612} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100380} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00100380} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100551} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00100551} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102129} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00102129} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103102} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00103102} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104420} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00104420} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105050} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00105050} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106471} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00106471} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107396} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00107396} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108257} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00108257} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109011} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00109011} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109722} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00109722} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110664} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00110664} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197520} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00197520} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199067} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00199067} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_med_diab.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_med_diab.yaml
@@ -8,7 +8,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00101537} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00101537} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00102685} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00102685} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00105966} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00105966} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107087} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00107087} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00107955} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00107955} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108629} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00108629} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109396} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00109396} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110058} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00110058} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_orlhypoag.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_orlhypoag.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099628} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00099628} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100567} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00100567} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102145} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00102145} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103118} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00103118} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104436} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00104436} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105066} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00105066} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106487} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00106487} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107412} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00107412} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108273} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00108273} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109027} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00109027} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109738} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00109738} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110680} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00110680} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197519} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00197519} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199083} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00199083} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_statin.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_statin.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100594} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00100594} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/tak_vasodil.yaml
+++ b/priority_variables_transform/CHS-ingest/tak_vasodil.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099637} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00099637} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099647} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00099647} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099648} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00099648} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100576} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00100576} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100586} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00100586} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS BASELINE BOTH
           range: string
         drug_concept:
-          expr: 'case(({phv00100587} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00100587} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102154} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00102154} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102164} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00102164} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102165} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00102165} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103127} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00103127} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103137} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00103137} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 11
           range: string
         drug_concept:
-          expr: 'case(({phv00103138} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00103138} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104445} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00104445} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104455} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00104455} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104456} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00104456} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105075} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00105075} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105085} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00105085} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105086} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00105086} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106496} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00106496} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106506} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00106506} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106507} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00106507} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107421} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00107421} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107431} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00107431} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107432} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00107432} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108282} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00108282} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108292} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00108292} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -372,7 +372,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108293} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00108293} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -386,7 +386,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109036} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00109036} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -400,7 +400,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109046} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00109046} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -414,7 +414,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109047} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00109047} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -428,7 +428,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109747} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00109747} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -442,7 +442,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109757} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00109757} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -456,7 +456,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109758} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00109758} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -470,7 +470,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110689} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00110689} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -484,7 +484,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110699} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00110699} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -498,7 +498,7 @@
           value: CHS YEAR 9
           range: string
         drug_concept:
-          expr: 'case(({phv00110700} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00110700} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -512,7 +512,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197543} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00197543} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -526,7 +526,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197554} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00197554} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
           value: CHS PSG 1
           range: string
         drug_concept:
-          expr: 'case(({phv00197555} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00197555} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -554,7 +554,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199092} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00199092} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -568,7 +568,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199102} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00199102} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -582,7 +582,7 @@
           value: CHS PSG 2
           range: string
         drug_concept:
-          expr: 'case(({phv00199103} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00199103} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/CHS-ingest/taking_non_statin_medication.yaml
+++ b/priority_variables_transform/CHS-ingest/taking_non_statin_medication.yaml
@@ -8,7 +8,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099590} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00099590} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00099621} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00099621} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00100529} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00100529} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: CHS BASELINE 2
           range: string
         drug_concept:
-          expr: 'case(({phv00100560} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00100560} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102107} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00102107} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00102138} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00102138} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00103080} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00103080} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: CHS YEAR 10
           range: string
         drug_concept:
-          expr: 'case(({phv00103111} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00103111} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104429} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00104429} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104398} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00104398} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: CHS YEAR 3
           range: string
         drug_concept:
-          expr: 'case(({phv00104429} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00104429} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105028} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00105028} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: CHS YEAR 4
           range: string
         drug_concept:
-          expr: 'case(({phv00105059} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00105059} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106449} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00106449} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: CHS YEAR 5 NEW
           range: string
         drug_concept:
-          expr: 'case(({phv00106480} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00106480} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107374} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00107374} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: CHS YEAR 5 OLD
           range: string
         drug_concept:
-          expr: 'case(({phv00107405} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00107405} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108235} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00108235} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -386,7 +386,7 @@
           value: CHS YEAR 6
           range: string
         drug_concept:
-          expr: 'case(({phv00108266} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00108266} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -400,7 +400,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00108989} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00108989} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -428,7 +428,7 @@
           value: CHS YEAR 7
           range: string
         drug_concept:
-          expr: 'case(({phv00109020} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00109020} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -442,7 +442,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109700} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00109700} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -470,7 +470,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00109731} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00109731} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -484,7 +484,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00110642} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00110642} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -512,7 +512,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00110673} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00110673} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -526,7 +526,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00197544} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00197544} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00197545} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00197545} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -554,7 +554,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00199045} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00199045} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -582,7 +582,7 @@
           value: CHS YEAR 8
           range: string
         drug_concept:
-          expr: 'case(({phv00199076} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00199076} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/FHS-ingest/hypert_trt.yaml
@@ -32,7 +32,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00177237}) + ":" + case(({phv00177238} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00177238} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00177238} == ''72'', ''FHS OMNI 2 EXAM 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00177250} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00177250} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -45,7 +45,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250725} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00250725} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -58,7 +58,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250749} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00250749} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -71,7 +71,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00251262}) + ":FHS OMNI 1 EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00251275} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00251275} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -109,7 +109,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00254024} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00254024} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -122,7 +122,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254596}) + ":FHS ORIGINAL EXAM 29")'
         drug_concept:
-          expr: 'case(({phv00254605} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00254605} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -135,7 +135,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254989}) + ":FHS ORIGINAL EXAM 30")'
         drug_concept:
-          expr: 'case(({phv00254996} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00254996} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00274708}) + ":FHS ORIGINAL EXAM 31")'
         drug_concept:
-          expr: 'case(({phv00274716} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00274716} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -161,7 +161,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00275064}) + ":FHS ORIGINAL EXAM 32")'
         drug_concept:
-          expr: 'case(({phv00275071} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00275071} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -174,7 +174,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002425}) + ":FHS ORIGINAL EXAM 14")'
         drug_concept:
-          expr: 'case(({phv00002223} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002223} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -187,7 +187,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002668}) + ":FHS ORIGINAL EXAM 15")'
         drug_concept:
-          expr: 'case(({phv00002446} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002446} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -200,7 +200,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         drug_concept:
-          expr: 'case(({phv00002700} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002700} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -213,7 +213,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: 'case(({phv00002965} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00002965} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -226,7 +226,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: 'case(({phv00003348} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00003348} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -239,7 +239,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003782} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00003782} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -277,7 +277,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004217} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00004217} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -290,7 +290,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004610} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00004610} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -303,7 +303,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004946} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00004946} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004966} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00004966} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -329,7 +329,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005566} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00005566} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -342,7 +342,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005586} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00005586} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -355,7 +355,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006117} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006117} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -368,7 +368,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006138} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006138} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -381,7 +381,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006457} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006457} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -394,7 +394,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006478} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006478} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -407,7 +407,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006845} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006845} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -420,7 +420,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006869} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006869} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -433,7 +433,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007282} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00007282} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -446,7 +446,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007306} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00007306} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -459,7 +459,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00070736}) + ":FHS ORIGINAL EXAM 28")'
         drug_concept:
-          expr: 'case(({phv00070370} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00070370} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -497,7 +497,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007709} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00007709} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -532,7 +532,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007992} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00007992} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -545,7 +545,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008391} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00008391} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -583,7 +583,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008798} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00008798} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -596,7 +596,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009174} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00009174} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -609,7 +609,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009193} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00009193} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -622,7 +622,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009674} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00009674} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -635,7 +635,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009694} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00009694} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -648,7 +648,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010151} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00010151} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -661,7 +661,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010175} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00010175} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -674,7 +674,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00072044}) + ":FHS OFFSPRING EXAM 8")'
         drug_concept:
-          expr: 'case(({phv00072052} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00072052} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -687,7 +687,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00021427}) + ":FHS GENERATION 3 EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00020877} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00020877} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -700,7 +700,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055253} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00055253} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -713,7 +713,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055341} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00055341} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -726,7 +726,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056722}) + ":FHS SHHS OFFSPRING")'
         drug_concept:
-          expr: 'case(({phv00056701} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00056701} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -739,7 +739,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00057006} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00057006} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/med_use.yaml
+++ b/priority_variables_transform/FHS-ingest/med_use.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004948} == 1, "RxCUI:C01A"))'
+          expr: 'case(({phv00004948} == 1, "ATC:C01A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004950} == 1, "RxCUI:N0000175415"))'
+          expr: 'case(({phv00004950} == 1, "NDFRT:N0000175415"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004951} == 1, "RxCUI:C08"))'
+          expr: 'case(({phv00004951} == 1, "ATC:C08"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004952} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00004952} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004953} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00004953} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -96,7 +96,7 @@
             '6': RxCUI:8332
             '7': RxCUI:149
             '8': RxCUI:6185
-            '9': RxCUI:C07A
+            '9': ATC:C07A
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -109,7 +109,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004955} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00004955} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -122,7 +122,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004957} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00004957} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -135,7 +135,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004958} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00004958} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -187,7 +187,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004962} == 1, "RxCUI:N0000009917"))'
+          expr: 'case(({phv00004962} == 1, "NDFRT:N0000009917"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -200,7 +200,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004963} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00004963} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -213,7 +213,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004964} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00004964} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -226,7 +226,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004965} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00004965} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -239,7 +239,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004966} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00004966} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -265,7 +265,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004969} == 1, "RxCUI:N0000175980"))'
+          expr: 'case(({phv00004969} == 1, "NDFRT:N0000175980"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -278,7 +278,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004972} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00004972} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -291,7 +291,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004973} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00004973} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -317,7 +317,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004975} == 1, "RxCUI:N0000175589"))'
+          expr: 'case(({phv00004975} == 1, "NDFRT:N0000175589"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004976} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00004976} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -343,7 +343,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004977} == 1, "RxCUI:M04"))'
+          expr: 'case(({phv00004977} == 1, "ATC:M04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -382,7 +382,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004980} == 1, "RxCUI:D013974"))'
+          expr: 'case(({phv00004980} == 1, "MeSH:D013974"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -395,7 +395,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004981} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00004981} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -408,7 +408,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004983} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00004983} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -434,7 +434,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004985} == 1, "RxCUI:HS051"))'
+          expr: 'case(({phv00004985} == 1, "VANDF:HS051"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -447,7 +447,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004986} == 1, "RxCUI:CN104"))'
+          expr: 'case(({phv00004986} == 1, "VANDF:CN104"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -460,7 +460,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004988} == 1, "RxCUI:N0000175690"))'
+          expr: 'case(({phv00004988} == 1, "NDFRT:N0000175690"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -473,7 +473,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004991} == 1, "RxCUI:AH000"))'
+          expr: 'case(({phv00004991} == 1, "VANDF:AH000"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -486,7 +486,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004992} == 1, "RxCUI:GA300"))'
+          expr: 'case(({phv00004992} == 1, "VANDF:GA300"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -499,7 +499,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005568} == 1, "RxCUI:C01A"))'
+          expr: 'case(({phv00005568} == 1, "ATC:C01A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -525,7 +525,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005570} == 1, "RxCUI:N0000175415"))'
+          expr: 'case(({phv00005570} == 1, "NDFRT:N0000175415"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -538,7 +538,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005571} == 1, "RxCUI:C08"))'
+          expr: 'case(({phv00005571} == 1, "ATC:C08"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -551,7 +551,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005572} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00005572} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -564,7 +564,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005573} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00005573} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -588,7 +588,7 @@
             '6': RxCUI:8332
             '7': RxCUI:149
             '8': RxCUI:6185
-            '9': RxCUI:C07A
+            '9': ATC:C07A
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -601,7 +601,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005575} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00005575} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -614,7 +614,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005577} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00005577} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -627,7 +627,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005578} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00005578} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -640,7 +640,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005582} == 1, "RxCUI:N0000009917"))'
+          expr: 'case(({phv00005582} == 1, "NDFRT:N0000009917"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -653,7 +653,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005583} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00005583} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -666,7 +666,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005584} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00005584} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -679,7 +679,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005585} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00005585} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -692,7 +692,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005586} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00005586} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -705,7 +705,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005592} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00005592} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -718,7 +718,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005593} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00005593} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -744,7 +744,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005595} == 1, "RxCUI:N0000175589"))'
+          expr: 'case(({phv00005595} == 1, "NDFRT:N0000175589"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -757,7 +757,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005596} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00005596} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -770,7 +770,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005601} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00005601} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -783,7 +783,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005601} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00005601} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -796,7 +796,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005603} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00005603} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -809,7 +809,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006119} == 1, "RxCUI:C01A"))'
+          expr: 'case(({phv00006119} == 1, "ATC:C01A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -835,7 +835,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006121} == 1, "RxCUI:N0000175415"))'
+          expr: 'case(({phv00006121} == 1, "NDFRT:N0000175415"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -848,7 +848,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006122} == 1, "RxCUI:C08"))'
+          expr: 'case(({phv00006122} == 1, "ATC:C08"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -861,7 +861,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006123} == 1, "RxCUI:C08"))'
+          expr: 'case(({phv00006123} == 1, "ATC:C08"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -874,7 +874,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006124} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00006124} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -898,7 +898,7 @@
             '6': RxCUI:8332
             '7': RxCUI:149
             '8': RxCUI:6185
-            '9': RxCUI:C07A
+            '9': ATC:C07A
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -911,7 +911,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006127} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00006127} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -924,7 +924,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006129} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00006129} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -937,7 +937,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006130} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00006130} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -950,7 +950,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006134} == 1, "RxCUI:N0000009917"))'
+          expr: 'case(({phv00006134} == 1, "NDFRT:N0000009917"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -963,7 +963,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006135} == 1, "RxCUI:N0000009918"))'
+          expr: 'case(({phv00006135} == 1, "NDFRT:N0000009918"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -976,7 +976,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006136} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00006136} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -989,7 +989,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006137} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00006137} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1002,7 +1002,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006138} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006138} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1015,7 +1015,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006143} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00006143} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1028,7 +1028,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006144} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00006144} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1054,7 +1054,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006146} == 1, "RxCUI:N0000175589"))'
+          expr: 'case(({phv00006146} == 1, "NDFRT:N0000175589"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1067,7 +1067,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006147} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00006147} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1080,7 +1080,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006152} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00006152} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1093,7 +1093,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006154} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006154} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -1106,7 +1106,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006154} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006154} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_aceinhib.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00276805} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00276805} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250746} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00250746} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003780} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00003780} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004215} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00004215} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004608} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00004608} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004964} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00004964} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005584} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00005584} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006136} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00006136} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006476} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00006476} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006866} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00006866} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007303} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00007303} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008400} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00008400} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008796} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00008796} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009692} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00009692} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010172} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00010172} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -229,7 +229,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055377} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00055377} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -242,7 +242,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055378} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00055378} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -255,7 +255,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056926} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00056926} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -268,7 +268,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056927} == 1, "RxCUI:C09BA"))'
+          expr: 'case(({phv00056927} == 1, "ATC:C09BA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_aldorecepblk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_aldorecepblk.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250740} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00250740} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003774} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00003774} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004602} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00004602} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004958} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00004958} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005578} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00005578} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006130} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00006130} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006472} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00006472} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006860} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00006860} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007297} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00007297} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008394} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00008394} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008790} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00008790} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009686} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00009686} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010166} == 1, "RxCUI:N0000175557"))'
+          expr: 'case(({phv00010166} == 1, "NDFRT:N0000175557"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_alphablk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_alphablk.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250745} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00250745} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004607} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00004607} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004963} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00004963} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005583} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00005583} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006135} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00006135} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006475} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00006475} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006865} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00006865} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007302} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00007302} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009691} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00009691} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010171} == 1, "RxCUI:N0000175553"))'
+          expr: 'case(({phv00010171} == 1, "NDFRT:N0000175553"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055363} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00055363} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055364} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00055364} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056930} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00056930} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056931} == 1, "RxCUI:N0000175562"))'
+          expr: 'case(({phv00056931} == 1, "NDFRT:N0000175562"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_angiorecepblk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_angiorecepblk.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250748} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00250748} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006868} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00006868} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007305} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00007305} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010174} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00010174} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056924} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00056924} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056925} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00056925} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00276809} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00276809} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00276809} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00276809} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_betablk.yaml
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: case(({phv00276806} == 1, "RxCUI:C07A"))
+          expr: case(({phv00276806} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: case(({phv00250734} == 1, "RxCUI:C07A"))
+          expr: case(({phv00250734} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -91,7 +91,7 @@
             '3': "RxCUI:7226"
             '4': "RxCUI:1202"
             '5': "RxCUI:6918"
-            '9': "RxCUI:C07A"
+            '9': "ATC:C07A"
                 #         dosage:
                 #           populated_from: phv00250736
         exposure_provenance:
@@ -106,7 +106,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: case(({phv00002955} == 1, "RxCUI:C07A"))
+          expr: case(({phv00002955} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -119,7 +119,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: case(({phv00003328} == 1, "RxCUI:C07A"))
+          expr: case(({phv00003328} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -138,7 +138,7 @@
             '3': "RxCUI:7226"
             '4': "RxCUI:1202"
             '5': "RxCUI:6918"
-            '9': "RxCUI:C07A"
+            '9': "ATC:C07A"
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -151,7 +151,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: case(({phv00003768} == 1, "RxCUI:C07A"))
+          expr: case(({phv00003768} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -164,7 +164,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: case(({phv00004203} == 1, "RxCUI:C07A"))
+          expr: case(({phv00004203} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -177,7 +177,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: case(({phv00004598} == 1, "RxCUI:C07A"))
+          expr: case(({phv00004598} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: case(({phv00004952} == 1, "RxCUI:C07A"))
+          expr: case(({phv00004952} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -222,7 +222,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: case(({phv00005572} == 1, "RxCUI:C07A"))
+          expr: case(({phv00005572} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -255,7 +255,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: case(({phv00006124} == 1, "RxCUI:C07A"))
+          expr: case(({phv00006124} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -277,7 +277,7 @@
                    ({phv00006125} == 6, "RxCUI:8332"),
                    ({phv00006125} == 7, "RxCUI:149"),
                    ({phv00006125} == 8, "RxCUI:6185"),
-                   ({phv00006125} == 9, "RxCUI:C07A"))'
+                   ({phv00006125} == 9, "ATC:C07A"))'
                 #         dosage:
                 #           populated_from: phv00006126
         exposure_provenance:
@@ -292,7 +292,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: case(({phv00006466} == 1, "RxCUI:C07A"))
+          expr: case(({phv00006466} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -329,7 +329,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: case(({phv00006854} == 1, "RxCUI:C07A"))
+          expr: case(({phv00006854} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -362,7 +362,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: case(({phv00007291} == 1, "RxCUI:C07A"))
+          expr: case(({phv00007291} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -395,7 +395,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: case(({phv00008784} == 1, "RxCUI:C07A"))
+          expr: case(({phv00008784} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -413,7 +413,7 @@
             ({phv00009180} == 4, "RxCUI:1202"), ({phv00009180} ==
             5, "RxCUI: 6918"), ({phv00009180} == 6, "RxCUI:8332"),
             ({phv00009180} == 7, "RxCUI:149"), ({phv00009180} ==
-            8, "RxCUI:6185"), ({phv00009180} == 9, "RxCUI:C07A"))'
+            8, "RxCUI:6185"), ({phv00009180} == 9, "ATC:C07A"))'
                 #         dosage:
                 #           populated_from: phv00009181
         exposure_provenance:
@@ -428,7 +428,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: case(({phv00009680} == 1, "RxCUI:C07A"))
+          expr: case(({phv00009680} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -461,7 +461,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: case(({phv00010160} == 1, "RxCUI:C07A"))
+          expr: case(({phv00010160} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -494,7 +494,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":FHS OFFSPRING BASELINE")'
         drug_concept:
-          expr: case(({phv00055374} == 1, "RxCUI:C07A"))
+          expr: case(({phv00055374} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -507,7 +507,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":FHS OFFSPRING BASELINE")'
         drug_concept:
-          expr: case(({phv00055375} == 1, "RxCUI:C07A"))
+          expr: case(({phv00055375} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -520,7 +520,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: case(({phv00008387} == 1, "RxCUI:C07A"))
+          expr: case(({phv00008387} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -533,7 +533,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: case(({phv00009179} == 1, "RxCUI:C07A"))
+          expr: case(({phv00009179} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_calchanblk.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: case(({phv00250730} == 1, "RxCUI:C08"))
+          expr: case(({phv00250730} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -41,7 +41,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: case(({phv00002954} == 1, "RxCUI:C08"))
+          expr: case(({phv00002954} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -54,7 +54,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: case(({phv00003326} == 1, "RxCUI:C08"))
+          expr: case(({phv00003326} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -67,7 +67,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: case(({phv00003767} == 1, "RxCUI:C08"))
+          expr: case(({phv00003767} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -80,7 +80,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: case(({phv00004202} == 1, "RxCUI:C08"))
+          expr: case(({phv00004202} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -93,7 +93,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: case(({phv00004597} == 1, "RxCUI:C08"))
+          expr: case(({phv00004597} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: case(({phv00004951} == 1, "RxCUI:C08"))
+          expr: case(({phv00004951} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -119,7 +119,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: case(({phv00005571} == 1, "RxCUI:C08"))
+          expr: case(({phv00005571} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -132,7 +132,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: case(({phv00006122} == 1, "RxCUI:C08"))
+          expr: case(({phv00006122} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -145,7 +145,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: case(({phv00006462} == 1, "RxCUI:C08"))
+          expr: case(({phv00006462} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -181,7 +181,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: case(({phv00006850} == 1, "RxCUI:C08"))
+          expr: case(({phv00006850} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: case(({phv00007287} == 1, "RxCUI:C08"))
+          expr: case(({phv00007287} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -255,7 +255,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: case(({phv00008386} == 1, "RxCUI:C08"))
+          expr: case(({phv00008386} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -268,7 +268,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: case(({phv00008783} == 1, "RxCUI:C08"))
+          expr: case(({phv00008783} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -281,7 +281,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: case(({phv00009178} == 1, "RxCUI:C08"))
+          expr: case(({phv00009178} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -294,7 +294,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: case(({phv00009679} == 1, "RxCUI:C08"))
+          expr: case(({phv00009679} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -307,7 +307,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: case(({phv00010156} == 1, "RxCUI:C08"))
+          expr: case(({phv00010156} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -320,7 +320,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: case(({phv00010156} == 1, "RxCUI:C08"))
+          expr: case(({phv00010156} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -354,7 +354,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: case(({phv00055376} == 1, "RxCUI:C08"))
+          expr: case(({phv00055376} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_cenactag.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_cenactag.yaml
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250744} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00250744} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004606} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00004606} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004962} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00004962} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005582} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00005582} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -228,7 +228,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006134} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00006134} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -241,7 +241,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006474} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00006474} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -267,7 +267,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006864} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00006864} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -293,7 +293,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007301} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00007301} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -384,7 +384,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009690} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00009690} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -410,7 +410,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010170} == 1, "RxCUI:N0000175554"))'
+          expr: 'case(({phv00010170} == 1, "NDFRT:N0000175554"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_diuret.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250737} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00250737} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250738} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00250738} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250739} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00250739} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250740} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00250740} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001558}) + ":FHS ORIGINAL EXAM 10")'
         drug_concept:
-          expr: 'case(({phv00001439} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00001439} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001803}) + ":FHS ORIGINAL EXAM 11")'
         drug_concept:
-          expr: 'case(({phv00001622} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00001622} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002020}) + ":FHS ORIGINAL EXAM 12")'
         drug_concept:
-          expr: 'case(({phv00001822} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00001822} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002204}) + ":FHS ORIGINAL EXAM 13")'
         drug_concept:
-          expr: 'case(({phv00002041} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002041} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002425}) + ":FHS ORIGINAL EXAM 14")'
         drug_concept:
-          expr: 'case(({phv00002223} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002223} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002425}) + ":FHS ORIGINAL EXAM 14")'
         drug_concept:
-          expr: 'case(({phv00002224} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002224} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002668}) + ":FHS ORIGINAL EXAM 15")'
         drug_concept:
-          expr: 'case(({phv00002446} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002446} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002668}) + ":FHS ORIGINAL EXAM 15")'
         drug_concept:
-          expr: 'case(({phv00002447} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002447} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         drug_concept:
-          expr: 'case(({phv00002700} == 4, "RxCUI:C03"))'
+          expr: 'case(({phv00002700} == 4, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         drug_concept:
-          expr: 'case(({phv00002701} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002701} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: 'case(({phv00002958} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00002958} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: 'case(({phv00002959} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00002959} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -215,7 +215,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: 'case(({phv00003334} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00003334} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -228,7 +228,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: 'case(({phv00003336} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00003336} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -241,7 +241,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003772} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00003772} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -254,7 +254,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003773} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00003773} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -267,7 +267,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003774} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00003774} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -280,7 +280,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004207} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00004207} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -293,7 +293,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004208} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00004208} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -306,7 +306,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004209} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00004209} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -319,7 +319,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004599} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00004599} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -332,7 +332,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004601} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00004601} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -345,7 +345,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004602} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00004602} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004955} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00004955} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -371,7 +371,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004957} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00004957} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -384,7 +384,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004958} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00004958} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -397,7 +397,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005575} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00005575} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -410,7 +410,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005577} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00005577} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -423,7 +423,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00004958} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00004958} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -436,7 +436,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005577} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00005577} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -449,7 +449,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006130} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00006130} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -462,7 +462,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006129} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00006129} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -475,7 +475,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006469} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00006469} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -488,7 +488,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006471} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00006471} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -501,7 +501,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006857} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00006857} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -514,7 +514,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006857} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00006857} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -527,7 +527,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006859} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00006859} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006860} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00006860} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -553,7 +553,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007294} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00007294} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -566,7 +566,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007296} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00007296} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -579,7 +579,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007297} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00007297} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -592,7 +592,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001035}) + ":FHS ORIGINAL EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00000867} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00000867} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -605,7 +605,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001035}) + ":FHS ORIGINAL EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00000952} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00000952} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -618,7 +618,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001187}) + ":FHS ORIGINAL EXAM 8")'
         drug_concept:
-          expr: 'case(({phv00001130} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00001130} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -631,7 +631,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001363}) + ":FHS ORIGINAL EXAM 9")'
         drug_concept:
-          expr: 'case(({phv00001245} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00001245} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -644,7 +644,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007675}) + ":FHS OFFSPRING EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00007590} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00007590} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -657,7 +657,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007675}) + ":FHS OFFSPRING EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00007591} == 4, "RxCUI:C03"))'
+          expr: 'case(({phv00007591} == 4, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -670,7 +670,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007709} == 4, "RxCUI:C03"))'
+          expr: 'case(({phv00007709} == 4, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -683,7 +683,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007710} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00007710} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -696,7 +696,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008392} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00008392} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -709,7 +709,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008394} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00008394} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -722,7 +722,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008788} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00008788} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -735,7 +735,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008789} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00008789} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -748,7 +748,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008790} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00008790} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -761,7 +761,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009182} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00009182} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -774,7 +774,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009184} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00009184} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -787,7 +787,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009185} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00009185} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -800,7 +800,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009685} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00009685} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -813,7 +813,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009686} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00009686} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -826,7 +826,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010163} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00010163} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -839,7 +839,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010165} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00010165} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -852,7 +852,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010166} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00010166} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -865,7 +865,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055358} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00055358} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -878,7 +878,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055359} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00055359} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -891,7 +891,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055381} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00055381} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -904,7 +904,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056959} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00056959} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -917,7 +917,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056968} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00056968} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -930,7 +930,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00057004} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00057004} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_insulin.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250767} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00250767} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002020}) + ":FHS ORIGINAL EXAM 12")'
         drug_concept:
-          expr: 'case(({phv00001827} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00001827} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002204}) + ":FHS ORIGINAL EXAM 13")'
         drug_concept:
-          expr: 'case(({phv00002046} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00002046} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002425}) + ":FHS ORIGINAL EXAM 14")'
         drug_concept:
-          expr: 'case(({phv00002229} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00002229} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002668}) + ":FHS ORIGINAL EXAM 15")'
         drug_concept:
-          expr: 'case(({phv00002451} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00002451} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         drug_concept:
-          expr: 'case(({phv00002705} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00002705} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: 'case(({phv00002970} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00002970} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: 'case(({phv00003358} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00003358} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003789} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00003789} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004224} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00004224} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004620} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00004620} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004981} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00004981} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005601} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00005601} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006152} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00006152} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006492} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00006492} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006887} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00006887} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -215,7 +215,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007324} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00007324} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -228,7 +228,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007718} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00007718} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -241,7 +241,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008404} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00008404} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -254,7 +254,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008805} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00008805} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -267,7 +267,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009207} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00009207} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -280,7 +280,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009708} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00009708} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -293,7 +293,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010193} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00010193} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -306,7 +306,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055345} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00055345} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -319,7 +319,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056962} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00056962} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_med_diab.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_med_diab.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00177237}) + ":" + case(({phv00177238} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00177238} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00177238} == ''72'', ''FHS OMNI 2 EXAM 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00177254} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00177254} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00273700}) + ":FHS NEW OFFSPRING SPOUSE EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00273715} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00273715} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254010}) + ":" + case(({phv00254011} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00254011} == ''7'', ''FHS OMNI 1 EXAM 4''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00254028} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00254028} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00275064}) + ":FHS ORIGINAL EXAM 32")'
         drug_concept:
-          expr: 'case(({phv00275073} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00275073} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00021427}) + ":FHS GENERATION 3 EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00020881} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00020881} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_nstat_med.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_nstat_med.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250758} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00250758} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250759} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00250759} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250760} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00250760} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004972} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00004972} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004973} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00004973} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004974} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00004974} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005592} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00005592} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005593} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00005593} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005594} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00005594} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006143} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00006143} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006144} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00006144} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006145} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00006145} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006483} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00006483} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006484} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00006484} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006485} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00006485} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006878} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00006878} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -215,7 +215,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006879} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00006879} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -228,7 +228,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006880} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00006880} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -241,7 +241,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007315} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00007315} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -254,7 +254,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007316} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00007316} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -267,7 +267,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007317} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00007317} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -280,7 +280,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007675}) + ":FHS OFFSPRING EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00007593} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00007593} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -293,7 +293,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007711} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00007711} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -306,7 +306,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008401} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00008401} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -319,7 +319,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008800} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00008800} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -332,7 +332,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008800} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00008800} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -345,7 +345,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009198} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00009198} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009199} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00009199} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -371,7 +371,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009200} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00009200} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -384,7 +384,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009202} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00009202} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -397,7 +397,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009699} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00009699} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -410,7 +410,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009700} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00009700} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -423,7 +423,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009701} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00009701} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -436,7 +436,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009703} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00009703} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -449,7 +449,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010184} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00010184} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -462,7 +462,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010185} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00010185} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -475,7 +475,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010186} == 1, "RxCUI:C10AB"))'
+          expr: 'case(({phv00010186} == 1, "ATC:C10AB"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -488,7 +488,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010188} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00010188} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -501,7 +501,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055369} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00055369} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -514,7 +514,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055370} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00055370} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -527,7 +527,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056940} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00056940} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -553,7 +553,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056971} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00056971} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -566,7 +566,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056971} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00056971} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -579,7 +579,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007319} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00007319} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -592,7 +592,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001035}) + ":FHS ORIGINAL EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00000868} == 1, "RxCUI:C10A"), ({phv00000868} == 3, "RxCUI:C10A"))'
+          expr: 'case(({phv00000868} == 1, "ATC:C10A"), ({phv00000868} == 3, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -605,7 +605,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006882} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00006882} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -618,7 +618,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006487} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00006487} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -631,7 +631,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006147} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00006147} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -644,7 +644,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005596} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00005596} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -657,7 +657,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004976} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00004976} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -670,7 +670,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004615} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00004615} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -683,7 +683,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004219} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00004219} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -696,7 +696,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003784} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00003784} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -709,7 +709,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         drug_concept:
-          expr: 'case(({phv00002702} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00002702} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -722,7 +722,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002668}) + ":FHS ORIGINAL EXAM 15")'
         drug_concept:
-          expr: 'case(({phv00002448} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00002448} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -735,7 +735,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002425}) + ":FHS ORIGINAL EXAM 14")'
         drug_concept:
-          expr: 'case(({phv00002226} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00002226} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -748,7 +748,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002204}) + ":FHS ORIGINAL EXAM 13")'
         drug_concept:
-          expr: 'case(({phv00002043} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00002043} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -761,7 +761,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002020}) + ":FHS ORIGINAL EXAM 12")'
         drug_concept:
-          expr: 'case(({phv00001824} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00001824} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -774,7 +774,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001803}) + ":FHS ORIGINAL EXAM 11")'
         drug_concept:
-          expr: 'case(({phv00001624} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00001624} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -787,7 +787,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001558}) + ":FHS ORIGINAL EXAM 10")'
         drug_concept:
-          expr: 'case(({phv00001441} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00001441} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -800,7 +800,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250762} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00250762} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_orlhypoag.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_orlhypoag.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250769} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00250769} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250775} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00250775} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250776} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00250776} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001558}) + ":FHS ORIGINAL EXAM 10")'
         drug_concept:
-          expr: 'case(({phv00001445} == 1, "RxCUI:HS509"))'
+          expr: 'case(({phv00001445} == 1, "VANDF:HS509"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00001803}) + ":FHS ORIGINAL EXAM 11")'
         drug_concept:
-          expr: 'case(({phv00001628} == 1, "RxCUI:HS509"))'
+          expr: 'case(({phv00001628} == 1, "VANDF:HS509"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002020}) + ":FHS ORIGINAL EXAM 12")'
         drug_concept:
-          expr: 'case(({phv00001829} == 1, "RxCUI:HS509"))'
+          expr: 'case(({phv00001829} == 1, "VANDF:HS509"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002204}) + ":FHS ORIGINAL EXAM 13")'
         drug_concept:
-          expr: 'case(({phv00002048} == 1, "RxCUI:HS509"))'
+          expr: 'case(({phv00002048} == 1, "VANDF:HS509"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002425}) + ":FHS ORIGINAL EXAM 14")'
         drug_concept:
-          expr: 'case(({phv00002230} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00002230} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002668}) + ":FHS ORIGINAL EXAM 15")'
         drug_concept:
-          expr: 'case(({phv00002452} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00002452} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         drug_concept:
-          expr: 'case(({phv00002706} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00002706} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: 'case(({phv00002969} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00002969} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -215,7 +215,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: 'case(({phv00003356} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00003356} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -228,7 +228,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003790} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00003790} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -241,7 +241,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004225} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00004225} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -254,7 +254,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004621} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00004621} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -267,7 +267,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004983} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00004983} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -280,7 +280,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005603} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00005603} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -293,7 +293,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006154} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006154} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -306,7 +306,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006494} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006494} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -319,7 +319,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006889} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006889} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -423,7 +423,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006897} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006897} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -436,7 +436,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006898} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00006898} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -449,7 +449,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007326} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00007326} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -553,7 +553,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007334} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00007334} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -566,7 +566,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007335} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00007335} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -579,7 +579,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007675}) + ":FHS OFFSPRING EXAM 1")'
         drug_concept:
-          expr: 'case(({phv00007597} == 4, "RxCUI:HS509"))'
+          expr: 'case(({phv00007597} == 4, "VANDF:HS509"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -592,7 +592,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008378}) + ":FHS OFFSPRING EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00007715} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00007715} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -605,7 +605,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008405} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00008405} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -618,7 +618,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008806} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00008806} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -631,7 +631,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009209} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00009209} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -644,7 +644,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009710} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00009710} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -657,7 +657,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010195} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00010195} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -735,7 +735,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010201} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00010201} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -748,7 +748,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010202} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00010202} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -761,7 +761,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056978} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00056978} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_statin.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_statin.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250761} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00250761} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004975} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00004975} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005595} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00005595} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006146} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00006146} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006486} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00006486} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006881} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00006881} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007318} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00007318} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009702} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00009702} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010187} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00010187} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00276803}) + ":" + case(({phv00276845} == ''0'', ''FHS ORIGINAL CHF''), ({phv00276845} == ''1'', ''FHS OFFSPRING CHF''), ({phv00276845} == ''2'', ''FHS NEW OFFSPRING CHF''), ({phv00276845} == ''3'', ''FHS GENERATION 3 CHF''), ({phv00276845} == ''7'', ''FHS OMNI 1 CHF''), ({phv00276845} == ''72'', ''FHS OMNI 2 CHF''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00276812} == 1, "RxCUI:N0000175589"))'
+          expr: 'case(({phv00276812} == 1, "NDFRT:N0000175589"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/FHS-ingest/tak_vasodil.yaml
+++ b/priority_variables_transform/FHS-ingest/tak_vasodil.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         drug_concept:
-          expr: 'case(({phv00250747} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00250747} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -20,7 +20,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         drug_concept:
-          expr: 'case(({phv00002964} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00002964} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -33,7 +33,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003667}) + ":FHS ORIGINAL EXAM 18")'
         drug_concept:
-          expr: 'case(({phv00003346} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00003346} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -46,7 +46,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004083}) + ":FHS ORIGINAL EXAM 19")'
         drug_concept:
-          expr: 'case(({phv00003781} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00003781} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -59,7 +59,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004525}) + ":FHS ORIGINAL EXAM 20")'
         drug_concept:
-          expr: 'case(({phv00004216} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00004216} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -72,7 +72,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00004939}) + ":FHS ORIGINAL EXAM 21")'
         drug_concept:
-          expr: 'case(({phv00004609} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00004609} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -85,7 +85,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005557}) + ":FHS ORIGINAL EXAM 22")'
         drug_concept:
-          expr: 'case(({phv00004965} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00004965} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -98,7 +98,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00005558}) + ":FHS ORIGINAL EXAM 23")'
         drug_concept:
-          expr: 'case(({phv00005585} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00005585} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -111,7 +111,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006031}) + ":FHS ORIGINAL EXAM 24")'
         drug_concept:
-          expr: 'case(({phv00006137} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00006137} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -124,7 +124,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00006663}) + ":FHS ORIGINAL EXAM 25")'
         drug_concept:
-          expr: 'case(({phv00006477} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00006477} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -137,7 +137,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007095}) + ":FHS ORIGINAL EXAM 26")'
         drug_concept:
-          expr: 'case(({phv00006867} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00006867} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -150,7 +150,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00007534}) + ":FHS ORIGINAL EXAM 27")'
         drug_concept:
-          expr: 'case(({phv00007304} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00007304} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -163,7 +163,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00008742}) + ":FHS OFFSPRING EXAM 3")'
         drug_concept:
-          expr: 'case(({phv00008389} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00008389} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009127}) + ":FHS OFFSPRING EXAM 4")'
         drug_concept:
-          expr: 'case(({phv00008797} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00008797} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -189,7 +189,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00009579}) + ":FHS OFFSPRING EXAM 5")'
         drug_concept:
-          expr: 'case(({phv00009192} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00009192} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -202,7 +202,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         drug_concept:
-          expr: 'case(({phv00009693} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00009693} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -215,7 +215,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         drug_concept:
-          expr: 'case(({phv00010173} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00010173} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -228,7 +228,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055368} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00055368} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -241,7 +241,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055379} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00055379} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -254,7 +254,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00055380} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00055380} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -267,7 +267,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056997} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00056997} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -280,7 +280,7 @@
         associated_visit:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00057982}) + ":" + case(({phv00057968} == ''1'', ''FHS OFFSPRING SHHS 2''), ({phv00057968} == ''7'', ''FHS OMNI 1 SHHS 2''), (True, ''FHS UNKNOWN VISIT'')))'
         drug_concept:
-          expr: 'case(({phv00056998} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00056998} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226324} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00226324} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00258039} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00258039} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_aceinhib.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226324} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00226324} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226325} == 1, "RxCUI:C09A"))'
+          expr: 'case(({phv00226325} == 1, "ATC:C09A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226326} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00226326} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_betablk.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226330} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00226330} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226330} == 1, "RxCUI:OP101"))'
+          expr: 'case(({phv00226330} == 1, "VANDF:OP101"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226330} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00226330} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_calchanblk.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226332} == 1, "RxCUI:C08"))'
+          expr: 'case(({phv00226332} == 1, "ATC:C08"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_diuret.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226339} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00226339} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226340} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00226340} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00258117} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00258117} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_insulin.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226345} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00226345} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226360} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00226360} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226361} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00226361} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_nstat_med.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_nstat_med.yaml
@@ -8,7 +8,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226344} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00226344} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00258053} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00258053} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00258054} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00258054} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: HCHS EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00226349} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00226349} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/JHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/JHS-ingest/hypert_trt.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: JHS Exam 1
         drug_concept:
-          value: case(({phv00127922} == 1, 'RxCUI:C02'))
+          value: case(({phv00127922} == 1, 'ATC:C02'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,7 +19,7 @@
         associated_visit:
           value: JHS AFU
         drug_concept:
-          value: case(({phv00400884} == 1, 'RxCUI:C02'))
+          value: case(({phv00400884} == 1, 'ATC:C02'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -31,7 +31,7 @@
         associated_visit:
           value: JHS Exam 6
         drug_concept:
-          value: case(({phv00403802} == 1, 'RxCUI:C02'))
+          value: case(({phv00403802} == 1, 'ATC:C02'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -43,6 +43,6 @@
         associated_visit:
           value: JHS Exam 1
         drug_concept:
-          value: case(({phv00403802} == 1, 'RxCUI:C02'))
+          value: case(({phv00403802} == 1, 'ATC:C02'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/JHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/JHS-ingest/tak_betablk.yaml
@@ -8,7 +8,7 @@
           value: JHS Exam 1
           range: string
         drug_concept:
-          expr: case(({phv00401106} == 1, "RxCUI:C07A"))
+          expr: case(({phv00401106} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: JHS Exam 2
           range: string
         drug_concept:
-          expr: case(({phv00401298} == 1, "RxCUI:C07A"))
+          expr: case(({phv00401298} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401399} == 1, "RxCUI:C07A"))
+          expr: case(({phv00401399} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/JHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/JHS-ingest/tak_calchanblk.yaml
@@ -8,7 +8,7 @@
           value: JHS Exam 1
           range: string
         drug_concept:
-          expr: case(({phv00401107} == 1, "RxCUI:C08"))
+          expr: case(({phv00401107} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: JHS Exam 2
           range: string
         drug_concept:
-          expr: case(({phv00401299} == 1, "RxCUI:C08"))
+          expr: case(({phv00401299} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401400} == 1, "RxCUI:C08"))
+          expr: case(({phv00401400} == 1, "ATC:C08"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/JHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/JHS-ingest/tak_diuret.yaml
@@ -8,7 +8,7 @@
           value: JHS Exam 1
           range: string
         drug_concept:
-          expr: case(({phv00401108} == 1, "RxCUI:C03"))
+          expr: case(({phv00401108} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: JHS Exam 2
           range: string
         drug_concept:
-          expr: case(({phv00401300} == 1, "RxCUI:C03"))
+          expr: case(({phv00401300} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401401} == 1, "RxCUI:C03"))
+          expr: case(({phv00401401} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: JHS Exam 1
           range: string
         drug_concept:
-          expr: case(({phv00401102} == 1, "RxCUI:C03"))
+          expr: case(({phv00401102} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: JHS Exam 2
           range: string
         drug_concept:
-          expr: case(({phv00401294} == 1, "RxCUI:C03"))
+          expr: case(({phv00401294} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401574} == 1, "RxCUI:C03"))
+          expr: case(({phv00401574} == 1, "ATC:C03"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/JHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/JHS-ingest/tak_insulin.yaml
@@ -8,7 +8,7 @@
           value: JHS Exam 1
           range: string
         drug_concept:
-          expr: case(({phv00401102} == 1, 'RxCUI:D007328'))
+          expr: case(({phv00401102} == 1, 'MeSH:D007328'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: JHS Exam 2
           range: string
         drug_concept:
-          expr: case(({phv00401273} == 1, 'RxCUI:D007328'))
+          expr: case(({phv00401273} == 1, 'MeSH:D007328'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401395} == 1, 'RxCUI:D007328'))
+          expr: case(({phv00401395} == 1, 'MeSH:D007328'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401574} == 1, 'RxCUI:D007328'))
+          expr: case(({phv00401574} == 1, 'MeSH:D007328'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/JHS-ingest/tak_med_diab.yaml
+++ b/priority_variables_transform/JHS-ingest/tak_med_diab.yaml
@@ -8,7 +8,7 @@
           value: JHS AFU
           range: string
         drug_concept:
-          expr: case(({phv00400885} == 1, "RxCUI:A10"))
+          expr: case(({phv00400885} == 1, "ATC:A10"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/JHS-ingest/tak_statin.yaml
+++ b/priority_variables_transform/JHS-ingest/tak_statin.yaml
@@ -8,7 +8,7 @@
           value: JHS Exam 1
           range: string
         drug_concept:
-          expr: case(({phv00401114} == 1, 'RxCUI:N0000175589'))
+          expr: case(({phv00401114} == 1, 'NDFRT:N0000175589'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: JHS Exam 2
           range: string
         drug_concept:
-          expr: case(({phv00401296} == 1, 'RxCUI:N0000175589'))
+          expr: case(({phv00401296} == 1, 'NDFRT:N0000175589'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: JHS Exam 3
           range: string
         drug_concept:
-          expr: case(({phv00401397} == 1, 'RxCUI:N0000175589'))
+          expr: case(({phv00401397} == 1, 'NDFRT:N0000175589'))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/MESA-ingest/hypert_trt.yaml
@@ -10,7 +10,7 @@
         age_at_exposure_start:
           expr: case(({phv00082998} == 1, {phv00082999} * 365))
         drug_concept:
-          expr: 'case(({phv00082998} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00082998} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -24,7 +24,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083163} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00083163} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -40,7 +40,7 @@
         age_at_exposure_start:
           expr: case(({phv00085236} == 1, {phv00085237} * 365))
         drug_concept:
-          expr: 'case(({phv00085236} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00085236} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -54,7 +54,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085324} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00085324} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -68,7 +68,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086014} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00086014} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -82,7 +82,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086496} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00086496} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -96,7 +96,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086933} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00086933} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -112,7 +112,7 @@
         age_at_exposure_start:
           expr: case(({phv00087093} == 1, {phv00087154} * 365))
         drug_concept:
-          expr: 'case(({phv00087093} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00087093} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -126,7 +126,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175410} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00175410} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -140,7 +140,7 @@
           value: MESA LUNG CT
           range: string
         drug_concept:
-          expr: 'case(({phv00175864} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00175864} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -154,7 +154,7 @@
           value: MESA LUNG CT
           range: string
         drug_concept:
-          expr: 'case(({phv00175949} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00175949} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -168,7 +168,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176833} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00176833} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_aceinhib.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: case(({phv00083083} == 1, "RxCUI:C09A"))
+          expr: case(({phv00083083} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: case(({phv00083084} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00083084} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: case(({phv00085328} == 1, "RxCUI:C09A"))
+          expr: case(({phv00085328} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: case(({phv00085329} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00085329} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: case(({phv00086001} == 1, "RxCUI:C09A"))
+          expr: case(({phv00086001} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: case(({phv00086002} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00086002} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: case(({phv00086483} == 1, "RxCUI:C09A"))
+          expr: case(({phv00086483} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: case(({phv00086484} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00086484} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: case(({phv00086920} == 1, "RxCUI:C09A"))
+          expr: case(({phv00086920} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: case(({phv00086921} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00086921} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: case(({phv00087304} == 1, "RxCUI:C09A"))
+          expr: case(({phv00087304} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: case(({phv00087305} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00087305} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: case(({phv00175329} == 1, "RxCUI:C09A"))
+          expr: case(({phv00175329} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: case(({phv00175330} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00175330} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: case(({phv00176752} == 1, "RxCUI:C09A"))
+          expr: case(({phv00176752} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: case(({phv00176753} == 1, "RxCUI:C09BA"))
+          expr: case(({phv00176753} == 1, "ATC:C09BA"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_alphablk.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_alphablk.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083087} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00083087} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083088} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00083088} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083088} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00083088} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085332} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00085332} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085333} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00085333} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085333} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00085333} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086019} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00086019} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086020} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00086020} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086020} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00086020} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086501} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00086501} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086502} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00086502} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086502} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00086502} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086938} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00086938} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086939} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00086939} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086939} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00086939} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087308} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00087308} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087309} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00087309} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087309} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00087309} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175333} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00175333} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175334} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00175334} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175334} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00175334} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176756} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00176756} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176757} == 1, "RxCUI:CV150"))'
+          expr: 'case(({phv00176757} == 1, "VANDF:CV150"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176757} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00176757} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_angiorecepblk.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_angiorecepblk.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083081} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00083081} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083082} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00083082} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085326} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00085326} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085326} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00085326} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086015} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00086015} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086016} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00086016} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086497} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00086497} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086498} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00086498} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086934} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00086934} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086935} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00086935} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087302} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00087302} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087303} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00087303} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175327} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00175327} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175328} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00175328} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176750} == 1, "RxCUI:C09C"))'
+          expr: 'case(({phv00176750} == 1, "ATC:C09C"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176751} == 1, "RxCUI:C09DA"))'
+          expr: 'case(({phv00176751} == 1, "ATC:C09DA"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_diuret.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083116} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00083116} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083117} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00083117} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083117} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00083117} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083117} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00083117} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083161} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00083161} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085361} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00085361} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085362} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00085362} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085362} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00085362} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085370} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00085370} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085406} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00085406} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086012} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00086012} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086043} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00086043} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086044} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00086044} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086044} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00086044} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086050} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00086050} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086494} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00086494} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086525} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00086525} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086526} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00086526} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086526} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00086526} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086532} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00086532} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086931} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00086931} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086962} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00086962} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086963} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00086963} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086963} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00086963} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -344,7 +344,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086969} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00086969} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -358,7 +358,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087381} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00087381} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -372,7 +372,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087337} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00087337} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -386,7 +386,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087338} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00087338} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -400,7 +400,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087338} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00087338} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -414,7 +414,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087346} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00087346} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -428,7 +428,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175408} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00175408} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -442,7 +442,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175363} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00175363} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -456,7 +456,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175364} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00175364} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -470,7 +470,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175364} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00175364} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -484,7 +484,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175372} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00175372} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -498,7 +498,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176831} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00176831} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -512,7 +512,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176786} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00176786} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -526,7 +526,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176787} == 1, "RxCUI:N0000175419"))'
+          expr: 'case(({phv00176787} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -540,7 +540,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176787} == 1, "RxCUI:N0000175418"))'
+          expr: 'case(({phv00176787} == 1, "NDFRT:N0000175418"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -554,7 +554,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176795} == 1, "RxCUI:CV702"))'
+          expr: 'case(({phv00176795} == 1, "VANDF:CV702"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_insulin.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083119} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00083119} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083302} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00083302} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00084979} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00084979} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085364} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00085364} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00085926} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00085926} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086008} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00086008} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086409} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00086409} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086490} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00086490} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086841} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00086841} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086927} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00086927} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175366} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00175366} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175455} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00175455} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176789} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00176789} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176889} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00176889} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_med_diab.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_med_diab.yaml
@@ -10,7 +10,7 @@
         age_at_exposure_start:
           expr: case(({phv00083006} == 1, {phv00083008} * 365))
         drug_concept:
-          expr: 'case(({phv00083006} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00083006} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -26,7 +26,7 @@
         age_at_exposure_start:
           expr: case(({phv00085234} == 1, {phv00085244} * 365))
         drug_concept:
-          expr: 'case(({phv00085234} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00085234} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -42,7 +42,7 @@
         age_at_exposure_start:
           expr: case(({phv00087115} == 1, {phv00087161} * 365))
         drug_concept:
-          expr: 'case(({phv00087115} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00087115} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -56,7 +56,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175292} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00175292} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -70,7 +70,7 @@
           value: MESA LUNG CT
           range: string
         drug_concept:
-          expr: 'case(({phv00175870} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00175870} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -84,7 +84,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176715} == 1, "RxCUI:A10"))'
+          expr: 'case(({phv00176715} == 1, "ATC:A10"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_nstat_med.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_nstat_med.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083097} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00083097} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083128} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00083128} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085342} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00085342} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085373} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00085373} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086028} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00086028} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086052} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00086052} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086510} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00086510} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086534} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00086534} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086947} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00086947} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086971} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00086971} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087318} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00087318} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087349} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00087349} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175343} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00175343} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175375} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00175375} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176766} == 1, "RxCUI:N0000180292"))'
+          expr: 'case(({phv00176766} == 1, "NDFRT:N0000180292"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176798} == 1, "RxCUI:N0000175594"))'
+          expr: 'case(({phv00176798} == 1, "NDFRT:N0000175594"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_orlhypoag.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_orlhypoag.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083135} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00083135} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083302} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00083302} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00084979} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00084979} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085380} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00085380} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00085926} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00085926} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086011} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00086011} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086409} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00086409} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086493} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00086493} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086841} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00086841} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086930} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00086930} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087103} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00087103} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175382} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00175382} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175455} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00175455} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176805} == 1, "RxCUI:HS502"))'
+          expr: 'case(({phv00176805} == 1, "VANDF:HS502"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176889} == 1, "RxCUI:HS500"))'
+          expr: 'case(({phv00176889} == 1, "VANDF:HS500"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_statin.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_statin.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083162} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00083162} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -24,7 +24,7 @@
         age_at_exposure_start:
           expr: case(({phv00083002} == 1, {phv00083003} * 365))
         drug_concept:
-          expr: 'case(({phv00083002} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00083002} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string          
@@ -38,7 +38,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085407} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00085407} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -54,7 +54,7 @@
         age_at_exposure_start:
           expr: case(({phv00087104} == 1, {phv00087157} * 365))
         drug_concept:
-          expr: 'case(({phv00087104} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00087104} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -69,7 +69,7 @@
         age_at_exposure_start:
           expr: case(({phv00085235} == 1, {phv00085237} * 365))
         drug_concept:
-          expr: 'case(({phv00085235} == 1, "RxCUI:C10A"))'
+          expr: 'case(({phv00085235} == 1, "ATC:C10A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION          
           range: string

--- a/priority_variables_transform/MESA-ingest/tak_vasodil.yaml
+++ b/priority_variables_transform/MESA-ingest/tak_vasodil.yaml
@@ -8,7 +8,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083154} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00083154} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083155} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00083155} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: MESA AIR EXAM
           range: string
         drug_concept:
-          expr: 'case(({phv00083144} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00083144} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085389} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00085389} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085399} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00085399} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: MESA CLASSIC EXAM 1
           range: string
         drug_concept:
-          expr: 'case(({phv00085400} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00085400} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -92,7 +92,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086067} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00086067} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -106,7 +106,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086077} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00086077} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -120,7 +120,7 @@
           value: MESA CLASSIC EXAM 2
           range: string
         drug_concept:
-          expr: 'case(({phv00086078} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00086078} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -134,7 +134,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086549} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00086549} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -148,7 +148,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086559} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00086559} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -162,7 +162,7 @@
           value: MESA CLASSIC EXAM 3
           range: string
         drug_concept:
-          expr: 'case(({phv00086560} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00086560} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -176,7 +176,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086986} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00086986} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -190,7 +190,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086996} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00086996} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -204,7 +204,7 @@
           value: MESA CLASSIC EXAM 4
           range: string
         drug_concept:
-          expr: 'case(({phv00086997} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00086997} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -218,7 +218,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087364} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00087364} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -232,7 +232,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087374} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00087374} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -246,7 +246,7 @@
           value: MESA FAMILY
           range: string
         drug_concept:
-          expr: 'case(({phv00087375} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00087375} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -260,7 +260,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175391} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00175391} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -274,7 +274,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175401} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00175401} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -288,7 +288,7 @@
           value: MESA AIR EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00175402} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00175402} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -302,7 +302,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176814} == 1, "RxCUI:C04"))'
+          expr: 'case(({phv00176814} == 1, "ATC:C04"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -316,7 +316,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176824} == 1, "RxCUI:C01D"))'
+          expr: 'case(({phv00176824} == 1, "ATC:C01D"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -330,7 +330,7 @@
           value: MESA CLASSIC EXAM 5
           range: string
         drug_concept:
-          expr: 'case(({phv00176825} == 1, "RxCUI:C02L"))'
+          expr: 'case(({phv00176825} == 1, "ATC:C02L"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/WHI-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/WHI-ingest/hypert_trt.yaml
@@ -8,7 +8,7 @@
           value: WHI FORM 30 - MEDICAL HISTORY QUESTIONNAIRE
           range: string
         drug_concept:
-          expr: 'case(({phv00078559} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00078559} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: WHI CAD
           range: string
         drug_concept:
-          expr: 'case(({phv00170607} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00170607} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: WHI CTOS
           range: string
         drug_concept:
-          expr: 'case(({phv00170689} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00170689} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: WHI EXTENSION STUDY 2 MRC
           range: string
         drug_concept:
-          expr: 'case(({phv00193667} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00193667} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: WHI EXTENSION STUDY 2 SRC
           range: string
         drug_concept:
-          expr: 'case(({phv00193779} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00193779} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -78,7 +78,7 @@
           value: WHI EXTENSION STUDY 2 SRC
           range: string
         drug_concept:
-          expr: 'case(({phv00193779} == 1, "RxCUI:C02"))'
+          expr: 'case(({phv00193779} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/WHI-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_aceinhib.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: WHI UNC HEART FAILURE DETAILS
         drug_concept:
-          expr: case(({phv00283673} == 1, "RxCUI:C09A"))
+          expr: case(({phv00283673} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,6 +19,6 @@
         associated_visit:
           value: WHI UNC HEART FAILURE DETAILS
         drug_concept:
-          expr: case(({phv00283674} == 1, "RxCUI:C09A"))
+          expr: case(({phv00283674} == 1, "ATC:C09A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/WHI-ingest/tak_angiorecepblk.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_angiorecepblk.yaml
@@ -8,7 +8,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: case(({phv00283675} == 1, "RxCUI:C09C"))
+          expr: case(({phv00283675} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: case(({phv00283676} == 1, "RxCUI:C09C"))
+          expr: case(({phv00283676} == 1, "ATC:C09C"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/WHI-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_betablk.yaml
@@ -8,7 +8,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: 'case(({phv00283677} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00283677} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: 'case(({phv00283678} == 1, "RxCUI:C07A"))'
+          expr: 'case(({phv00283678} == 1, "ATC:C07A"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/WHI-ingest/tak_betablks.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_betablks.yaml
@@ -7,7 +7,7 @@
         associated_visit:
           value: WHI UNC HEART FAILURE DETAILS
         drug_concept:
-          expr: case(({phv00283677} == 1, "RxCUI:C07A"))
+          expr: case(({phv00283677} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
 - class_derivations:
@@ -19,6 +19,6 @@
         associated_visit:
           value: WHI UNC HEART FAILURE DETAILS
         drug_concept:
-          expr: case(({phv00283678} == 1, "RxCUI:C07A"))
+          expr: case(({phv00283678} == 1, "ATC:C07A"))
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION

--- a/priority_variables_transform/WHI-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_diuret.yaml
@@ -8,7 +8,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: 'case(({phv00283681} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00283681} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: 'case(({phv00283682} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00283682} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         drug_concept:
-          expr: 'case(({phv00283694} == 1, "RxCUI:C03"))'
+          expr: 'case(({phv00283694} == 1, "ATC:C03"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/WHI-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_insulin.yaml
@@ -8,7 +8,7 @@
           value: WHI ELIGIBILITY
           range: string
         drug_concept:
-          expr: 'case(({phv00078469} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00078469} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -22,7 +22,7 @@
           value: WHI CAD
           range: string
         drug_concept:
-          expr: 'case(({phv00170601} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00170601} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -36,7 +36,7 @@
           value: WHI CTOS
           range: string
         drug_concept:
-          expr: 'case(({phv00170683} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00170683} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -50,7 +50,7 @@
           value: WHI EXTENSION STUDY 2 MRC
           range: string
         drug_concept:
-          expr: 'case(({phv00193671} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00193671} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string
@@ -64,7 +64,7 @@
           value: WHI EXTENSION STUDY 2 SRC
           range: string
         drug_concept:
-          expr: 'case(({phv00193783} == 1, "RxCUI:D007328"))'
+          expr: 'case(({phv00193783} == 1, "MeSH:D007328"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/WHI-ingest/tak_steroid.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_steroid.yaml
@@ -8,7 +8,7 @@
           value: WHI MAIN 44
           range: string
         drug_concept:
-          expr: 'case(({phv00169610} == 1, "RxCUI:HS051"))'
+          expr: 'case(({phv00169610} == 1, "VANDF:HS051"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string


### PR DESCRIPTION
## Summary

Closes #390

Fixes a systemic issue where non-RxNorm drug class codes were incorrectly prefixed as \RxCUI:\. True RxCUI identifiers are pure numeric (e.g., \RxCUI:253182\); alpha-prefixed codes belong to their respective source vocabularies.

## Changes

Applied correct CURIE prefixes across **78 YAML files** in \priority_variables_transform/\ (all cohorts, \_archive\ excluded):

| Old Prefix | New Prefix | Vocabulary | Example |
|---|---|---|---|
| \RxCUI:C10A\ | \ATC:C10A\ | WHO ATC (Anatomical Therapeutic Chemical) | Lipid-modifying agents |
| \RxCUI:D007328\ | \MeSH:D007328\ | MeSH descriptor | Insulin |
| \RxCUI:N0000175589\ | \NDFRT:N0000175589\ | NDF-RT / MED-RT | HMG CoA Reductase Inhibitors |
| \RxCUI:CV702\ | \VANDF:CV702\ | VA Drug Class | Diuretics |

### Code counts fixed
- **ATC:** 17 distinct codes (A10, C01A, C01D, C02, C02L, C03, C04, C07A, C07D, C08, C09A, C09BA, C09C, C09DA, C10A, C10AB, M04)
- **MeSH:** 2 codes (D007328, D013974)
- **NDFRT:** 15 codes (N0000009917, N0000009918, N0000175415–N0000180292)
- **VANDF:** 10 codes (AH000, CN104, CV150, CV702, GA300, HS051, HS500, HS502, HS509, OP101)

## Rationale

Per the [RxClass API documentation](https://lhncbc.nlm.nih.gov/RxNav/APIs/api-RxClass.getClassMembers.html), the \classId\ parameter takes native identifiers from the source vocabulary (ATC, MeSH, NDF-RT, VA), not RxCUI numeric identifiers. The \elaSource\ parameter is a separate concept. Applying \RxCUI:\ to these codes is semantically incorrect and would break downstream RxClass API lookups.

## Verification

- Post-fix scan: **0 remaining** \RxCUI:[A-Z]\ patterns in scope
- Numeric RxCUI values (e.g., \RxCUI:253182\) are **untouched**
- All 4 new prefix types confirmed present and correctly formed