### PR TITLE
Comment out FHS person.yaml cause_of_death blocks referencing non-existent pht000094 (#450)

### DIFF
--- a/priority_variables_transform/FHS-ingest/person.yaml
+++ b/priority_variables_transform/FHS-ingest/person.yaml
@@ -98,76 +98,76 @@
 #                      '1': OMOP:434489
 #                  age_at_death:
 #                    expr: '{pht002075.phv00141916} * 365'
-                  cause_of_death:
-                    object_derivations:
-                    - class_derivations:
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021941
-                            order:
-                              value: 1        
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021942
-                            order:
-                              value: 2
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021943
-                            order:
-                              value: 3
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021944
-                            order:
-                              value: 4 
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021945
-                            order:
-                              value: 5
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021946
-                            order:
-                              value: 6
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021947
-                            order:
-                              value: 7
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021948
-                            order:
-                              value: 8
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021949
-                            order:
-                              value: 9
-                        CauseOfDeath:
-                          populated_from: pht000094
-                          slot_derivations:
-                            cause:
-                              populated_from: phv00021950
-                            order:
-                              value: 10
+#                  cause_of_death:
+#                    object_derivations:
+#                    - class_derivations:
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021941
+#                            order:
+#                              value: 1        
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021942
+#                            order:
+#                              value: 2
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021943
+#                            order:
+#                              value: 3
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021944
+#                            order:
+#                              value: 4 
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021945
+#                            order:
+#                              value: 5
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021946
+#                            order:
+#                              value: 6
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021947
+#                            order:
+#                              value: 7
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021948
+#                            order:
+#                              value: 8
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021949
+#                            order:
+#                              value: 9
+#                        CauseOfDeath:
+#                          populated_from: pht000094
+#                          slot_derivations:
+#                            cause:
+#                              populated_from: phv00021950
+#                            order:
+#                              value: 10


### PR DESCRIPTION
## Summary

Comment out the entire `cause_of_death` section in FHS person.yaml (lines 101-173). All 10 nested CauseOfDeath derivations reference `pht000094` which doesn't exist in the FHS v35 source schema.

Closes #450