### PR TITLE
feat(FHS): add visit_category to 11 exam blocks (#401)

### DIFF
--- a/priority_variables_transform/FHS-ingest/visit.yaml
+++ b/priority_variables_transform/FHS-ingest/visit.yaml
@@ -17,6 +17,13 @@
           expr: '{phv00177930} * 365'
         age_at_visit_end:
           expr: '{phv00177930} * 365'
+        visit_category:
+          populated_from: pht004813.phv00565431
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -33,6 +40,14 @@
           expr: '{phv00177932} * 365'
         age_at_visit_end:
           expr: '{phv00177932} * 365'
+        visit_category:
+          populated_from: pht004814.phv00251057
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -49,6 +64,14 @@
           expr: '{phv00177934} * 365'
         age_at_visit_end:
           expr: '{phv00177934} * 365'
+        visit_category:
+          populated_from: pht004815.phv00251531
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -65,6 +88,14 @@
           expr: '{phv00177936} * 365'
         age_at_visit_end:
           expr: '{phv00177936} * 365'
+        visit_category:
+          populated_from: pht005140.phv00254283
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -81,6 +112,15 @@
           expr: '{phv00177938} * 365'
         age_at_visit_end:
           expr: '{phv00177938} * 365'
+        visit_category:
+          populated_from: pht015104.phv00545435
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': TELEHEALTH
+            '8': OUTPATIENT
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -145,6 +185,14 @@
           expr: '{phv00177946} * 365'
         age_at_visit_end:
           expr: '{phv00177946} * 365'
+        visit_category:
+          populated_from: pht005140.phv00254283
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -161,6 +209,15 @@
           expr: '{phv00177948} * 365'
         age_at_visit_end:
           expr: '{phv00177948} * 365'
+        visit_category:
+          populated_from: pht015104.phv00545435
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': TELEHEALTH
+            '8': OUTPATIENT
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -465,6 +522,14 @@
           expr: '{phv00226999} * 365'
         age_at_visit_end:
           expr: '{phv00226999} * 365'
+        visit_category:
+          populated_from: pht005141.phv00254761
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -481,6 +546,14 @@
           expr: '{phv00227002} * 365'
         age_at_visit_end:
           expr: '{phv00227002} * 365'
+        visit_category:
+          populated_from: pht005142.phv00255154
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -497,6 +570,14 @@
           expr: '{phv00227005} * 365'
         age_at_visit_end:
           expr: '{phv00227005} * 365'
+        visit_category:
+          populated_from: pht006007.phv00274879
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -513,6 +594,14 @@
           expr: '{phv00227008} * 365'
         age_at_visit_end:
           expr: '{phv00227008} * 365'
+        visit_category:
+          populated_from: pht006008.phv00275237
+          value_mappings:
+            '0': OUTPATIENT
+            '1': NON_HOSPITAL_INSTITUTION
+            '2': HOME
+            '3': NON_HOSPITAL_INSTITUTION
+            '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht000395


### PR DESCRIPTION
## Summary

Adds visit_category slot_derivation to **11 FHS Visit EXAM blocks** in priority_variables_transform/FHS-ingest/visit.yaml, resolving #401.

- **Branch:** `feature/401-fhs-visit-category`
- **File:** `priority_variables_transform/FHS-ingest/visit.yaml`
- **Change:** +89 lines (11 `visit_category` slot_derivations added, no comments)

## 11 Blocks Applied

| EXAM Block | Age PHV | Source Table.Variable | Value Mappings |
|---|---|---|---|
| EXAM 1 | phv00177930 | pht004813.phv00565431 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, .→UNKNOWN |
| EXAM 2 | phv00177932 | pht004814.phv00251057 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 3 | phv00177934 | pht004815.phv00251531 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 4 (Omni 1) | phv00177936 | pht005140.phv00254283 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 5 (COVID) | phv00177938 | pht015104.phv00545435 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→TELEHEALTH, 8→OUTPATIENT, .→UNKNOWN |
| EXAM 9 (Offspring) | phv00177946 | pht005140.phv00254283 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 10 (COVID) | phv00177948 | pht015104.phv00545435 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→TELEHEALTH, 8→OUTPATIENT, .→UNKNOWN |
| EXAM 29 | phv00226999 | pht005141.phv00254761 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 30 | phv00227002 | pht005142.phv00255154 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 31 | phv00227005 | pht006007.phv00274879 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |
| EXAM 32 | phv00227008 | pht006008.phv00275237 | 0→OUTPATIENT, 1→NON_HOSPITAL_INSTITUTION, 2→HOME, 3→NON_HOSPITAL_INSTITUTION, .→UNKNOWN |

## Key Design Decision

Because each YAML EXAM block covers all cohorts via `case()`, **Offspring Exam 9 / Omni 1 Exam 4** required `visit_category` in two blocks (EXAM 4 and EXAM 9), both referencing the same dataset `pht005140.phv00254283`. Same for the **COVID exam** (EXAM 5 and EXAM 10 → `pht015104.phv00545435`). The cross-table join naturally returns null for cohorts not present in the source dataset, so non-matching cohorts are unaffected.

## Related Issues

- #457 — COVID hybrid exam: domain expert review of medical vs. tech portion
- #458 — ~25 visits without Site of Exam variable: domain expert triage