### PR TITLE
fix: standardize relationship_to_participant SELF to ONESELF (#442)

### DIFF
--- a/priority_variables_transform/ARIC-ingest/hist_my_inf.yaml
+++ b/priority_variables_transform/ARIC-ingest/hist_my_inf.yaml
@@ -19,7 +19,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -43,7 +43,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -67,7 +67,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -91,7 +91,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -115,7 +115,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -139,7 +139,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -163,7 +163,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -187,7 +187,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -211,7 +211,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -235,7 +235,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -259,7 +259,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -283,7 +283,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -307,7 +307,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -331,7 +331,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -355,7 +355,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -378,7 +378,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -402,7 +402,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -426,7 +426,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -450,7 +450,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -473,7 +473,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -496,7 +496,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -519,7 +519,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -542,7 +542,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -566,7 +566,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -590,7 +590,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -616,7 +616,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -640,7 +640,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -664,7 +664,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -687,7 +687,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -710,7 +710,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -733,7 +733,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -756,7 +756,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -780,7 +780,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -804,7 +804,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -828,7 +828,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -852,7 +852,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -875,7 +875,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -900,7 +900,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -923,7 +923,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -946,7 +946,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -970,7 +970,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -993,7 +993,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1016,7 +1016,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1039,7 +1039,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1063,7 +1063,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1087,7 +1087,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1111,7 +1111,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1135,7 +1135,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1158,7 +1158,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1181,7 +1181,7 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -1205,5 +1205,5 @@
           value: PATIENT_SELF-REPORTED_CONDITION
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string

--- a/priority_variables_transform/CHS-ingest/history_cvd.yaml
+++ b/priority_variables_transform/CHS-ingest/history_cvd.yaml
@@ -19,7 +19,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -42,7 +42,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -65,7 +65,7 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string
 - class_derivations:
     Condition:
@@ -88,5 +88,5 @@
           value: CLINICAL_DIAGNOSIS
           range: string
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
           range: string

--- a/priority_variables_transform/COPDGene-ingest/angina.yaml
+++ b/priority_variables_transform/COPDGene-ingest/angina.yaml
@@ -11,7 +11,7 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
         condition_status:
           populated_from: phv00159608
           value_mappings:

--- a/priority_variables_transform/COPDGene-ingest/asthma.yaml
+++ b/priority_variables_transform/COPDGene-ingest/asthma.yaml
@@ -22,6 +22,6 @@
         condition_provenance:
           expr: "'PATIENT_SELF-REPORTED_CONDITION' if {phv00159701} == 0 else 'CLINICAL_DIAGNOSIS'"
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
         age_at_condition_start:
           expr: '{phv00159702} * 365'

--- a/priority_variables_transform/COPDGene-ingest/copd.yaml
+++ b/priority_variables_transform/COPDGene-ingest/copd.yaml
@@ -21,6 +21,6 @@
           expr: case( ({phv00159732} == 0, 'PATIENT_SELF-REPORTED_CONDITION'), ({phv00159732}
             == 1, 'CLINICAL_DIAGNOSIS'), (True, 'PATIENT_SELF-REPORTED_CONDITION') )
         relationship_to_participant:
-          value: SELF
+          value: ONESELF
         age_at_condition_start:
           expr: '{phv00159733} * 365'

--- a/priority_variables_transform/COPDGene-ingest/diabetes.yaml
+++ b/priority_variables_transform/COPDGene-ingest/diabetes.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/hist_hrt_failure.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hist_hrt_failure.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/hist_my_inf.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hist_my_inf.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/hyperten.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hyperten.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/pad.yaml
+++ b/priority_variables_transform/COPDGene-ingest/pad.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/slp_ap.yaml
+++ b/priority_variables_transform/COPDGene-ingest/slp_ap.yaml
@@ -23,4 +23,4 @@
           expr: case( ({phv00159737} == 0, 'PATIENT_SELF-REPORTED_CONDITION'), ({phv00159737}
             == 1, 'CLINICAL_DIAGNOSIS'), (True, 'PATIENT_SELF-REPORTED_CONDITION') )
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/stroke.yaml
+++ b/priority_variables_transform/COPDGene-ingest/stroke.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF

--- a/priority_variables_transform/COPDGene-ingest/stroke_isch_atk.yaml
+++ b/priority_variables_transform/COPDGene-ingest/stroke_isch_atk.yaml
@@ -16,4 +16,4 @@
         condition_provenance:
           value: PATIENT_SELF-REPORTED_CONDITION
         relationship_to_participant:
-          value: SELF
+          value: ONESELF


### PR DESCRIPTION
## Summary

Resolves #442. Replaces invalid enum value \SELF\ with schema-compliant \ONESELF\ (OMOP:4167538) in \elationship_to_participant\ across all affected cohort files.

The bdchm schema \FamilyRelationshipEnum\ defines \ONESELF\ as the only valid value for self-relationship. Several files incorrectly used \SELF\, which is not in the enum.

## Changes

### COPDGene-ingest (11 files, 1 occurrence each)
- angina.yaml
- asthma.yaml
- copd.yaml
- diabetes.yaml
- hist_hrt_failure.yaml
- hist_my_inf.yaml
- hyperten.yaml
- pad.yaml
- slp_ap.yaml
- stroke.yaml
- stroke_isch_atk.yaml

### ARIC-ingest (1 file, 51 occurrences)
- hist_my_inf.yaml

### CHS-ingest (1 file, 4 occurrences)
- history_cvd.yaml

## Verification
- Zero remaining \alue: SELF\ across all cohort YAML files
- All modified files pass YAML validation
- No other values altered (\PATIENT_SELF-REPORTED_CONDITION\, \PATIENT SELF-REPORTED MEDICATION\ are untouched)

**13 files changed, 66 insertions, 66 deletions**