### PR TITLE
Update albumin urine YAML with new expression for value_decimal

### DIFF
--- a/priority_variables_transform/ARIC-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/ARIC-ingest/albumin_urine.yaml
@@ -61,7 +61,7 @@
                 populated_from: pht006427
                 slot_derivations:
                   value_decimal:
-                    expr: {phv00295248} * ({phv00295250} * 100)
+                    expr: "{phv00295248} * ({phv00295250} * 0.01)"
                   unit:
                     value: "mg/L"
                     range: string


### PR DESCRIPTION
adding math to convert mg/g{creat} to mg/L - I don't think LinkML map is equipped for this kind of conversion
#419 