### PR TITLE
fix(FHS): Correct transposed OMOP smoking codes + cross-table visit_category workaround (#498)

### DIFF
--- a/priority_variables_transform/FHS-ingest/cig_smok.yaml
+++ b/priority_variables_transform/FHS-ingest/cig_smok.yaml
@@ -15,7 +15,7 @@
           populated_from: phv00000543
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht003094
@@ -33,7 +33,7 @@
           populated_from: phv00177303
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht006005
@@ -51,7 +51,7 @@
           populated_from: phv00273761
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht004814
@@ -69,7 +69,7 @@
           populated_from: phv00251239
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht004815
@@ -87,7 +87,7 @@
           populated_from: phv00251297
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht005141
@@ -105,7 +105,7 @@
           populated_from: phv00254617
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht005140
@@ -123,7 +123,7 @@
           populated_from: phv00254043
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht000012
@@ -141,7 +141,7 @@
           populated_from: phv00001452
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht000013
@@ -159,7 +159,7 @@
           populated_from: phv00001636
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht000014
@@ -176,9 +176,9 @@
         value_enum:
           expr: 'case(
                   ({phv00001836} ==0, "OMOP:45883537"),
-                  ({phv00001836} == 1, "OMOP:40766945"),
-                  ({phv00001836} == 3, "OMOP:40766945"),
-                  ({phv00001849} == 8, "OMOP:45883458"),
+                  ({phv00001836} == 1, "OMOP:45883458"),
+                  ({phv00001836} == 3, "OMOP:45883458"),
+                  ({phv00001849} == 8, "OMOP:45883459"),
                   (True, None))'
 - class_derivations:
     Observation:
@@ -194,8 +194,8 @@
           value: OMOP:4282779
           range: string
         value_enum:
-          expr: 'case(({phv00002055} ==0, "OMOP:45883537"), ({phv00002055} == 1, "OMOP:40766945"),({phv00002055}
-            == 3, "OMOP:40766945"), ({phv00002064} == 8, "OMOP:45883458"), (True, None))'
+          expr: 'case(({phv00002055} ==0, "OMOP:45883537"), ({phv00002055} == 1, "OMOP:45883458"),({phv00002055}
+            == 3, "OMOP:45883458"), ({phv00002064} == 8, "OMOP:45883459"), (True, None))'
 - class_derivations:
     Observation:
       populated_from: pht000019
@@ -211,7 +211,7 @@
           range: string
         value_enum:
           expr: 'case(({phv00002981} == 8, "OMOP:45883537"), ({phv00002981} == 1,
-            "OMOP:45883458"),({phv00002981} == 2, "OMOP:40766945"), (True, None))'
+            "OMOP:45883459"),({phv00002981} == 2, "OMOP:45883458"), (True, None))'
 - class_derivations:
     Observation:
       populated_from: pht000692
@@ -229,8 +229,8 @@
           populated_from: phv00070406
           value_mappings:
             '0': OMOP:45883537
-            '1': OMOP:40766945
-            '2': OMOP:45883458
+            '1': OMOP:45883458
+            '2': OMOP:45883459
 - class_derivations:
     Observation:
       populated_from: pht000009
@@ -245,9 +245,9 @@
         value_enum:
           populated_from: phv00000543
           value_mappings:
-            '1': OMOP:40766945
-            '2': OMOP:45883458
-            '3': OMOP:40766945
+            '1': OMOP:45883458
+            '2': OMOP:45883459
+            '3': OMOP:45883458
             '5': OMOP:45883537
             '7': None
 - class_derivations:
@@ -266,8 +266,8 @@
         value_enum:
           populated_from: phv00000780
           value_mappings:
-            '0': OMOP:45883458
-            '1': OMOP:40766945
+            '0': OMOP:45883459
+            '1': OMOP:45883458
             '2': OMOP:45883537
 - class_derivations:
     Observation:
@@ -285,11 +285,11 @@
         value_enum:
           expr: 'case(
                    ({phv00007735} == 0, "OMOP:45883537"),
-                   ({phv00007735} == 1, "OMOP:45883458"),
+                   ({phv00007735} == 1, "OMOP:45883459"),
                    ({phv00007735} == 3, case(
-                     ({phv00007736} == 0, "OMOP:45883458")
+                     ({phv00007736} == 0, "OMOP:45883459")
                    )),
-                   (True, "OMOP:40766945")
+                   (True, "OMOP:45883458")
                  )'
 - class_derivations:
     Observation:
@@ -308,8 +308,8 @@
           populated_from: phv00007612
           value_mappings:
             '0': OMOP:45883537
-            '1': OMOP:40766945
-            '2': OMOP:45883458
+            '1': OMOP:45883458
+            '2': OMOP:45883459
 - class_derivations:
     Observation:
       populated_from: pht000747
@@ -327,7 +327,7 @@
           populated_from: phv00072090
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht000074
@@ -343,7 +343,7 @@
           range: string
         value_enum:
           expr: 'case(({phv00020925} == 0, "OMOP:45883537"), ({phv00020927} == 0,
-            "OMOP:45883458"),({phv00020927} == 1, "OMOP:40766945"), (True, None))'
+            "OMOP:45883459"),({phv00020927} == 1, "OMOP:45883458"), (True, None))'
 - class_derivations:
     Observation:
       populated_from: pht000395
@@ -361,8 +361,8 @@
           populated_from: phv00056589
           value_mappings:
             '0': OMOP:45883537
-            '1': OMOP:40766945
-            '2': OMOP:45883458
+            '1': OMOP:45883458
+            '2': OMOP:45883459
 - class_derivations:
     Observation:
       populated_from: pht000397
@@ -380,8 +380,8 @@
           populated_from: phv00056725
           value_mappings:
             '0': OMOP:45883537
-            '1': OMOP:40766945
-            '2': OMOP:45883458
+            '1': OMOP:45883458
+            '2': OMOP:45883459
 - class_derivations:
     Observation:
       populated_from: pht006026
@@ -399,7 +399,7 @@
           populated_from: phv00277032
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht006026
@@ -417,7 +417,7 @@
           populated_from: phv00277033
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht009761
@@ -435,7 +435,7 @@
           populated_from: phv00423898
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht009761
@@ -453,7 +453,7 @@
           populated_from: phv00423899
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht009761
@@ -471,7 +471,7 @@
           populated_from: phv00423900
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht009761
@@ -489,7 +489,7 @@
           populated_from: phv00423901
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht006026
@@ -507,7 +507,7 @@
           populated_from: phv00277032
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht006026
@@ -525,7 +525,7 @@
           populated_from: phv00277033
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht006026
@@ -543,7 +543,7 @@
           populated_from: phv00369811
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -561,7 +561,7 @@
           populated_from: phv00369812
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -579,7 +579,7 @@
           populated_from: phv00369813
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -597,7 +597,7 @@
           populated_from: phv00544779
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht009761
@@ -615,7 +615,7 @@
           populated_from: phv00369814
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -633,7 +633,7 @@
           populated_from: phv00369815
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -651,7 +651,7 @@
           populated_from: phv00369816
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -669,7 +669,7 @@
           populated_from: phv00369809
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -687,7 +687,7 @@
           populated_from: phv00369810
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -705,7 +705,7 @@
           populated_from: phv00369811
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -723,7 +723,7 @@
           populated_from: phv00369812
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -741,7 +741,7 @@
           populated_from: phv00369813
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -759,7 +759,7 @@
           populated_from: phv00369814
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -777,7 +777,7 @@
           populated_from: phv00369815
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -795,7 +795,7 @@
           populated_from: phv00369816
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -813,7 +813,7 @@
           populated_from: phv00369817
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -831,7 +831,7 @@
           populated_from: phv00369818
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -849,7 +849,7 @@
           populated_from: phv00369819
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -867,7 +867,7 @@
           populated_from: phv00369820
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -885,7 +885,7 @@
           populated_from: phv00369821
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -903,7 +903,7 @@
           populated_from: phv00369822
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -921,7 +921,7 @@
           populated_from: phv00369823
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -939,7 +939,7 @@
           populated_from: phv00369824
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -957,7 +957,7 @@
           populated_from: phv00369825
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -975,7 +975,7 @@
           populated_from: phv00369826
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -993,7 +993,7 @@
           populated_from: phv00369827
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1011,7 +1011,7 @@
           populated_from: phv00369828
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1029,7 +1029,7 @@
           populated_from: phv00369829
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1047,7 +1047,7 @@
           populated_from: phv00369830
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1065,7 +1065,7 @@
           populated_from: phv00369831
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1083,7 +1083,7 @@
           populated_from: phv00369832
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1101,7 +1101,7 @@
           populated_from: phv00369833
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1119,7 +1119,7 @@
           populated_from: phv00369834
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1137,7 +1137,7 @@
           populated_from: phv00369835
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1155,7 +1155,7 @@
           populated_from: phv00369836
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1173,7 +1173,7 @@
           populated_from: phv00369837
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458
 - class_derivations:
     Observation:
       populated_from: pht007777
@@ -1191,4 +1191,4 @@
           populated_from: phv00369838
           value_mappings:
             '0': None
-            '1': OMOP:40766945
+            '1': OMOP:45883458

--- a/priority_variables_transform/FHS-ingest/visit.yaml
+++ b/priority_variables_transform/FHS-ingest/visit.yaml
@@ -17,13 +17,13 @@
           expr: '{phv00177930} * 365'
         age_at_visit_end:
           expr: '{phv00177930} * 365'
-        visit_category:
-          populated_from: pht004813.phv00565431
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht004813.phv00565431
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -40,14 +40,14 @@
           expr: '{phv00177932} * 365'
         age_at_visit_end:
           expr: '{phv00177932} * 365'
-        visit_category:
-          populated_from: pht004814.phv00251057
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht004814.phv00251057
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -64,14 +64,14 @@
           expr: '{phv00177934} * 365'
         age_at_visit_end:
           expr: '{phv00177934} * 365'
-        visit_category:
-          populated_from: pht004815.phv00251531
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht004815.phv00251531
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -86,14 +86,14 @@
           expr: '{phv00177936} * 365'
         age_at_visit_end:
           expr: '{phv00177936} * 365'
-        visit_category:
-          populated_from: pht005140.phv00254283
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht005140.phv00254283
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -108,15 +108,15 @@
           expr: '{phv00177938} * 365'
         age_at_visit_end:
           expr: '{phv00177938} * 365'
-        visit_category:
-          populated_from: pht015104.phv00545435
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': TELEHEALTH
-            '8': OUTPATIENT
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht015104.phv00545435
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': TELEHEALTH
+        #   '8': OUTPATIENT
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -173,14 +173,14 @@
           expr: '{phv00177946} * 365'
         age_at_visit_end:
           expr: '{phv00177946} * 365'
-        visit_category:
-          populated_from: pht005140.phv00254283
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht005140.phv00254283
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -195,15 +195,15 @@
           expr: '{phv00177948} * 365'
         age_at_visit_end:
           expr: '{phv00177948} * 365'
-        visit_category:
-          populated_from: pht015104.phv00545435
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': TELEHEALTH
-            '8': OUTPATIENT
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht015104.phv00545435
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': TELEHEALTH
+        #   '8': OUTPATIENT
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -470,14 +470,14 @@
           expr: '{phv00226999} * 365'
         age_at_visit_end:
           expr: '{phv00226999} * 365'
-        visit_category:
-          populated_from: pht005141.phv00254761
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht005141.phv00254761
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -492,14 +492,14 @@
           expr: '{phv00227002} * 365'
         age_at_visit_end:
           expr: '{phv00227002} * 365'
-        visit_category:
-          populated_from: pht005142.phv00255154
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht005142.phv00255154
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -514,14 +514,14 @@
           expr: '{phv00227005} * 365'
         age_at_visit_end:
           expr: '{phv00227005} * 365'
-        visit_category:
-          populated_from: pht006007.phv00274879
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht006007.phv00274879
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht003099
@@ -536,14 +536,14 @@
           expr: '{phv00227008} * 365'
         age_at_visit_end:
           expr: '{phv00227008} * 365'
-        visit_category:
-          populated_from: pht006008.phv00275237
-          value_mappings:
-            '0': OUTPATIENT
-            '1': NON_HOSPITAL_INSTITUTION
-            '2': HOME
-            '3': NON_HOSPITAL_INSTITUTION
-            '.': UNKNOWN
+        # visit_category: commented out - cross-table populated_from not supported by pipeline
+        #   populated_from: pht006008.phv00275237
+        #   value_mappings:
+        #   '0': OUTPATIENT
+        #   '1': NON_HOSPITAL_INSTITUTION
+        #   '2': HOME
+        #   '3': NON_HOSPITAL_INSTITUTION
+        #   '.': UNKNOWN
 - class_derivations:
     Visit:
       populated_from: pht000395


### PR DESCRIPTION
## Summary

Fixes two FHS pipeline issues in `priority_variables_transform/FHS-ingest/`:

1. **cig_smok.yaml** — OMOP smoking status concept codes were **transposed** across all 33 mapping blocks, causing former smokers to be coded as current smokers and vice versa
2. **visit.yaml** — 11 `visit_category` blocks use cross-table `populated_from` references that the current LinkML-Mapper does not support, breaking pipeline processing

Closes #498

---

## Fix 1: Smoking OMOP Code Transposition (cig_smok.yaml)

### Defect

All smoking status mapping blocks in `cig_smok.yaml` had OMOP concept codes assigned to the **wrong semantic positions**:

| Source Meaning | Was (Wrong) | Now (Correct) | OMOP Concept Name |
|---|---|---|---|
| **Former smoker** | `OMOP:45883458` | `OMOP:45883459` | Former smoker |
| **Current smoker** | `OMOP:40766945` | `OMOP:45883458` | Current every day smoker |
| **Never smoked** | `OMOP:45883537` | `OMOP:45883537` | Never smoker *(unchanged)* |

### How the defect was identified

During a BDC-vs-TOPMed DCC comparison of FHS harmonized output, smoking status distributions showed anomalies: 2,059 participants labeled 'Current Smoker' and 4,542 labeled 'Unknown', which was epidemiologically implausible for a study where explicit current/former/never categories exist.

### Root cause verification

The transposition was confirmed by tracing from dbGaP source variable semantics through to the YAML mapping output:

- **phv00020927** (CURRSMK, *'Do you NOW smoke cigarettes?'*): coded `1` = Yes (current smoker), `0` = No. The YAML mapped `0` (not currently smoking → former) to `OMOP:45883458` which is actually *'Current every day smoker'*, and `1` (currently smoking) to `OMOP:40766945` which is actually *'Smoker, current status unknown'*
- **phv00056589** (CURSMK01): explicitly coded `0` = Never, `1` = Current, `2` = Former. The YAML mapped code `1` (Current) to `OMOP:40766945` (Unknown) and code `2` (Former) to `OMOP:45883458` (Current)
- **Cross-cohort validation**: WHI's `cig_smok.yaml` correctly maps `CURRSMK=1` → `OMOP:45883458` (Current every day smoker). FHS had the same semantic value mapped to `OMOP:40766945` (Unknown), confirming FHS was the outlier

### OMOP code reference

Correct OMOP concept IDs verified via [OHDSI Athena](https://athena.ohdsi.org/):
- [OMOP:45883458](https://athena.ohdsi.org/search-terms/terms/45883458) = *Current every day smoker* (SNOMED 449868002)
- [OMOP:45883459](https://athena.ohdsi.org/search-terms/terms/45883459) = *Former smoker* (SNOMED 8517006)
- [OMOP:45883537](https://athena.ohdsi.org/search-terms/terms/45883537) = *Never smoker* (SNOMED 266919005)
- [OMOP:40766945](https://athena.ohdsi.org/search-terms/terms/40766945) = *Smoker, current status unknown* (SNOMED 266927001)

### Changes

- **81 total OMOP code replacements** across 33 mapping blocks:
  - 12 instances: `OMOP:45883458` → `OMOP:45883459` (Former smoker position)
  - 69 instances: `OMOP:40766945` → `OMOP:45883458` (Current smoker position)
- **This is a semantic correctness defect**, not a TOPMed alignment change. A participant who reports *'No, I do not currently smoke'* was being coded as *'Current every day smoker'* — objectively wrong regardless of any external comparison

---

## Fix 2: Cross-Table visit_category Workaround (visit.yaml)

### Defect

11 `visit_category` slot derivations in `visit.yaml` use cross-table `populated_from` references (e.g., `pht004813.phv00565431`). The current version of LinkML-Mapper does not support cross-table joins. While some cross-table references fail gracefully, these particular blocks cause the pipeline to crash during FHS data processing.

### Fix

All 11 cross-table `visit_category` blocks are **commented out** with an explanatory note. The original mapping logic is preserved in the comments so it can be re-enabled when pipeline support for cross-table references is added.

This matches the approach from commit `da48b152` on the test integration branch.

### Affected visit blocks

| Visit | Cross-table reference |
|---|---|
| Exam 1 | `pht004813.phv00565431` |
| Exam 2 | `pht004814.phv00251057` |
| Exam 3 | `pht004815.phv00251531` |
| Exam 4 | `pht005140.phv00254283` |
| Exam 5 | `pht015104.phv00545435` |
| Exam 9 | `pht005140.phv00254283` |
| Exam 10 | `pht015104.phv00545435` |
| Exam 29 | `pht005141.phv00254761` |
| Exam 30 | `pht005142.phv00255154` |
| Exam 31 | `pht006007.phv00274879` |
| Exam 32 | `pht006008.phv00275237` |

---

## Testing

- Post-fix OMOP code inventory verified: 69x Current (45883458), 12x Former (45883459), 11x Never (45883537), 0x Unknown (40766945)
- Zero uncommented cross-table `populated_from` references remain in visit.yaml
- Pipeline re-run in BDC enclave pending