### PR TITLE
Revert accidental direct pushes to main

### DIFF
--- a/priority_variables_transform/FHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/creat_bld.yaml
@@ -577,12 +577,12 @@
                     range: string
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht009761
+      populated_from: pht000039
       slot_derivations:
         associated_participant:
-          populated_from: phv00423868
+          populated_from: phv00010777
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 5''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 5''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010777}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -590,7 +590,29 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423895
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:2050096
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544772
@@ -604,7 +626,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 6''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 6''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -612,7 +634,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544773
@@ -626,7 +648,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 7''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 7''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -634,7 +656,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544774
@@ -648,7 +670,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 8''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 8''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -656,7 +678,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544775
@@ -670,7 +692,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 9''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:2050096
           range: string
@@ -678,7 +700,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544776

--- a/priority_variables_transform/FHS-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/fast_gluc_bld.yaml
@@ -72,23 +72,64 @@
                     range: string
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht009761
+      populated_from: pht000039
       slot_derivations:
         associated_participant:
-          populated_from: phv00423868
+          populated_from: phv00010767
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 5''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 5''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010767}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
-          range: string
-        method_type:
-          value: 'fasting >= 8 hours'
           range: string
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423912
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4156660
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423913
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4156660
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544804
@@ -102,18 +143,15 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 6''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 6''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
-          range: string
-        method_type:
-          value: 'fasting >= 8 hours'
           range: string
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544805
@@ -127,18 +165,15 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 7''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 7''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
-          range: string
-        method_type:
-          value: 'fasting >= 8 hours'
           range: string
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544806
@@ -152,18 +187,15 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 8''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 8''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
-          range: string
-        method_type:
-          value: 'fasting >= 8 hours'
           range: string
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544807
@@ -177,18 +209,15 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 9''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4156660
-          range: string
-        method_type:
-          value: 'fasting >= 8 hours'
           range: string
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544808

--- a/priority_variables_transform/FHS-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/glucose_bld.yaml
@@ -1150,12 +1150,12 @@
                     range: string
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht009761
+      populated_from: pht000039
       slot_derivations:
         associated_participant:
-          populated_from: phv00423868
+          populated_from: phv00010767
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 5''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 5''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010767}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1163,7 +1163,95 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423879
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000188
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423880
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000188
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423881
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000188
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423882
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000188
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544748
@@ -1177,7 +1265,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 6''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 6''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1185,7 +1273,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544749
@@ -1199,7 +1287,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 7''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 7''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1207,7 +1295,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544750
@@ -1221,7 +1309,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 8''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 8''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1229,7 +1317,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544751
@@ -1243,7 +1331,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 9''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000188
           range: string
@@ -1251,7 +1339,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544752

--- a/priority_variables_transform/FHS-ingest/hdl.yaml
+++ b/priority_variables_transform/FHS-ingest/hdl.yaml
@@ -718,12 +718,12 @@
                     range: string
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht009761
+      populated_from: pht000039
       slot_derivations:
         associated_participant:
-          populated_from: phv00423868
+          populated_from: phv00010767
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 5''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 5''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010767}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -734,7 +734,107 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423914
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4041720
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423915
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4041720
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423916
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4041720
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423917
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4041720
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544810
@@ -748,7 +848,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 6''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 6''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -759,7 +859,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544811
@@ -773,7 +873,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 7''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 7''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -784,7 +884,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544812
@@ -798,7 +898,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 8''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 8''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -809,7 +909,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544813
@@ -823,7 +923,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 9''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OMOP:4041720
           range: string
@@ -834,7 +934,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544814
@@ -1459,6 +1559,56 @@
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00277041
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht000039
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00010767
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010767}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4041720
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423914
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OMOP:4041720
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423915
                   unit:
                     value: mg/dL
                     range: string

--- a/priority_variables_transform/FHS-ingest/ldl.yaml
+++ b/priority_variables_transform/FHS-ingest/ldl.yaml
@@ -270,12 +270,12 @@
                     range: string
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht009761
+      populated_from: pht000039
       slot_derivations:
         associated_participant:
-          populated_from: phv00423868
+          populated_from: phv00010767
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 5''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 5''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010767}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -286,7 +286,107 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423887
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000181
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs - calculated value
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423888
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000181
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs - calculated value
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423889
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000181
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs - calculated value
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00423890
+                  unit:
+                    value: mg/dL
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht009761
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00423868
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
+        observation_type:
+          value: OBA:VT0000181
+          range: string
+        method_type:
+          value: fasted for minimum 12 hrs - calculated value
+          range: string          
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544760
@@ -300,7 +400,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 6''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 6''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -311,7 +411,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544761
@@ -325,7 +425,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 7''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 7''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -336,7 +436,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544762
@@ -350,7 +450,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 8''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 8''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -361,7 +461,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544763
@@ -375,7 +475,7 @@
         associated_participant:
           populated_from: phv00423868
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 9''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         observation_type:
           value: OBA:VT0000181
           range: string
@@ -386,7 +486,7 @@
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544764

--- a/priority_variables_transform/FHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/tot_chol_bld.yaml
@@ -668,20 +668,86 @@
 #                     populated_from: phv00520306
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht009761
+      populated_from: pht000039
       slot_derivations:
         observation_type:
           value: OBA:VT0000180
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 9''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010767}) + ":UNKNOWN")'
         associated_participant:
-          populated_from: phv00423868
+          populated_from: phv00010767
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370069
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370063
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370064
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00544854
@@ -696,17 +762,105 @@
           value: OBA:VT0000180
           range: string
         associated_visit:
-          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":" + case(({phv00423869} == ''1'', ''FHS OFFSPRING EXAM 5''), ({phv00423869} == ''7'', ''FHS OMNI 1 EXAM 5''), (True, ''FHS UNKNOWN VISIT'')))'
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":UNKNOWN")'
         associated_participant:
           populated_from: phv00423868
         value_quantity:
           object_derivations:
           - class_derivations:
               Quantity:
-                populated_from: pht009761
+                populated_from: pht000039
                 slot_derivations:
                   value_decimal:
-                    populated_from: phv00544850
+                    populated_from: phv00370067
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370068
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370066
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370065
+                  unit:
+                    value: mg/dl
+                    range: string
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht007777
+      slot_derivations:
+        observation_type:
+          value: OBA:VT0000180
+          range: string
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369652}) + ":UNKNOWN")'
+        associated_participant:
+          populated_from: phv00369652
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht000039
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00370070
                   unit:
                     value: mg/dl
                     range: string


### PR DESCRIPTION
## Summary

- Reverts feature branch content (`feature/478-fhs-resolve-unknown-visits`) that was accidentally pushed directly to main via two merge commits (`a01b5369`, `1a8c137c`)
- Only reverts the 6 FHS file changes from those merges — legitimate PR #486 and #490 content is preserved
- The feature branch work can be re-submitted as a proper PR after this merges

## Files reverted (6 FHS-ingest files)
- `creat_bld.yaml`
- `fast_gluc_bld.yaml`
- `glucose_bld.yaml`
- `hdl.yaml`
- `ldl.yaml`
- `tot_chol_bld.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)