### PR TITLE
fix(WHI): Resolve CHR-blocking errors, semantic issues, and visit label fragmentation

### DIFF
--- a/priority_variables_transform/WHI-ingest/afib.yaml
+++ b/priority_variables_transform/WHI-ingest/afib.yaml
@@ -140,7 +140,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
         condition_concept:
           value: MONDO:0004981
         condition_status:

--- a/priority_variables_transform/WHI-ingest/alcohol_servings.yaml
+++ b/priority_variables_transform/WHI-ingest/alcohol_servings.yaml
@@ -50,7 +50,7 @@
         associated_participant:
           populated_from: phv00156379
         associated_visit:
-          value: WHI FG 60 2
+          value: WHI YEAR 3
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/WHI-ingest/bdy_hgt.yaml
@@ -53,7 +53,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/WHI-ingest/bdy_wgt.yaml
@@ -187,7 +187,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/bmi.yaml
+++ b/priority_variables_transform/WHI-ingest/bmi.yaml
@@ -1,27 +1,5 @@
 - class_derivations:
     MeasurementObservation:
-      populated_from: pht006217
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00283284
-        associated_visit:
-          value: WHI LONG LIFE STUDY
-        # age_at_observation:
-          # expr: "{nan} * 365"
-        observation_type:
-          value: OBA:2045455
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht006217
-                slot_derivations:
-                  value_decimal:
-                    populated_from: phv00283344
-                  unit:
-                    value: "kg/m2"
-- class_derivations:
-    MeasurementObservation:
       populated_from: pht001019
       slot_derivations:
         associated_participant:

--- a/priority_variables_transform/WHI-ingest/bmi.yaml
+++ b/priority_variables_transform/WHI-ingest/bmi.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/bp_diastolic.yaml
+++ b/priority_variables_transform/WHI-ingest/bp_diastolic.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
@@ -49,7 +49,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/bp_systolic.yaml
+++ b/priority_variables_transform/WHI-ingest/bp_systolic.yaml
@@ -27,7 +27,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
@@ -49,7 +49,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/cause_of_death.yaml
+++ b/priority_variables_transform/WHI-ingest/cause_of_death.yaml
@@ -64,7 +64,7 @@
                 populated_from: pht003409
                 slot_derivations:
                   cause:
-                    populated_from: phv00193497
+                    populated_from: phv00193532
                     value_mappings:
                       '1': ICD10CM:C50
                       '31': ICD10CM:G30

--- a/priority_variables_transform/WHI-ingest/cause_of_death.yaml
+++ b/priority_variables_transform/WHI-ingest/cause_of_death.yaml
@@ -2,11 +2,6 @@
     Person:
       populated_from: pht003402
       slot_derivations:
-        associated_participant:
-          populated_from: phv00192476
-        associated_visit:
-          value: WHI CAD
-          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -35,11 +30,6 @@
     Person:
       populated_from: pht003407
       slot_derivations:
-        associated_participant:
-          populated_from: phv00193141
-        associated_visit:
-          value: WHI OUTCOMES - CLINICAL TRIALS + OBSERVATIONAL STUDY ADJUDICATED
-          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -67,11 +57,6 @@
     Person:
       populated_from: pht003409
       slot_derivations:
-        associated_participant:
-          populated_from: phv00193529
-        associated_visit:
-          value: WHI OUTCOMES - CLINICAL TRIALS + OBSERVATIONAL STUDY ADJUDICATED
-          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -99,11 +84,6 @@
     Person:
       populated_from: pht003415
       slot_derivations:
-        associated_participant:
-          populated_from: phv00193798
-        associated_visit:
-          value: WHI SCAD
-          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -120,11 +100,6 @@
     Person:
       populated_from: pht003416
       slot_derivations:
-        associated_participant:
-          populated_from: phv00193819
-        associated_visit:
-          value: WHI SCAD 4
-          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -141,11 +116,6 @@
     Person:
       populated_from: pht006220
       slot_derivations:
-        associated_participant:
-          populated_from: phv00283412
-        associated_visit:
-          value: WHI OUTCOMES - CLINICAL TRIALS + OBSERVATIONAL STUDY ADJUDICATED
-          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -173,11 +143,6 @@
     Person:
       populated_from: pht006212
       slot_derivations:
-        associated_participant:
-          populated_from: phv00282951
-        associated_visit:
-          value: WHI CAD MED
-          range: string
         vital_status:
           populated_from: phv00282963
           value_mappings:
@@ -187,11 +152,6 @@
     Person:
       populated_from: pht006213
       slot_derivations:
-        associated_participant:
-          populated_from: phv00282964
-        associated_visit:
-          value: WHI HRT MED
-          range: string
         vital_status:
           populated_from: phv00282974
           value_mappings:

--- a/priority_variables_transform/WHI-ingest/cause_of_death.yaml
+++ b/priority_variables_transform/WHI-ingest/cause_of_death.yaml
@@ -2,6 +2,11 @@
     Person:
       populated_from: pht003402
       slot_derivations:
+        associated_participant:
+          populated_from: phv00192476
+        associated_visit:
+          value: WHI CAD
+          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -30,6 +35,11 @@
     Person:
       populated_from: pht003407
       slot_derivations:
+        associated_participant:
+          populated_from: phv00193141
+        associated_visit:
+          value: WHI OUTCOMES - CLINICAL TRIALS + OBSERVATIONAL STUDY ADJUDICATED
+          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -57,6 +67,11 @@
     Person:
       populated_from: pht003409
       slot_derivations:
+        associated_participant:
+          populated_from: phv00193529
+        associated_visit:
+          value: WHI OUTCOMES - CLINICAL TRIALS + OBSERVATIONAL STUDY ADJUDICATED
+          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -84,6 +99,11 @@
     Person:
       populated_from: pht003415
       slot_derivations:
+        associated_participant:
+          populated_from: phv00193798
+        associated_visit:
+          value: WHI SCAD
+          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -100,6 +120,11 @@
     Person:
       populated_from: pht003416
       slot_derivations:
+        associated_participant:
+          populated_from: phv00193819
+        associated_visit:
+          value: WHI SCAD 4
+          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -116,6 +141,11 @@
     Person:
       populated_from: pht006220
       slot_derivations:
+        associated_participant:
+          populated_from: phv00283412
+        associated_visit:
+          value: WHI OUTCOMES - CLINICAL TRIALS + OBSERVATIONAL STUDY ADJUDICATED
+          range: string
         cause_of_death:
           object_derivations:
           - class_derivations:
@@ -143,6 +173,11 @@
     Person:
       populated_from: pht006212
       slot_derivations:
+        associated_participant:
+          populated_from: phv00282951
+        associated_visit:
+          value: WHI CAD MED
+          range: string
         vital_status:
           populated_from: phv00282963
           value_mappings:
@@ -152,6 +187,11 @@
     Person:
       populated_from: pht006213
       slot_derivations:
+        associated_participant:
+          populated_from: phv00282964
+        associated_visit:
+          value: WHI HRT MED
+          range: string
         vital_status:
           populated_from: phv00282974
           value_mappings:

--- a/priority_variables_transform/WHI-ingest/cig_smok.yaml
+++ b/priority_variables_transform/WHI-ingest/cig_smok.yaml
@@ -14,5 +14,5 @@
           populated_from: phv00078825
           value_mappings:
             '0': OMOP:45883537
-            '1': OMOP:45883459
-            '2': OMOP:45883458
+            '1': OMOP:45883458
+            '2': OMOP:40766945

--- a/priority_variables_transform/WHI-ingest/demography.yaml
+++ b/priority_variables_transform/WHI-ingest/demography.yaml
@@ -28,7 +28,7 @@
         associated_participant:
           populated_from: phv00079312
         associated_visit:
-          value: WHI PI 41
+          value: WHI SCREENING
         sex:
           value: OMOP:8532
         ethnicity:

--- a/priority_variables_transform/WHI-ingest/diabetes.yaml
+++ b/priority_variables_transform/WHI-ingest/diabetes.yaml
@@ -4,8 +4,6 @@
       slot_derivations:
         associated_participant:
           populated_from: phv00078435
-        age_at_condition_start:
-          expr: case((phv00078464 == 1, {phv00078465} * 365))
         associated_visit:
           value: WHI SCREENING
           range: string

--- a/priority_variables_transform/WHI-ingest/factor_7.yaml
+++ b/priority_variables_transform/WHI-ingest/factor_7.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
@@ -27,7 +27,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/fibrin.yaml
+++ b/priority_variables_transform/WHI-ingest/fibrin.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/WHI-ingest/fruit_serving.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00111654
         associated_visit:
-          value: WHI FG 60 1
+          value: WHI SCREENING
           range: string
         observation_type:
           value: OMOP:21493059
@@ -28,7 +28,7 @@
         associated_participant:
           populated_from: phv00156379
         associated_visit:
-          value: WHI FG 60 2
+          value: WHI YEAR 3
           range: string
         observation_type:
           value: OMOP:21493059
@@ -51,7 +51,7 @@
         associated_participant:
           populated_from: phv00283348
         associated_visit:
-          value: WHI BASELINE
+          value: WHI SCREENING
           range: string
         observation_type:
           value: OMOP:21493059

--- a/priority_variables_transform/WHI-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/glucose_bld.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hdl.yaml
+++ b/priority_variables_transform/WHI-ingest/hdl.yaml
@@ -5,11 +5,11 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
-          value: OBA:VT0000184
+          value: LOINC:18363-4
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -27,11 +27,11 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
-          value: OBA:VT0000184
+          value: LOINC:18362-6
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -49,7 +49,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hdl.yaml
+++ b/priority_variables_transform/WHI-ingest/hdl.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
@@ -27,7 +27,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
@@ -49,7 +49,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hdl.yaml
+++ b/priority_variables_transform/WHI-ingest/hdl.yaml
@@ -9,7 +9,7 @@
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
-          value: LOINC:18363-4
+          value: OBA:VT0000184
         value_quantity:
           object_derivations:
           - class_derivations:
@@ -31,7 +31,7 @@
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
-          value: LOINC:18362-6
+          value: OBA:VT0000184
         value_quantity:
           object_derivations:
           - class_derivations:

--- a/priority_variables_transform/WHI-ingest/hdl.yaml
+++ b/priority_variables_transform/WHI-ingest/hdl.yaml
@@ -17,50 +17,6 @@
                 populated_from: pht000987
                 slot_derivations:
                   value_decimal:
-                    populated_from: phv00077387
-                  unit:
-                    value: "mg/dL"
-- class_derivations:
-    MeasurementObservation:
-      populated_from: pht000987
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00077369
-        associated_visit:
-          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
-        # age_at_observation:
-          # expr: "{nan} * 365"
-        observation_type:
-          value: OBA:VT0000184
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht000987
-                slot_derivations:
-                  value_decimal:
-                    populated_from: phv00077386
-                  unit:
-                    value: "mg/dL"
-- class_derivations:
-    MeasurementObservation:
-      populated_from: pht000987
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00077369
-        associated_visit:
-          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
-        # age_at_observation:
-          # expr: "{nan} * 365"
-        observation_type:
-          value: OBA:VT0000184
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht000987
-                slot_derivations:
-                  value_decimal:
                     populated_from: phv00077388
                   unit:
                     value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/hemat.yaml
+++ b/priority_variables_transform/WHI-ingest/hemat.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077360
         associated_visit:
-          value: WHI CBC
+          expr: "case(({phv00077361} == 1, 'WHI SCREENING'), ({phv00077361} == 3 and {phv00077362} == 1, 'WHI YEAR 1'), ({phv00077361} == 3 and {phv00077362} == 2, 'WHI YEAR 2'), ({phv00077361} == 3 and {phv00077362} == 3, 'WHI YEAR 3'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hemo.yaml
+++ b/priority_variables_transform/WHI-ingest/hemo.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077360
         associated_visit:
-          value: WHI CBC
+          expr: "case(({phv00077361} == 1, 'WHI SCREENING'), ({phv00077361} == 3 and {phv00077362} == 1, 'WHI YEAR 1'), ({phv00077361} == 3 and {phv00077362} == 2, 'WHI YEAR 2'), ({phv00077361} == 3 and {phv00077362} == 3, 'WHI YEAR 3'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hip_circ.yaml
+++ b/priority_variables_transform/WHI-ingest/hip_circ.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hist_cor_angio.yaml
+++ b/priority_variables_transform/WHI-ingest/hist_cor_angio.yaml
@@ -12,18 +12,6 @@
           value: PATIENT_SELF-REPORTED_CONDITION
 - class_derivations:
     Procedure:
-      populated_from: pht000999
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00078506
-        associated_visit:
-          value: WHI SCREENING
-        procedure_concept:
-          expr: case(({phv00078537} == 1, "OMOP:1242799"))
-        procedure_provenance:
-          value: PATIENT_SELF-REPORTED_CONDITION
-- class_derivations:
-    Procedure:
       populated_from: pht003407
       slot_derivations:
         associated_participant:

--- a/priority_variables_transform/WHI-ingest/hist_hrtfail.yaml
+++ b/priority_variables_transform/WHI-ingest/hist_hrtfail.yaml
@@ -214,7 +214,7 @@
         associated_participant:
           populated_from: phv00170648
         associated_visit:
-          value: WHI CTOS
+          value: WHI SCREENING
           range: string
         condition_concept:
           value: MONDO:0005009

--- a/priority_variables_transform/WHI-ingest/hrtrt.yaml
+++ b/priority_variables_transform/WHI-ingest/hrtrt.yaml
@@ -27,7 +27,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/WHI-ingest/hypert_trt.yaml
@@ -33,7 +33,7 @@
         associated_participant:
           populated_from: phv00170648
         associated_visit:
-          value: WHI CTOS
+          value: WHI SCREENING
           range: string
         drug_concept:
           expr: 'case(({phv00170689} == 1, "ATC:C02"))'

--- a/priority_variables_transform/WHI-ingest/hyperten.yaml
+++ b/priority_variables_transform/WHI-ingest/hyperten.yaml
@@ -31,7 +31,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         condition_concept:
-          value: MONDO:0005149
+          value: MONDO:0002619
           range: string
         condition_status:
           populated_from: phv00283528
@@ -101,7 +101,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         condition_concept:
-          value: MONDO:0005149
+          value: MONDO:0002619
           range: string
         condition_status:
           populated_from: phv00283592

--- a/priority_variables_transform/WHI-ingest/hyperten.yaml
+++ b/priority_variables_transform/WHI-ingest/hyperten.yaml
@@ -31,7 +31,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         condition_concept:
-          value: MONDO:0002619
+          value: MONDO:0005149
           range: string
         condition_status:
           populated_from: phv00283528
@@ -101,7 +101,7 @@
           value: WHI UNC HEART FAILURE DETAILS
           range: string
         condition_concept:
-          value: MONDO:0002619
+          value: MONDO:0005149
           range: string
         condition_status:
           populated_from: phv00283592

--- a/priority_variables_transform/WHI-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/WHI-ingest/insulin_blood.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/ldl.yaml
+++ b/priority_variables_transform/WHI-ingest/ldl.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/lvh_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/lvh_ekg.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
           range: string
         condition_concept:
           value: HP:0001712

--- a/priority_variables_transform/WHI-ingest/pacem_stat.yaml
+++ b/priority_variables_transform/WHI-ingest/pacem_stat.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
           range: string
         procedure_concept:
           expr: case(({phv00155223} == 1, "OMOP:45772840"))

--- a/priority_variables_transform/WHI-ingest/pacem_stat.yaml
+++ b/priority_variables_transform/WHI-ingest/pacem_stat.yaml
@@ -13,19 +13,6 @@
           expr: case(({phv00155223} == 1, "OMOP:4822157"))
 - class_derivations:
     Procedure:
-      populated_from: pht002118
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00154925
-        associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
-          range: string
-        procedure_concept:
-          expr: case(({phv00193137} == 1, "OMOP:4323629"))
-        procedure_provenance:
-          expr: case(({phv00193137} == 1, "OMOP:4822157"))
-- class_derivations:
-    Procedure:
       populated_from: pht006223
       slot_derivations:
         associated_participant:

--- a/priority_variables_transform/WHI-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/WHI-ingest/platelet_ct.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077360
         associated_visit:
-          value: WHI CBC
+          expr: "case(({phv00077361} == 1, 'WHI SCREENING'), ({phv00077361} == 3 and {phv00077362} == 1, 'WHI YEAR 1'), ({phv00077361} == 3 and {phv00077362} == 2, 'WHI YEAR 2'), ({phv00077361} == 3 and {phv00077362} == 3, 'WHI YEAR 3'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/pr_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/pr_ekg.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/qrs_ekg.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/qt_ekg.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00154925
         associated_visit:
-          value: WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP
+          expr: "case(({phv00154926} == 1, 'WHI SCREENING'), ({phv00154926} == 2 and {phv00154927} == 1, 'WHI SEMI-ANNUAL VISIT YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 1, 'WHI YEAR 1'), ({phv00154926} == 3 and {phv00154927} == 2, 'WHI YEAR 2'), ({phv00154926} == 3 and {phv00154927} == 3, 'WHI YEAR 3'), ({phv00154926} == 3 and {phv00154927} == 4, 'WHI YEAR 4'), ({phv00154926} == 3 and {phv00154927} == 5, 'WHI YEAR 5'), ({phv00154926} == 3 and {phv00154927} == 6, 'WHI YEAR 6'), ({phv00154926} == 3 and {phv00154927} == 7, 'WHI YEAR 7'), ({phv00154926} == 3 and {phv00154927} == 8, 'WHI YEAR 8'), ({phv00154926} == 3 and {phv00154927} == 9, 'WHI YEAR 9'), ({phv00154926} == 3 and {phv00154927} == 10, 'WHI YEAR 10'), ({phv00154926} == 3 and {phv00154927} == 11, 'WHI YEAR 11'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/WHI-ingest/sleep_duration_daily.yaml
@@ -93,7 +93,7 @@
         associated_participant:
           populated_from: phv00079085
         associated_visit:
-          value: WHI DL 38
+          value: WHI SCREENING
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:
@@ -115,7 +115,7 @@
         associated_participant:
           populated_from: phv00078867
         associated_visit:
-          value: WHI TF 37
+          value: WHI SCREENING
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/WHI-ingest/sodium_intak.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00156379
         associated_visit:
-          value: WHI FG 60 2
+          value: WHI YEAR 3
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/WHI-ingest/tak_insulin.yaml
@@ -33,7 +33,7 @@
         associated_participant:
           populated_from: phv00170648
         associated_visit:
-          value: WHI CTOS
+          value: WHI SCREENING
           range: string
         drug_concept:
           expr: 'case(({phv00170683} == 1, "MeSH:D007328"))'

--- a/priority_variables_transform/WHI-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/tot_chol_bld.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/triglyc_bld.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077369
         associated_visit:
-          value: WHI CORE
+          expr: "case(({phv00077370} == 1, 'WHI SCREENING'), ({phv00077370} == 3 and {phv00077371} == 1, 'WHI YEAR 1'), ({phv00077370} == 3 and {phv00077371} == 2, 'WHI YEAR 2'), ({phv00077370} == 3 and {phv00077371} == 3, 'WHI YEAR 3'), ({phv00077370} == 3 and {phv00077371} == 4, 'WHI YEAR 4'), ({phv00077370} == 3 and {phv00077371} == 5, 'WHI YEAR 5'), ({phv00077370} == 3 and {phv00077371} == 6, 'WHI YEAR 6'), ({phv00077370} == 4, 'WHI NON-ROUTINE'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/vege_serving.yaml
+++ b/priority_variables_transform/WHI-ingest/vege_serving.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00111654
         associated_visit:
-          value: WHI FG 60 1
+          value: WHI SCREENING
           range: string
         observation_type:
           value: OMOP:4042886
@@ -28,7 +28,7 @@
         associated_participant:
           populated_from: phv00283348
         associated_visit:
-          value: WHI BASELINE
+          value: WHI SCREENING
           range: string
         observation_type:
           value: OMOP:4042886

--- a/priority_variables_transform/WHI-ingest/ven_thromb.yaml
+++ b/priority_variables_transform/WHI-ingest/ven_thromb.yaml
@@ -77,7 +77,7 @@
         associated_participant:
           populated_from: phv00170648
         associated_visit:
-          value: WHI CTOS
+          value: WHI SCREENING
         condition_concept:
           value: HP:0002625
         condition_status:
@@ -96,7 +96,7 @@
         associated_participant:
           populated_from: phv00170648
         associated_visit:
-          value: WHI CTOS
+          value: WHI SCREENING
         condition_concept:
           value: MONDO:0005279
         condition_status:

--- a/priority_variables_transform/WHI-ingest/waist_circ.yaml
+++ b/priority_variables_transform/WHI-ingest/waist_circ.yaml
@@ -31,7 +31,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/waist_hip.yaml
+++ b/priority_variables_transform/WHI-ingest/waist_hip.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00079849
         associated_visit:
-          value: WHI PM 80
+          expr: "case(({phv00079850} == 1, 'WHI SCREENING'), ({phv00079850} == 3 and {phv00079851} == 1, 'WHI YEAR 1'), ({phv00079850} == 3 and {phv00079851} == 2, 'WHI YEAR 2'), ({phv00079850} == 3 and {phv00079851} == 3, 'WHI YEAR 3'), ({phv00079850} == 3 and {phv00079851} == 4, 'WHI YEAR 4'), ({phv00079850} == 3 and {phv00079851} == 5, 'WHI YEAR 5'), ({phv00079850} == 3 and {phv00079851} == 6, 'WHI YEAR 6'), ({phv00079850} == 3 and {phv00079851} == 7, 'WHI YEAR 7'), ({phv00079850} == 3 and {phv00079851} == 8, 'WHI YEAR 8'), ({phv00079850} == 3 and {phv00079851} == 9, 'WHI YEAR 9'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:

--- a/priority_variables_transform/WHI-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/WHI-ingest/whtbld_ct.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00077360
         associated_visit:
-          value: WHI CBC
+          expr: "case(({phv00077361} == 1, 'WHI SCREENING'), ({phv00077361} == 3 and {phv00077362} == 1, 'WHI YEAR 1'), ({phv00077361} == 3 and {phv00077362} == 2, 'WHI YEAR 2'), ({phv00077361} == 3 and {phv00077362} == 3, 'WHI YEAR 3'), (True, None))"
         # age_at_observation:
           # expr: "{nan} * 365"
         observation_type:


### PR DESCRIPTION
## Summary

Resolves all ERROR and CRITICAL findings from the **WHI phs000200 v12** Cohort Harmonization Review (CHR) dated 2026-03-24. This PR addresses 2 semantic code errors, removes 3 structural duplicates/misplacements, removes 2 out-of-scope HDL subfraction blocks, fixes 2 cross-table PHV references, implements multi-visit `case()` discrimination for 4 longitudinal tables (33 blocks across 27 files), and normalizes 14 visit labels to canonical `visit.yaml` definitions across 11 files.

HDL subfraction measurements (HDL-2, HDL-3) were **removed** per ontology lead direction — they are out of scope for priority variable harmonization. The MONDO code change for pulmonary hypertension was also **reverted** after ontology review confirmed the original CURIE was correct.

| Metric | Before | After |
|--------|--------|-------|
| Phase 1 ERRORs | 3 | **0** |
| Phase 2 ERRORs | 16 | **16** (all `associated_participant`/`associated_visit` on Person — accepted, see Change 6) |
| Phase 3 WARNINGs | 3 | **0** |
| CP5 CRITICALs | 3 | **1** (MONDO revert — original was correct) |
| Undefined visit labels | 26 | **14** (all deferred with rationale) |
| Files changed | — | **42** |
| Line delta from main | — | **+92 / −101** |

**HV-Lint post-fix:** Phase 1 PASS · Phase 2 PASS (16 accepted Person-slot ERRORs — see Change 6) · Phase 3 PASS

---

## Resolution Scorecard

| # | Severity | Finding | Fix | Files |
|---|----------|---------|-----|-------|
| 1 | ERROR | Duplicate LLS block in bmi.yaml | Deleted byte-for-byte duplicate block | 1 |
| 2 | ERROR | Carotid endarterectomy in coronary angiography file | Deleted wrong-domain block | 1 |
| 3 | CRITICAL | Wrong OMOP smoking status codes | Corrected `'1'`→OMOP:45883458 (Former), `'2'`→OMOP:40766945 (Current) | 1 |
| 4 | REVERTED | MONDO code for pulmonary HTN | **No change** — original MONDO:0005149 confirmed correct by ontology lead (MONDO:0002619 = bone fibrosarcoma) | 0 |
| 5 | CRITICAL | Encoded age range treated as numeric days | Removed broken `age_at_condition_start` | 1 |
| 6 | ERROR (ACCEPTED) | Person slots `associated_participant`/`associated_visit` (×16) | **KEPT per tech lead direction** — needed downstream, doesn't break pipeline | 1 |
| 7 | ERROR | Cross-table PHV in pacem_stat.yaml | Deleted block with pht003406 PHV declared under pht002118 | 1 |
| 8 | WARNING | Cross-table PHV in cause_of_death.yaml | Swapped to table-native PHV (phv00193497→phv00193532) | 1 |
| 9 | LINT | Static visit labels on multi-visit tables | `case()` expressions using VTYP/VY discriminators | 27 |
| 10 | LINT | Form/dataset names used as visit labels | Renamed to canonical `visit.yaml` labels | 11 |
| 11 | REMOVED | HDL subfraction blocks (HDL-2, HDL-3) | Deleted 2 out-of-scope blocks; total HDL retained with visit `case()` | 1 |

---

## Detailed Changes

### 1. ERROR — Duplicate LLS block in bmi.yaml — 1 file

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Deleted block 0 (lines 1–22): a `MeasurementObservation` for pht006217 (Long Life Study) that was a byte-for-byte duplicate of block 2.

**Why:** Phase 1 ERROR [1.2] and CHR finding H-2. Block 0 and block 2 had identical PHT (pht006217), PHV (phv00283344), visit label, observation_type, and unit — a pure structural duplicate.

**Source info:** `git log --follow bmi.yaml` shows the duplicate was introduced in commit `e61a7d23` (direct push to main, no PR review).

**Reasoning:** No semantic judgment needed — byte-for-byte identical blocks are always safe to deduplicate.

**Confidence:** ✅ **HIGH**

**Files (1):** `cohort_whi/transform/bmi.yaml` — also receives a visit `case()` change on its pht001019 block (see Change 9)

</details>

---

### 2. ERROR — Misplaced carotid endarterectomy block in hist_cor_angio.yaml — 1 file

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Deleted block 1: a `Procedure` mapping phv00078537 (CARONE) from pht000999 to OMOP:1242799 (Endarterectomy of carotid artery).

**Why:** Phase 1 ERROR [1.2] and Phase 3 WARNING [3.12]. Carotid endarterectomy is NOT coronary angiography. The variable CARONE belongs in a carotid procedures file, not in `hist_cor_angio.yaml`. The block also structurally duplicated block 0's participant PHV and table reference.

**Source info:** phv00078537 description: "Carotid endarterectomy" (FTP data dict `pht000999.v2.p3.c1.WHI_History_ECG_LVH_EKG.data_dict.xml`). OMOP:1242799 = "Endarterectomy of carotid artery".

**Reasoning:** Both the OMOP concept and the dbGaP variable description confirm this is a carotid procedure, not a coronary one. Removing it from the coronary file is the correct fix; if a `hist_carotid_endart.yaml` file is created later, this mapping could be reinstated there.

**Confidence:** ✅ **HIGH**

**Files (1):** `cohort_whi/transform/hist_cor_angio.yaml`

</details>

---

### 3. CRITICAL — Wrong OMOP smoking status codes in cig_smok.yaml — 1 file

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Fixed `value_mappings` for SMOKEVR (phv00078471):
- `'1'` (Past Smoker): `OMOP:45883459` → **`OMOP:45883458`** ("Former smoker")
- `'2'` (Current Smoker): `OMOP:45883458` → **`OMOP:40766945`** ("Current every day smoker")

**Why:** CP5 CRITICAL finding C-1. The original mapping had codes swapped — `'1'` (Past) pointed to OMOP:45883459 ("11-20 cigarettes, 1 point" — a Fagerström Test score, not a smoking status), and `'2'` (Current) pointed to OMOP:45883458 ("Former smoker" — the opposite status).

**Source info:** Verified via Athena (athena.ohdsi.org): OMOP:45883458 = "Former smoker" (OMOP Extension vocabulary); OMOP:40766945 = "Current every day smoker" (SNOMED). Same fix pattern confirmed in FHS PR #499 (reviewed and merged).

**Reasoning:** Direct lookup against the OMOP vocabulary authority. The original was a copy-paste error from another cohort.

**Confidence:** ✅ **HIGH**

**Files (1):** `cohort_whi/transform/cig_smok.yaml`

> **Note:** HV-Lint Phase 3 rule [3.11] reports a stale label for OMOP:45883458 in its embedded dictionary — shows "Current every day smoker" when Athena confirms "Former smoker". This is a known lint false positive (advisory, below fail threshold).

</details>

---

### 4. REVERTED — MONDO code for pulmonary hypertension in hyperten.yaml — NO CHANGE

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Nothing. The original MONDO:0005149 on blocks 1 (phv00283528, PULMHTNHX) and 4 (phv00283592, TTEPULMHTN) is **confirmed correct** and remains unchanged from `main`.

**Why reverted:** Ontology lead (Anne) reviewed and confirmed that MONDO:0005149 IS the correct CURIE for pulmonary hypertension. The proposed replacement MONDO:0002619 is actually "bone fibrosarcoma" — an entirely wrong domain.

**Source info:** Anne (ontology authority) review comment on PR #512. MONDO ontology verification: MONDO:0005149 = pulmonary hypertension (confirmed); MONDO:0002619 = bone fibrosarcoma (NOT pulmonary HTN).

**Reasoning:** The original automated CHR analysis incorrectly characterized MONDO:0005149 as "systemic arterial hypertension" and suggested MONDO:0002619 as "pulmonary hypertension." Both characterizations were wrong. The ontology lead’s review caught this error before merge.

**Confidence:** ✅ **HIGH** (ontology lead confirmation)

**Files (0):** No net change to `cohort_whi/transform/hyperten.yaml`

</details>

---

### 5. CRITICAL — Broken age_at_condition_start in diabetes.yaml — 1 file

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Deleted `age_at_condition_start` and its `expr: case(...)` from block 0 (2 lines removed).

**Why:** CP5 CRITICAL finding C-2. DIABAGE (phv00078465) uses encoded age ranges (1=<21, 2=21-29, 3=30-39, 4=40-49, 5=50-59, 6=60-69, 7=70+). The YAML multiplied the code × 365, producing "365 days" (1 year) for code 1 — biologically impossible for diabetes onset in WHI's 50–79 year-old population.

**Source info:** phv00078465 coded values from FTP data dict `pht000998.v2.p3.c1.WHI_Medical_History.data_dict.xml`: type=encoded, values="1 = Less than 21 years old, 2 = 21-29, 3 = 30-39, …"

**Reasoning:** Mapping was provably producing nonsensical values. Midpoint mapping was considered (e.g., 1→16, 2→25) but rejected because (a) it's imprecise and (b) no other cohort populates this slot for diabetes.

**Confidence:** ✅ **HIGH**

**Files (1):** `cohort_whi/transform/diabetes.yaml`

</details>

---

### 6. ACCEPTED — Person class `associated_participant` / `associated_visit` — KEPT (tech lead decision)

<details>
<summary><b>Click to expand</b></summary>

**What changed:** NO CHANGE. The `associated_participant` and `associated_visit` slots on all 8 Person blocks are **intentionally retained**.

**Background:** HV-Lint Phase 2 rule [2.1] flags 16 ERRORs (2 per block × 8 blocks) because `Person` in the current bdchm LinkML schema does not formally define these slots. They were initially removed in this PR branch, then **reverted** per tech lead direction.

**Why kept:** Tech lead confirmed these slots (a) do not break the pipeline at runtime (silently passed through), and (b) carry participant/visit context information that is needed for future pipeline features. Removing them would lose information that would need to be manually re-added later.

**Future action:** The bdchm schema will be updated in a future HM PR to formally support these slots on `Person`. Until then, the Phase 2 [2.1] ERRORs for these specific slot/class combinations are treated as **accepted/known warnings**, not blockers.

**Applies to all cohorts:** This decision applies globally — do not remove `associated_participant` or `associated_visit` from Person blocks in any cohort.

**Confidence:** ✅ **HIGH** (tech lead directive)

**Files (1):** `cohort_whi/transform/cause_of_death.yaml` — 8 Person blocks retain their original `associated_participant` and `associated_visit`

</details>

---

### 7. ERROR — Cross-table PHV in pacem_stat.yaml — 1 file (−13 lines)

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Deleted block 1 (13 lines): a `Procedure` mapped to OMOP:4323629 ("AV node ablation") that declared `populated_from: pht002118` (ECG table) but used phv00193137 from pht003406 (outcomes table).

**Why:** Phase 1 ERROR [1.2] and Phase 3 WARNING [3.5] (CP3). The block had the wrong participant PHV, wrong visit label, and wrong table context — a cross-table ownership error.

**Source info:** Phase 3 [3.5] WARNING output. PHV-to-PHT ownership verified via `whi_detail.json.gz` dbGaP index: phv00193137 ∈ pht003406, NOT pht002118.

**Reasoning:** The block cannot function correctly — it references a PHV that doesn't exist in the declared table. The pipeline would either silently produce null values or error at runtime.

**Confidence:** ✅ **HIGH**

**Files (1):** `cohort_whi/transform/pacem_stat.yaml` — also receives a visit `case()` change on its surviving ECG block (see Change 9)

</details>

---

### 8. WARNING — Cross-table PHV in cause_of_death.yaml block 2 — 1 file

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Block 2: `cause.populated_from: phv00193497` → **`phv00193532`**

**Why:** Phase 3 WARNING [3.5] (CP3). phv00193497 (DEATHCAUSE) belongs to pht003407, but block 2 declares `populated_from: pht003409`. Cross-table reference without a join.

**Source info:** `whi_detail.json.gz` confirms: phv00193497 ∈ pht003407, phv00193532 ∈ pht003409. Both are DEATHCAUSE with identical descriptions and coded values — same semantic content, different table versions.

**Reasoning:** Using the table-native PHV (phv00193532) is objectively correct. The variable content is identical; only the table ownership differs.

**Confidence:** ✅ **HIGH**

**Files (1):** `cohort_whi/transform/cause_of_death.yaml`

</details>

---

### 9. LINT — Multi-visit `case()` discrimination for 4 longitudinal tables — 27 files, 33 blocks

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Replaced static `associated_visit: value:` labels with dynamic `expr: "case(...)"` expressions using table-native VTYP (visit type) and VY (visit year) discriminator PHVs across 4 multi-visit tables.

**Why:** WHI has 4 longitudinal tables where each row can come from a different study visit. Previously, all rows from each table were assigned a single static visit label (the dataset name). Now, each block uses a `case()` expression to dynamically assign the correct visit based on the discriminator values embedded in each row.

**Pattern (before → after):**
```yaml
# BEFORE:
associated_visit:
  value: WHI CORE        # static — all rows get same label

# AFTER:
associated_visit:
  expr: "case(({VTYP_phv} == 1, 'WHI SCREENING'), ({VTYP_phv} == 3 and {VY_phv} == 1, 'WHI YEAR 1'), ..., (True, None))"
```

All target visit labels (`WHI SCREENING`, `WHI YEAR n`, `WHI NON-ROUTINE`, `WHI SEMI-ANNUAL VISIT YEAR 1`) already exist in the current `visit.yaml`. The `(True, None)` fallback ensures unexpected discriminator values produce null rather than a wrong visit assignment.

---

#### 9a. core_rel2 (pht000987) — 8 files, 11 blocks

**Discriminators:** COREVTYP (phv00077370) + COREVY (phv00077371)
**Visit types:** 1=Screening, 3=Annual Visit, 4=Non-Routine | **Years:** 0–6
**Old label:** `WHI CORE`

| File | Blocks | Measurement PHV(s) | Variable(s) |
|------|--------|--------------------|-------------|
| hdl.yaml | 3 | phv00077387, phv00077386, phv00077388 | COREHDL3, COREHDL2, COREHDL |
| factor_7.yaml | 2 | phv00077389, phv00077390 | COREFAC7A, COREFAC7T |
| ldl.yaml | 1 | phv00077394 | CORELDL |
| insulin_blood.yaml | 1 | phv00077393 | COREINSL |
| triglyc_bld.yaml | 1 | phv00077396 | CORETRIG |
| tot_chol_bld.yaml | 1 | phv00077395 | CORETCHL |
| glucose_bld.yaml | 1 | phv00077391 | COREGLUC |
| fibrin.yaml | 1 | phv00077385 | COREFIB |

**Evidence:** FTP data dict `pht000987.v7.p3.c1.WHI_Core_Rel2.data_dict.xml` — COREVTYP type=encoded {1: "Screening", 3: "Annual Visit", 4: "Non-Routine Visit"}; COREVY type=integer, range 0–6.

---

#### 9b. f80 (pht001019) — 8 files, 10 blocks

**Discriminators:** F80VTYP (phv00079850) + F80VY (phv00079851)
**Visit types:** 1=Screening, 3=Annual Visit | **Years:** 0–10
**Old label:** `WHI PM 80`

| File | Blocks | Measurement PHV(s) | Variable(s) |
|------|--------|--------------------|-------------|
| bp_diastolic.yaml | 2 | phv00079856, phv00079855 | F80DBP, F80DBPF |
| bp_systolic.yaml | 2 | phv00079854, phv00079853 | F80SBP, F80SBPF |
| waist_circ.yaml | 1 | phv00079860 | F80WAIST |
| bdy_hgt.yaml | 1 | phv00079857 | F80HGT |
| bdy_wgt.yaml | 1 | phv00079858 | F80WGT |
| bmi.yaml | 1 | phv00079859 | F80BMI |
| hip_circ.yaml | 1 | phv00079861 | F80HIP |
| waist_hip.yaml | 1 | phv00079862 | F80WHIPRT |

**Evidence:** FTP data dict `pht001019.v7.p3.c1.WHI_F80_Physical_Measures.data_dict.xml` — F80VTYP type=encoded {1: "Screening", 3: "Annual Visit"}; F80VY type=integer, range 0–10.

---

#### 9c. cbc_rel1 (pht000986) — 4 files, 4 blocks

**Discriminators:** CBCVTYP (phv00077361) + CBCVY (phv00077362)
**Visit types:** 1=Screening, 3=Annual Visit | **Years:** 0–3
**Old label:** `WHI CBC`

| File | Blocks | Measurement PHV(s) | Variable(s) |
|------|--------|--------------------|-------------|
| platelet_ct.yaml | 1 | phv00077367 | CBCPLAT |
| hemat.yaml | 1 | phv00077365 | CBCHCT |
| hemo.yaml | 1 | phv00077366 | CBCHGB |
| whtbld_ct.yaml | 1 | phv00077368 | CBCWBC |

**Evidence:** FTP data dict `pht000986.v7.p3.c1.WHI_CBC_Rel1.data_dict.xml` — CBCVTYP type=encoded {1: "Screening", 3: "Annual Visit"}; CBCVY type=integer, range 0–3.

---

#### 9d. ecg_rel2 (pht002118) — 7 files, 8 blocks

**Discriminators:** ECGVTYP (phv00154926) + ECGVY (phv00154927)
**Visit types:** 1=Screening, 2=Semi-Annual, 3=Annual Visit | **Years:** 0–11
**Old label:** `WHI ELECTROCARDIOGRAM -MYOCARDIAL INFARCTION NOVACODE FOLLOW-UP`

| File | Blocks | Notes |
|------|--------|-------|
| afib.yaml | 1 of 3 | Only the pht002118 block; 2 × pht003406 blocks unchanged |
| lvh_ekg.yaml | 1 | |
| pacem_stat.yaml | 1 | Surviving ECG block after dup removal (Change 7) |
| qrs_ekg.yaml | 1 | |
| qt_ekg.yaml | 1 | |
| pr_ekg.yaml | 1 | |
| hrtrt.yaml | 1 of 2 | Only the pht002118 block; pht006223 block unchanged |

**Evidence:** FTP data dict `pht002118.v2.p3.c1.WHI_ECG_Rel2.data_dict.xml` — ECGVTYP type=encoded {1: "Screening", 2: "Semi-Annual", 3: "Annual"}; ECGVY type=integer, range 0–11. Semi-Annual type (code 2) appears only at Year 1, mapped to `WHI SEMI-ANNUAL VISIT YEAR 1`.

---

**Confidence for all 4 tables:** ✅ **HIGH** — All discriminator PHVs verified from FTP data dictionaries. All target visit labels exist in `visit.yaml`.

</details>

---

### 10. LINT — Simple visit label renames — 11 files, 14 replacements

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Renamed dataset/form names used as visit labels to canonical `visit.yaml` labels for single-visit or one-row-per-participant tables.

**Why:** These tables used form identifiers (e.g., `WHI PI 41`, `WHI FG 60 1`) or generic labels (`WHI BASELINE`, `WHI CTOS`) instead of the canonical visit names defined in `visit.yaml`. Standardizing these enables correct visit-level joins across cohort data.

| Old Label | New Label | Files (blocks) | Rationale |
|-----------|-----------|----------------|-----------|
| `WHI PI 41` | `WHI SCREENING` | demography.yaml (1) | Form 41 = "Personal Information" collected at screening |
| `WHI FG 60 1` | `WHI SCREENING` | vege_serving.yaml (1), fruit_serving.yaml (1) | Food/Group form 60, version 1 = screening FFQ |
| `WHI BASELINE` | `WHI SCREENING` | vege_serving.yaml (1), fruit_serving.yaml (1) | WHI "baseline" = screening visit; `WHI SCREENING` is canonical |
| `WHI CTOS` | `WHI SCREENING` | ven_thromb.yaml (2), hypert_trt.yaml (1), tak_insulin.yaml (1), hist_hrtfail.yaml (1) | pht002770 (CTOS) = aggregate endpoint summary, one row per participant at baseline |
| `WHI FG 60 2` | `WHI YEAR 3` | sodium_intak.yaml (1), alcohol_servings.yaml (1), fruit_serving.yaml (1) | Food/Group form 60, version 2 = Year 3 follow-up FFQ |
| `WHI DL 38` | `WHI SCREENING` | sleep_duration_daily.yaml (1) | Form 38 = "Daily Life" screening questionnaire |
| `WHI TF 37` | `WHI SCREENING` | sleep_duration_daily.yaml (1) | Form 37 = "Thoughts and Feelings" screening questionnaire |

**Source info:** FTP data dicts for pht001009 (PI 41), pht001517/pht002125 (FG 60 v1/v2), pht006218 (LLS BASELINE), pht002770 (CTOS), pht001006 (DL 38), pht001005 (TF 37). WHI study design: "baseline" visit = screening visit for all arms.

**Note on CTOS mapping:** pht002770 (CT/OS Truncated Dataset) is technically an aggregate summary table, not a screening form. Mapped to `WHI SCREENING` because: (a) one row per participant, (b) relevant variables represent baseline status at study entry. If the team prefers a different label (e.g., `WHI ENROLLMENT SUMMARY`), it would need to be added to `visit.yaml` first.

**Confidence:** ✅ **HIGH** for all except CTOS (⚠️ **MEDIUM** — pragmatic mapping, team may prefer different approach)

**Files (11):**

| File | Blocks Changed | Table(s) | Old → New |
|------|---------------|----------|-----------|
| demography.yaml | 1 of 2 | pht001009 | `WHI PI 41` → `WHI SCREENING` |
| fruit_serving.yaml | 3 of 3 | pht001517, pht002125, pht006218 | `WHI FG 60 1` → `WHI SCREENING`, `WHI FG 60 2` → `WHI YEAR 3`, `WHI BASELINE` → `WHI SCREENING` |
| vege_serving.yaml | 2 of 2 | pht001517, pht006218 | `WHI FG 60 1` → `WHI SCREENING`, `WHI BASELINE` → `WHI SCREENING` |
| sodium_intak.yaml | 1 of 1 | pht002125 | `WHI FG 60 2` → `WHI YEAR 3` |
| alcohol_servings.yaml | 1 of 2 | pht002125 | `WHI FG 60 2` → `WHI YEAR 3` |
| sleep_duration_daily.yaml | 2 of 6 | pht001006, pht001005 | `WHI DL 38` → `WHI SCREENING`, `WHI TF 37` → `WHI SCREENING` |
| ven_thromb.yaml | 2 of 28 | pht002770 (×2) | `WHI CTOS` → `WHI SCREENING` |
| hypert_trt.yaml | 1 of 5 | pht002770 | `WHI CTOS` → `WHI SCREENING` |
| tak_insulin.yaml | 1 of 5 | pht002770 | `WHI CTOS` → `WHI SCREENING` |
| hist_hrtfail.yaml | 1 of 12 | pht002770 | `WHI CTOS` → `WHI SCREENING` |

</details>

---

### 11. REMOVED — HDL subfraction blocks (HDL-2, HDL-3) deleted from hdl.yaml — 1 file

<details>
<summary><b>Click to expand</b></summary>

**What changed:** Deleted 2 of 3 MeasurementObservation blocks from hdl.yaml:
- Block 0: phv00077387 (COREHDL3 = HDL-3 subfraction) — **DELETED**
- Block 1: phv00077386 (COREHDL2 = HDL-2 subfraction) — **DELETED**
- Block 2: phv00077388 (COREHDL = total HDL cholesterol) — **KEPT** (with visit `case()` expression)

**Why:** Ontology lead (Anne) directed that HDL subfraction measurements (HDL-2 and HDL-3) are **out of scope** for the current harmonization priority variables. Only total HDL cholesterol is in scope.

**Source info:** Anne’s review comment on PR #512: "I think we need to just remove the HDL subfraction measurements. Technically those are out of scope."

**Reasoning:** The priority variable list targets total HDL cholesterol, not subfractions. HDL-2 and HDL-3 are specialized lipid panel components that are not part of the harmonized measurement set. WHI is the only cohort with these subfractions, and no other cohort maps them. Removing them simplifies the file and eliminates the follow-up HM schema work that would have been needed for subfraction LOINC codes.

**Confidence:** ✅ **HIGH** (ontology lead directive)

**Files (1):** `cohort_whi/transform/hdl.yaml` — reduced from 3 blocks to 1 block (total HDL only, with core_rel2 visit `case()` expression)

</details>

---

## Issue #9 — Creatinine Core Labs: No Fix Possible

Exhaustive review of all 37+ core_rel2 (pht000987) variables confirmed creatinine is NOT in the WHI core labs panel. pht000987 contains lipids, glucose, insulin, Factor VII, fibrinogen, antioxidants, and CRP — no creatinine, BUN, or kidney function markers. The existing `creat_bld.yaml` maps phv00283659 (SERUMCREAT) from pht006223 (UNC Heart Failure Post-Hospitalization) — hospitalization-context creatinine, not routine core labs. **No action taken; documented as known limitation.**

---

## Deferred Items

| Category | Labels | Count | Reason |
|----------|--------|-------|--------|
| Outcome event datasets | WHI UNC HEART FAILURE DETAILS, WHI CAD, WHI DVTPE, WHI OUTCOMES (CT+OS), WHI EXT 2 SRC, WHI SCAD, WHI SCAD 4, WHI CAD 121, WHI STROKE | 9 | Event-based tables (~142 blocks), not visit-based. Requires architectural discussion about representing adjudicated outcome events. |
| Multi-visit forms needing `case()` | WHI LQ 155, WHI MH 134, WHI MAIN 44, WHI EXT 156 | 4 | Additional multi-visit tables needing discriminator identification. Deferred for follow-up PR. |
| ECG ancillary | WHI ELECTROCARDIOGRAM-MI NOVACODE FOLLOW-UP (pht003406 blocks) | 1 | pht003406 is an outcomes table with different structure than pht002118. Needs own discriminator investigation. |
| H-1/H-4/H-5: `{nan}` age placeholders | 6 files | — | User confirmed these are intentional placeholders for now. |
| M-1: Race/ethnicity dropped codes | demography.yaml | — | Requires architectural decision on "Hispanic" race code and multi-category ethnicity. |
| M-4: Treatment status collapsed | hyperten.yaml | — | Requires schema discussion about `condition_severity` for treated/untreated. |
| CP7: Schema enrichment slots | 0/6 populated | — | `visit_category`, `body_position`, `body_site`, `method_type`, `associated_evidence`, `observation_provenance` require HM schema work first. |

---

## Post-Merge Follow-Up

- [ ] Follow-up PR for remaining 4 multi-visit tables (`case()` discrimination for LQ 155, MH 134, MAIN 44, EXT 156)
- [ ] Architectural discussion on outcome event visit labels (9 labels, ~142 blocks)
- [ ] Investigate pht003406 ECG ancillary discriminator columns (afib.yaml blocks)
- [ ] Race/ethnicity mapping review (M-1 finding)
