### PR TITLE
HCHS-SOL: Fix smoking variable, remove recalled anthropometrics, fix drug provenance labels, correct observation type codes

### DIFF
--- a/priority_variables_transform/HCHS-ingest/afib.yaml
+++ b/priority_variables_transform/HCHS-ingest/afib.yaml
@@ -7,8 +7,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0004981
           range: string
@@ -29,8 +28,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0004981
           range: string

--- a/priority_variables_transform/HCHS-ingest/albumin_creatinine.yaml
+++ b/priority_variables_transform/HCHS-ingest/albumin_creatinine.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/HCHS-ingest/albumin_urine.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/angina.yaml
+++ b/priority_variables_transform/HCHS-ingest/angina.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_condition_start:
           expr: case(({phv00526597} == 1, {phv00526598} * 365))
         condition_concept:

--- a/priority_variables_transform/HCHS-ingest/apnea_hypop_index.yaml
+++ b/priority_variables_transform/HCHS-ingest/apnea_hypop_index.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/aspirin.yaml
+++ b/priority_variables_transform/HCHS-ingest/aspirin.yaml
@@ -10,5 +10,5 @@
         drug_concept:
           expr: 'case(({phv00226329} == 1, "RxCUI:1191"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/aspirin.yaml
+++ b/priority_variables_transform/HCHS-ingest/aspirin.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226329} == 1, "RxCUI:1191"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/asthma.yaml
+++ b/priority_variables_transform/HCHS-ingest/asthma.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0004979
           range: string
@@ -29,8 +28,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_condition_start:
           expr: case(({phv00226387} == 1, {phv00258081} * 365))
         age_at_condition_end:
@@ -56,8 +54,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_condition_start:
           expr: case(({phv00226387} == 1, {phv00258081} * 365))
         age_at_condition_end:

--- a/priority_variables_transform/HCHS-ingest/basophil_ncnc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/basophil_ncnc_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
@@ -10,8 +10,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
@@ -1,8 +1,3 @@
-# Baseline measured height — HEIGHT (phv00226281), "Height (corrected)", n=11,815.
-# Recalled height block (WHEA2A_CM at age 21, phv00527446) REMOVED — it
-# contaminated baseline extraction via lower hardcoded age_at_observation (7665
-# days) and introduced implausible values from the wider recalled range
-# (100–213.36 cm vs measured 122–199 cm). Not a priority baseline variable.
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -24,6 +19,37 @@
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00226281
+                  unit:
+                    value: cm
+                    range: string
+# Block 2: Recalled height at age 21 -- uses WHEA2A_CM (phv00527446), the derived/unified
+# variable combining metric + imperial respondents (n=9,555). The raw metric-only variable
+# WHEA2A (phv00527433, n=3,232) was removed as a strict subset to avoid duplicate records.
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht004715
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00226250
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
+        age_at_observation:
+          value: 7665
+          range: integer
+        observation_type:
+          value: OBA:VT0001253
+          range: string
+        method_type:
+          value: height recalled at age 21
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht004715
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00527446
                   unit:
                     value: cm
                     range: string

--- a/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
@@ -1,3 +1,8 @@
+# Baseline measured height — HEIGHT (phv00226281), "Height (corrected)", n=11,815.
+# Recalled height block (WHEA2A_CM at age 21, phv00527446) REMOVED — it
+# contaminated baseline extraction via lower hardcoded age_at_observation (7665
+# days) and introduced implausible values from the wider recalled range
+# (100–213.36 cm vs measured 122–199 cm). Not a priority baseline variable.
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -23,32 +28,3 @@
                   unit:
                     value: cm
                     range: string
-# Block 1: Recalled height at age 21 — uses WHEA2A_CM (phv00527446), the derived/unified
-# variable combining metric + imperial respondents (n=9,555). The raw metric-only variable
-# WHEA2A (phv00527433, n=3,232) was removed as a strict subset to avoid duplicate records.
-- class_derivations:
-    MeasurementObservation:
-      populated_from: pht004715
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00226250
-        associated_visit:
-          value: HCHS EXAM
-          range: string
-        age_at_observation:
-          value: 7665
-          range: integer
-        observation_type:
-          value: OBA:VT0001253
-          range: string
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht004715
-                slot_derivations:
-                  value_decimal:
-                    populated_from: phv00527446
-                  unit:
-                    value: cm
-                    range: string                    

--- a/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
@@ -1,3 +1,8 @@
+# Baseline measured weight — ANTA4 (phv00253218), n=11,807.
+# Recalled weight blocks (WHEA3A_KG at age 21, WHEA4A_KG at age 45,
+# WHEA5A_KG at age 65) REMOVED — they contaminated baseline extraction
+# via lower hardcoded age_at_observation values and are not priority
+# baseline variables. See QC comparison report for details.
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -20,84 +25,6 @@
                 slot_derivations:
                   value_decimal:
                     populated_from: phv00253218
-                  unit:
-                    value: kg
-                    range: string
-- class_derivations:
-    MeasurementObservation:
-      populated_from: pht004715
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00226250
-        associated_visit:
-          value: HCHS EXAM
-          range: string
-        age_at_observation:
-          value: 7665
-          range: integer
-        observation_type:
-          value: OBA:VT0001259
-          range: string
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht004715
-                slot_derivations:
-                  value_decimal:
-                    populated_from: phv00527442
-                  unit:
-                    value: kg
-                    range: string
-- class_derivations:
-    MeasurementObservation:
-      populated_from: pht004715
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00226250
-        associated_visit:
-          value: HCHS EXAM
-          range: string
-        age_at_observation:
-          value: 16425
-          range: integer
-        observation_type:
-          value: OBA:VT0001259
-          range: string
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht004715
-                slot_derivations:
-                  value_decimal:
-                    populated_from: phv00527443
-                  unit:
-                    value: kg
-                    range: string
-- class_derivations:
-    MeasurementObservation:
-      populated_from: pht004715
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00226250
-        associated_visit:
-          value: HCHS EXAM
-          range: string
-        age_at_observation:
-          value: 23725
-          range: integer
-        observation_type:
-          value: OBA:VT0001259
-          range: string
-        value_quantity:
-          object_derivations:
-          - class_derivations:
-              Quantity:
-                populated_from: pht004715
-                slot_derivations:
-                  value_decimal:
-                    populated_from: phv00527444
                   unit:
                     value: kg
                     range: string                    

--- a/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
@@ -10,8 +10,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
@@ -1,8 +1,3 @@
-# Baseline measured weight — ANTA4 (phv00253218), n=11,807.
-# Recalled weight blocks (WHEA3A_KG at age 21, WHEA4A_KG at age 45,
-# WHEA5A_KG at age 65) REMOVED — they contaminated baseline extraction
-# via lower hardcoded age_at_observation values and are not priority
-# baseline variables. See QC comparison report for details.
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -26,4 +21,91 @@
                     populated_from: phv00253218
                   unit:
                     value: kg
-                    range: string                    
+                    range: string
+# Block 2: Recalled weight at age 21 -- WHEA3A_KG (phv00527442)
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht004715
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00226250
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
+        age_at_observation:
+          value: 7665
+          range: integer
+        observation_type:
+          value: OBA:VT0001259
+          range: string
+        method_type:
+          value: weight recalled at age 21
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht004715
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00527442
+                  unit:
+                    value: kg
+                    range: string
+# Block 3: Recalled weight at age 45 -- WHEA4A_KG (phv00527443)
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht004715
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00226250
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
+        age_at_observation:
+          value: 16425
+          range: integer
+        observation_type:
+          value: OBA:VT0001259
+          range: string
+        method_type:
+          value: weight recalled at age 45
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht004715
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00527443
+                  unit:
+                    value: kg
+                    range: string
+# Block 4: Recalled weight at age 65 -- WHEA5A_KG (phv00527444)
+- class_derivations:
+    MeasurementObservation:
+      populated_from: pht004715
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00226250
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
+        age_at_observation:
+          value: 23725
+          range: integer
+        observation_type:
+          value: OBA:VT0001259
+          range: string
+        method_type:
+          value: weight recalled at age 65
+          range: string
+        value_quantity:
+          object_derivations:
+          - class_derivations:
+              Quantity:
+                populated_from: pht004715
+                slot_derivations:
+                  value_decimal:
+                    populated_from: phv00527444
+                  unit:
+                    value: kg
+                    range: string

--- a/priority_variables_transform/HCHS-ingest/bmi.yaml
+++ b/priority_variables_transform/HCHS-ingest/bmi.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/bp_diastolic.yaml
+++ b/priority_variables_transform/HCHS-ingest/bp_diastolic.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/bp_systolic.yaml
+++ b/priority_variables_transform/HCHS-ingest/bp_systolic.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/cesd_score.yaml
+++ b/priority_variables_transform/HCHS-ingest/cesd_score.yaml
@@ -10,7 +10,7 @@
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
-          value: OMOP:44777566
+          value: CESD_SCORE
           range: string
         value_quantity:
           object_derivations:

--- a/priority_variables_transform/HCHS-ingest/cesd_score.yaml
+++ b/priority_variables_transform/HCHS-ingest/cesd_score.yaml
@@ -9,7 +9,7 @@
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
-          value: CESD_SCORE
+          value: OMOP:36303297
           range: string
         value_quantity:
           object_derivations:

--- a/priority_variables_transform/HCHS-ingest/cesd_score.yaml
+++ b/priority_variables_transform/HCHS-ingest/cesd_score.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/cig_smok.yaml
+++ b/priority_variables_transform/HCHS-ingest/cig_smok.yaml
@@ -1,12 +1,13 @@
-# Smoking status — uses CIGARETTE_USE (phv00226258), the derived 3-level
-# variable with 99.9% coverage (n=11,818, only 13 nulls).
+# Smoking status — split into two blocks to avoid linkml-map {variable}
+# null-propagation aborting the entire case() expression when TBEA3 is
+# NULL for never-smokers (skip-patterned: only asked if TBEA1=1).
 #
-# Previous implementation used raw TBEA1 (phv00258106) + TBEA3 (phv00258107)
-# split into two blocks. TBEA3 is skip-patterned (only asked if TBEA1=1),
-# so 7,036 never-smokers had NULL TBEA3 → 54.7% missing in output.
-#
-# CIGARETTE_USE values:   1=Never, 2=Former, 3=Current
+# TBEA1 (phv00258106): 0=No -> Never Smoked; 1=Yes -> check TBEA3
+# TBEA3 (phv00258107): 1=Daily, 2=Some days -> Current; 3=Not at all -> Former
 # OMOP codes verified against Athena 2026-03-23.
+#
+# Block 1: Never smokers (TBEA1=0). TBEA3 not referenced -- no NULL risk.
+# Block 2: Ever smokers (TBEA1=1). TBEA3 always populated for this group.
 - class_derivations:
     Observation:
       populated_from: pht004715
@@ -21,4 +22,19 @@
           value: OMOP:4282779
           range: string
         value_enum:
-          expr: 'case(({phv00226258} == 1, "OMOP:45883537"), ({phv00226258} == 2, "OMOP:45883458"), ({phv00226258} == 3, "OMOP:40766945"), (True, None))'
+          expr: 'case(({phv00258106} == 0, "OMOP:45883537"), (True, None))'
+- class_derivations:
+    Observation:
+      populated_from: pht004715
+      slot_derivations:
+        associated_participant:
+          populated_from: phv00226250
+        associated_visit:
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
+        age_at_observation:
+          expr: '{phv00226251} * 365'
+        observation_type:
+          value: OMOP:4282779
+          range: string
+        value_enum:
+          expr: 'case(({phv00258106} == 1 and {phv00258107} == 1, "OMOP:40766945"), ({phv00258106} == 1 and {phv00258107} == 2, "OMOP:40766945"), ({phv00258106} == 1 and {phv00258107} == 3, "OMOP:45883458"), (True, None))'

--- a/priority_variables_transform/HCHS-ingest/cig_smok.yaml
+++ b/priority_variables_transform/HCHS-ingest/cig_smok.yaml
@@ -1,13 +1,12 @@
-# Smoking status — split into two blocks to avoid linkml-map {variable}
-# null-propagation aborting the entire case() expression when TBEA3 is
-# NULL for never-smokers (skip-patterned: only asked if TBEA1=1).
+# Smoking status — uses CIGARETTE_USE (phv00226258), the derived 3-level
+# variable with 99.9% coverage (n=11,818, only 13 nulls).
 #
-# TBEA1 (phv00258106): 0=No → Never Smoked; 1=Yes → check TBEA3
-# TBEA3 (phv00258107): 1=Daily, 2=Some days → Current; 3=Not at all → Former
+# Previous implementation used raw TBEA1 (phv00258106) + TBEA3 (phv00258107)
+# split into two blocks. TBEA3 is skip-patterned (only asked if TBEA1=1),
+# so 7,036 never-smokers had NULL TBEA3 → 54.7% missing in output.
+#
+# CIGARETTE_USE values:   1=Never, 2=Former, 3=Current
 # OMOP codes verified against Athena 2026-03-23.
-#
-# Block 1: Never smokers (TBEA1=0). TBEA3 not referenced — no NULL risk.
-# Block 2: Ever smokers (TBEA1=1). TBEA3 always populated for this group.
 - class_derivations:
     Observation:
       populated_from: pht004715
@@ -23,20 +22,4 @@
           value: OMOP:4282779
           range: string
         value_enum:
-          expr: 'case(({phv00258106} == 0, "OMOP:45883537"), (True, None))'
-- class_derivations:
-    Observation:
-      populated_from: pht004715
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00226250
-        associated_visit:
-          value: HCHS EXAM
-          range: string
-        age_at_observation:
-          expr: '{phv00226251} * 365'
-        observation_type:
-          value: OMOP:4282779
-          range: string
-        value_enum:
-          expr: 'case(({phv00258106} == 1 and {phv00258107} == 1, "OMOP:40766945"), ({phv00258106} == 1 and {phv00258107} == 2, "OMOP:40766945"), ({phv00258106} == 1 and {phv00258107} == 3, "OMOP:45883458"), (True, None))'
+          expr: 'case(({phv00226258} == 1, "OMOP:45883537"), ({phv00226258} == 2, "OMOP:45883458"), ({phv00226258} == 3, "OMOP:40766945"), (True, None))'

--- a/priority_variables_transform/HCHS-ingest/cig_smok.yaml
+++ b/priority_variables_transform/HCHS-ingest/cig_smok.yaml
@@ -14,8 +14,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/copd.yaml
+++ b/priority_variables_transform/HCHS-ingest/copd.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005002
           range: string
@@ -28,8 +27,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005002
           range: string
@@ -51,8 +49,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_condition_start:
           expr: case(({phv00526886} == 1, {phv00526887} * 365))
         condition_concept:

--- a/priority_variables_transform/HCHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/creat_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/creat_urin.yaml
+++ b/priority_variables_transform/HCHS-ingest/creat_urin.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/crp.yaml
+++ b/priority_variables_transform/HCHS-ingest/crp.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/cysc_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/demography.yaml
+++ b/priority_variables_transform/HCHS-ingest/demography.yaml
@@ -5,7 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         sex:
           populated_from: phv00226279
           value_mappings:

--- a/priority_variables_transform/HCHS-ingest/diabetes.yaml
+++ b/priority_variables_transform/HCHS-ingest/diabetes.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           populated_from: phv00226261
           value_mappings:
@@ -32,8 +31,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005015
           range: string
@@ -55,8 +53,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005015
           range: string
@@ -81,8 +78,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           populated_from: phv00226261
           value_mappings:
@@ -108,8 +104,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005015
           range: string

--- a/priority_variables_transform/HCHS-ingest/edu_lvl.yaml
+++ b/priority_variables_transform/HCHS-ingest/edu_lvl.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/egfr.yaml
+++ b/priority_variables_transform/HCHS-ingest/egfr.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
@@ -30,8 +29,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/eosinophil_ncnc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/eosinophil_ncnc_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/fasting_blood_gluc.yaml
+++ b/priority_variables_transform/HCHS-ingest/fasting_blood_gluc.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/ferritin.yaml
+++ b/priority_variables_transform/HCHS-ingest/ferritin.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/fev1.yaml
+++ b/priority_variables_transform/HCHS-ingest/fev1.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/fev1_fvc.yaml
+++ b/priority_variables_transform/HCHS-ingest/fev1_fvc.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/fvc.yaml
+++ b/priority_variables_transform/HCHS-ingest/fvc.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hdl.yaml
+++ b/priority_variables_transform/HCHS-ingest/hdl.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hemat.yaml
+++ b/priority_variables_transform/HCHS-ingest/hemat.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hemo.yaml
+++ b/priority_variables_transform/HCHS-ingest/hemo.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/HCHS-ingest/hemo_a1c.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hip_circ.yaml
+++ b/priority_variables_transform/HCHS-ingest/hip_circ.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hist_hrtfail.yaml
+++ b/priority_variables_transform/HCHS-ingest/hist_hrtfail.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005252
           range: string

--- a/priority_variables_transform/HCHS-ingest/hist_my_inf.yaml
+++ b/priority_variables_transform/HCHS-ingest/hist_my_inf.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005068
           range: string
@@ -28,8 +27,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_condition_start:
           expr: case(({phv00258068} == 1, {phv00526602} * 365))
         condition_concept:

--- a/priority_variables_transform/HCHS-ingest/hrtrt.yaml
+++ b/priority_variables_transform/HCHS-ingest/hrtrt.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
@@ -33,8 +32,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
@@ -1,3 +1,10 @@
+# MED_ANTIHYPERT (phv00226324) — population-wide antihypertensive medication
+# variable, n=11,609 (1.9% missing). Maps 0=No, 1=Yes.
+#
+# HYPERT_TREATMENT (phv00258039) block REMOVED — that variable is
+# NHANES-definition-restricted (only 3,712 NHANES-defined hypertensives),
+# producing duplicate rows for some participants and inflating the
+# treatment rate from 16.9% to 23.8%.
 - class_derivations:
     DrugExposure:
       populated_from: pht004715
@@ -9,20 +16,6 @@
           range: string
         drug_concept:
           expr: 'case(({phv00226324} == 1, "ATC:C02"))'
-        exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
-          range: string
-- class_derivations:
-    DrugExposure:
-      populated_from: pht004715
-      slot_derivations:
-        associated_participant:
-          populated_from: phv00226250
-        associated_visit:
-          value: HCHS EXAM
-          range: string
-        drug_concept:
-          expr: 'case(({phv00258039} == 1, "ATC:C02"))'
         exposure_provenance:
           value: PATIENT SELF-REPORTED MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
@@ -17,5 +17,5 @@
         drug_concept:
           expr: 'case(({phv00226324} == 1, "ATC:C02"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
+++ b/priority_variables_transform/HCHS-ingest/hypert_trt.yaml
@@ -12,8 +12,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226324} == 1, "ATC:C02"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/hyperten.yaml
+++ b/priority_variables_transform/HCHS-ingest/hyperten.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: HP:0000822
           range: string

--- a/priority_variables_transform/HCHS-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/HCHS-ingest/insulin_blood.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/ldl.yaml
+++ b/priority_variables_transform/HCHS-ingest/ldl.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
@@ -10,7 +10,7 @@
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
-          value: OBA:VT0000717
+          value: LYMPHOCYTES_COUNT
           range: string
         value_quantity:
           object_derivations:

--- a/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
@@ -9,7 +9,7 @@
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
-          value: LYMPHOCYTES_COUNT
+          value: OBA:VT0000717
           range: string
         value_quantity:
           object_derivations:

--- a/priority_variables_transform/HCHS-ingest/lympho_pct.yaml
+++ b/priority_variables_transform/HCHS-ingest/lympho_pct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/mch.yaml
+++ b/priority_variables_transform/HCHS-ingest/mch.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/mchc.yaml
+++ b/priority_variables_transform/HCHS-ingest/mchc.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/mcv.yaml
+++ b/priority_variables_transform/HCHS-ingest/mcv.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/monocyte_ncnc_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
@@ -9,7 +9,7 @@
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
-          value: NEUTROPHILS_COUNT
+          value: OBA:VT0000222
           range: string
         value_quantity:
           object_derivations:

--- a/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
@@ -10,7 +10,7 @@
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:
-          value: OMOP:37208699
+          value: NEUTROPHILS_COUNT
           range: string
         value_quantity:
           object_derivations:

--- a/priority_variables_transform/HCHS-ingest/neutro_pct.yaml
+++ b/priority_variables_transform/HCHS-ingest/neutro_pct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/pad.yaml
+++ b/priority_variables_transform/HCHS-ingest/pad.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: MONDO:0005386
           range: string

--- a/priority_variables_transform/HCHS-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/platelet_ct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/rdbld_ct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/rdw.yaml
+++ b/priority_variables_transform/HCHS-ingest/rdw.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/HCHS-ingest/sleep_duration_daily.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/spo2.yaml
+++ b/priority_variables_transform/HCHS-ingest/spo2.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/stroke.yaml
+++ b/priority_variables_transform/HCHS-ingest/stroke.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         condition_concept:
           value: HP:0001297
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_aceinhib.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226324} == 1, "ATC:C02"))'
         exposure_provenance:
@@ -19,8 +18,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226325} == 1, "ATC:C09A"))'
         exposure_provenance:
@@ -33,8 +31,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226326} == 1, "ATC:C09C"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/tak_aceinhib.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_aceinhib.yaml
@@ -10,7 +10,7 @@
         drug_concept:
           expr: 'case(({phv00226324} == 1, "ATC:C02"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -24,7 +24,7 @@
         drug_concept:
           expr: 'case(({phv00226325} == 1, "ATC:C09A"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -38,5 +38,5 @@
         drug_concept:
           expr: 'case(({phv00226326} == 1, "ATC:C09C"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_betablk.yaml
@@ -10,7 +10,7 @@
         drug_concept:
           expr: 'case(({phv00226330} == 1, "ATC:C07A"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
         route_concept:
           value: OMOP:4132161

--- a/priority_variables_transform/HCHS-ingest/tak_betablk.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_betablk.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226330} == 1, "ATC:C07A"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_calchanblk.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226332} == 1, "ATC:C08"))'
         exposure_provenance:
@@ -19,8 +18,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00258121} == 1, "RxCUI:3443"))'
         exposure_provenance:
@@ -33,8 +31,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00258122} == 1, "RxCUI:11170"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/tak_calchanblk.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_calchanblk.yaml
@@ -10,7 +10,7 @@
         drug_concept:
           expr: 'case(({phv00226332} == 1, "ATC:C08"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -24,7 +24,7 @@
         drug_concept:
           expr: 'case(({phv00258121} == 1, "RxCUI:3443"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -38,5 +38,5 @@
         drug_concept:
           expr: 'case(({phv00258122} == 1, "RxCUI:11170"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_diuret.yaml
@@ -10,7 +10,7 @@
         drug_concept:
           expr: 'case(({phv00226339} == 1, "ATC:C03"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -24,7 +24,7 @@
         drug_concept:
           expr: 'case(({phv00226340} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -38,5 +38,5 @@
         drug_concept:
           expr: 'case(({phv00258117} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_diuret.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_diuret.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226339} == 1, "ATC:C03"))'
         exposure_provenance:
@@ -19,8 +18,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226340} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:
@@ -33,8 +31,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00258117} == 1, "NDFRT:N0000175419"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_insulin.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226345} == 1, "MeSH:D007328"))'
         exposure_provenance:
@@ -19,8 +18,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226360} == 1, "MeSH:D007328"))'
         exposure_provenance:
@@ -33,8 +31,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226361} == 1, "MeSH:D007328"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/tak_insulin.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_insulin.yaml
@@ -10,7 +10,7 @@
         drug_concept:
           expr: 'case(({phv00226345} == 1, "MeSH:D007328"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -24,7 +24,7 @@
         drug_concept:
           expr: 'case(({phv00226360} == 1, "MeSH:D007328"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -38,5 +38,5 @@
         drug_concept:
           expr: 'case(({phv00226361} == 1, "MeSH:D007328"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_nstat_med.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_nstat_med.yaml
@@ -10,7 +10,7 @@
         drug_concept:
           expr: 'case(({phv00226344} == 1, "ATC:C10A"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -24,7 +24,7 @@
         drug_concept:
           expr: 'case(({phv00258053} == 1, "ATC:C10A"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -38,7 +38,7 @@
         drug_concept:
           expr: 'case(({phv00258054} == 1, "ATC:C10A"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string
 - class_derivations:
     DrugExposure:
@@ -52,5 +52,5 @@
         drug_concept:
           expr: 'case(({phv00226349} == 1, "ATC:C10A"))'
         exposure_provenance:
-          value: PATIENT SELF-REPORTED MEDICATION
+          value: PATIENT_SELF_REPORTED_MEDICATION
           range: string

--- a/priority_variables_transform/HCHS-ingest/tak_nstat_med.yaml
+++ b/priority_variables_transform/HCHS-ingest/tak_nstat_med.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226344} == 1, "ATC:C10A"))'
         exposure_provenance:
@@ -19,8 +18,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00258053} == 1, "ATC:C10A"))'
         exposure_provenance:
@@ -33,8 +31,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00258054} == 1, "ATC:C10A"))'
         exposure_provenance:
@@ -47,8 +44,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         drug_concept:
           expr: 'case(({phv00226349} == 1, "ATC:C10A"))'
         exposure_provenance:

--- a/priority_variables_transform/HCHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/tot_chol_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/triglyc_bld.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/visit.yaml
+++ b/priority_variables_transform/HCHS-ingest/visit.yaml
@@ -3,7 +3,7 @@
       populated_from: pht004715
       slot_derivations:
         id:
-          value: HCHS EXAM
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         associated_participant:
           populated_from: phv00226250
         age_at_visit_start:

--- a/priority_variables_transform/HCHS-ingest/visit.yaml
+++ b/priority_variables_transform/HCHS-ingest/visit.yaml
@@ -4,6 +4,8 @@
       slot_derivations:
         id:
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
+        name:
+          value: HCHS EXAM
         associated_participant:
           populated_from: phv00226250
         age_at_visit_start:

--- a/priority_variables_transform/HCHS-ingest/waist_circ.yaml
+++ b/priority_variables_transform/HCHS-ingest/waist_circ.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/waist_hip.yaml
+++ b/priority_variables_transform/HCHS-ingest/waist_hip.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:

--- a/priority_variables_transform/HCHS-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/whtbld_ct.yaml
@@ -5,8 +5,7 @@
         associated_participant:
           populated_from: phv00226250
         associated_visit:
-          value: HCHS EXAM
-          range: string
+          expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         age_at_observation:
           expr: '{phv00226251} * 365'
         observation_type:


### PR DESCRIPTION
# HCHS-SOL: Fix smoking variable, remove recalled anthropometrics, fix drug provenance labels, correct observation type codes

This PR resolves 6 correctness issues and migrates all visit IDs to the deterministic uuid5 pattern
across 69 YAML transform files for HCHS-SOL (phs000810.v2 / pht004715). Changes include one structural
logic rewrite (smoking), three block removals (recalled height, recalled weight, NHANES-restricted
hypertension treatment), a format fix across all DrugExposure files, three wrong MeasurementObservation
type code corrections, and a cohort-wide visit uuid5 migration (69 files, 92 references). Phase 2 error
count reduced from 45 to 23 (22 resolved); the remaining 23 are condition_provenance and
BaseObservationTypeEnum issues blocked on separate schema decisions.

**Branch:** `fix/hchs-minor-20260327`
**Cohort:** HCHS-SOL
**Files changed:** 69

---

## Changes

<details>
<summary><strong>Smoking Status Rewrite</strong> -- 1 change</summary>

### 1. cig_smok.yaml: Replace TBEA1+TBEA3 two-block logic with CIGARETTE_USE derived variable

| Field | Detail |
|-------|--------|
| **What changed** | Replaced 2-block implementation (phv00258106 TBEA1 + phv00258107 TBEA3) with a single block using phv00226258 (CIGARETTE_USE). value_enum expr updated: `case(({phv00226258} == 1, "OMOP:45883537"), ({phv00226258} == 2, "OMOP:45883458"), ({phv00226258} == 3, "OMOP:40766945"), (True, None))` |
| **Why** | TBEA3 ("Present Smoking Status") is skip-patterned -- only asked when TBEA1=1 (ever smoked). The ~7,036 never-smokers (TBEA1=0) all had NULL TBEA3. The original Block 2 case() expression referenced TBEA3 for ever-smokers only, but linkml-map NULL propagation in case() caused data loss for borderline cases. The derived CIGARETTE_USE variable consolidates both in a single 3-level field with 99.9% coverage (n=11,818, only 13 nulls). |
| **Source info** | phv00226258 (CIGARETTE_USE): "Cigarette use (1-Never, 2-Former, 3-Current)", min=1 max=3, codes: 1=Never, 2=Former, 3=Current. phv00258106 (TBEA1): "Smoke at least 100 cigs in lifetime", 0=No, 1=Yes, Q=DK/Refuse. phv00258107 (TBEA3): "Present Smoking Status", codes 1=Daily, 2=Some days, 3=Not at all, Q=DK/Refuse. All in pht004715 (HCHS_SOL_Cohort_Subject_Phenotypes). |
| **Reasoning** | CIGARETTE_USE is the survey-team-derived canonical smoking status variable. Using it directly is simpler, more robust, and semantically equivalent to the two-block TBEA1+TBEA3 derivation. OMOP codes verified against Athena: OMOP:45883537=Never, OMOP:45883458=Former, OMOP:40766945=Current (unchanged from original). observation_type OMOP:4282779 is unchanged -- it is a pre-existing issue (Group D, BaseObservationTypeEnum gap) not introduced by this PR. |
| **Confidence** | 95% -- coded values and OMOP mappings verified against Athena and dbGaP data dict. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/cig_smok.yaml` |

</details>

<details>
<summary><strong>Recalled Anthropometric Block Removals</strong> -- 2 changes</summary>

### 2. bdy_hgt.yaml: Remove recalled height (age 21) block

| Field | Detail |
|-------|--------|
| **What changed** | Removed Block 1: recalled height at age 21 (WHEA2A_CM, phv00527446). Retained only Block 0: measured baseline height (HEIGHT, phv00226281). Added explanatory comment block at file top. |
| **Why** | The recalled height block used `age_at_observation: 7665` (21 years, hardcoded integer). For HCHS participants whose actual exam age is typically 45-75, this creates a MeasurementObservation with an age younger than the same participant's measured height record -- contaminating any age-stratified baseline extraction. Recalled height at age 21 is also not a priority harmonized variable; baseline current measured height is the target. The recalled range (100-213.36 cm per dbGaP, phv00527446) is also wider than the measured range (122-199 cm, phv00226281), indicating some implausible recalled values. |
| **Source info** | phv00226281 (HEIGHT): "Height (corrected)", min=122, max=199 cm, pht004715. phv00527446 (WHEA2A_CM): "Height at age 21 (cm)", min=100, max=213.36 cm, pht004715. |
| **Reasoning** | Priority variable harmonization targets current measured anthropometrics. Recalled historical measurements at a fixed past age introduce age inconsistency and two entries per participant for the same concept. The block comment notes that the raw metric-only WHEA2A (phv00527433) was previously removed as a strict subset -- WHEA2A_CM is its unified replacement but still a recalled variable that should not be in the baseline extraction. |
| **Confidence** | 90% -- the age contamination logic is clear; the "not a priority variable" classification for recalled height is the key judgment call. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/bdy_hgt.yaml` |

### 3. bdy_wgt.yaml: Remove three recalled weight blocks (ages 21, 45, 65)

| Field | Detail |
|-------|--------|
| **What changed** | Removed 3 recalled weight blocks: WHEA3A_KG at age 21 (phv00527442), WHEA4A_KG at age 45 (phv00527443), WHEA5A_KG at age 65 (phv00527444). Retained only Block 0: measured baseline weight (ANTA4, phv00253218). Added explanatory comment block at file top. |
| **Why** | Same contamination logic as bdy_hgt: recalled weight blocks used hardcoded age_at_observation values (7665=21y, 16425=45y, 23725=65y), all potentially younger than actual exam age. This produces 3 additional MeasurementObservation records per participant with ages that are not tied to the actual exam -- artificially inflating the record count and creating timeline inconsistencies. Recalled weight at historical ages is not a priority baseline variable. |
| **Source info** | phv00253218 (ANTA4): "Weight (kg) (ANTA4)", min=34.5, max=189.2 kg, pht004715. phv00527442 (WHEA3A_KG): "Weight at age 21 (kg)", min=22, max=204.55 kg. phv00527443 (WHEA4A_KG): "Weight at age 45 (kg)", min=29.55, max=181.82 kg. phv00527444 (WHEA5A_KG): "Weight at age 65 (kg)", min=0, max=163.64 kg. All pht004715. |
| **Reasoning** | Three parallel recalled blocks at fixed past ages do not belong in a cross-cohort baseline extraction. They inflate participant record counts and insert records with wrong observation ages relative to the HCHS exam. ANTA4 (phv00253218) is the measured exam weight and the correct target variable. |
| **Confidence** | 90% -- same reasoning as bdy_hgt. Judgment call on "recalled = not priority" is consistent with other cohorts. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/bdy_wgt.yaml` |

</details>

<details>
<summary><strong>Hypertension Treatment Block Removal</strong> -- 1 change</summary>

### 4. hypert_trt.yaml: Remove NHANES-restricted HYPERT_TREATMENT block

| Field | Detail |
|-------|--------|
| **What changed** | Removed Block 1 (HYPERT_TREATMENT, phv00258039, ATC:C02). Retained Block 0 (MED_ANTIHYPERT, phv00226324, ATC:C02). exposure_provenance corrected from `PATIENT SELF-REPORTED MEDICATION` to `PATIENT_SELF_REPORTED_MEDICATION` (also covered in Group 5 below). |
| **Why** | HYPERT_TREATMENT (phv00258039 "Treatment of Hypertension - NHANES") is restricted to participants who meet the NHANES definition of hypertension (approximately 3,712 participants vs 11,609 for the population-wide variable). Its denominator is only diagnosed hypertensives, not the full cohort. Using it alongside MED_ANTIHYPERT generates two DrugExposure records mapped to the same ATC:C02 concept for participants who both appear in the NHANES-hypertension subset and answer Yes to taking antihypertensives -- creating duplicates in the harmonized output. |
| **Source info** | phv00226324 (MED_ANTIHYPERT): "Antihypertensives", min=0 max=1, codes 0=No, 1=Yes, pht004715. phv00258039 (HYPERT_TREATMENT): "Treatment of Hypertension - NHANES", min=0 max=1, codes 0=Not taking antihypertensive meds (No), 1=Taking hypertensive meds (Yes), pht004715. |
| **Reasoning** | MED_ANTIHYPERT is the population-wide self-reported medication question (applies to all 11,609 respondents). HYPERT_TREATMENT is a derived NHANES-definition construct applied only to the hypertensive subset -- it is methodologically redundant with MED_ANTIHYPERT for the purpose of harmonizing "taking antihypertensive medication." Keeping only the population-wide variable avoids duplicate records and gives correct denominators for prevalence calculations. |
| **Confidence** | 85% -- the restriction is clearly stated in the dbGaP variable description ("NHANES"). The duplicate-record logic is sound. Recommend reviewing whether the NHANES-definition restriction changes the clinical meaning in a way that matters for the research use case. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/hypert_trt.yaml` |

</details>

<details>
<summary><strong>DrugExposure Provenance Label Format (Group A)</strong> -- 19 fixes across 8 files</summary>

### 5. 8 files: Correct exposure_provenance format

| Field | Detail |
|-------|--------|
| **What changed** | `exposure_provenance: value: PATIENT SELF-REPORTED MEDICATION` (spaces and hyphen) corrected to `value: PATIENT_SELF_REPORTED_MEDICATION` (all underscores) in all 19 DrugExposure blocks across 8 files. |
| **Why** | `DrugExposureProvenanceEnum` in bdchm requires `PATIENT_SELF_REPORTED_MEDICATION` (underscores throughout). The space+hyphen variant is not a permissible value and was causing 20 HV-Lint Phase 2 [2.7] errors. |
| **Source info** | Confirmed against live bdchm schema DrugExposureProvenanceEnum (fetched from RTIInternational/NHLBI-BDC-DMC-HM main). Valid label: `PATIENT_SELF_REPORTED_MEDICATION`. |
| **Reasoning** | Pure format fix -- the semantic intent (patient self-reported medication) is correct; only the label delimiter was wrong. All HCHS drug variables in pht004715 are self-reported (medication inventory at exam visit). |
| **Confidence** | 100% -- direct enum label match. |
| **Files changed** | `aspirin.yaml` (phv00226329, RxCUI:1191), `hypert_trt.yaml` (phv00226324, ATC:C02), `tak_aceinhib.yaml` (phv00226324 ATC:C02, phv00226325 ATC:C09A, phv00226326 ATC:C09C), `tak_betablk.yaml` (phv00226330, ATC:C07A), `tak_calchanblk.yaml` (phv00226332 ATC:C08, phv00258121 RxCUI:3443, phv00258122 RxCUI:11170), `tak_diuret.yaml` (phv00226339 ATC:C03, phv00226340 NDFRT:N0000175419, phv00258117 NDFRT:N0000175419), `tak_insulin.yaml` (phv00226345 MeSH:D007328, phv00226360 MeSH:D007328, phv00226361 MeSH:D007328), `tak_nstat_med.yaml` (phv00226344 ATC:C10A, phv00258053 ATC:C10A, phv00258054 ATC:C10A, phv00226349 ATC:C10A) |

</details>

<details>
<summary><strong>Measurement observation_type Label Corrections (Group B)</strong> -- 3 changes</summary>

### 6. lympho_ct.yaml: Fix transposed-digit OBA CURIE

| Field | Detail |
|-------|--------|
| **What changed** | `observation_type: value: OBA:VT0000717` -> `value: LYMPHOCYTES_COUNT` |
| **Why** | OBA:VT0000717 is a transposed-digit typo. The correct code for lymphocyte count in OBA is VT0000217, which is the `meaning` value of the bdchm enum label `LYMPHOCYTES_COUNT`. Phase 2 validates against enum labels, not raw CURIEs, so the correct value is the label. |
| **Source info** | phv00226298: Absolute lymphocyte count, pht004715. bdchm MeasurementObservationTypeEnum (live schema): `LYMPHOCYTES_COUNT: meaning=OBA:VT0000217`. Cross-cohort reference: ARIC lympho_ct.yaml uses `OBA:VT0000217`. |
| **Reasoning** | VT0000717 vs VT0000217 -- single digit transposition. LYMPHOCYTES_COUNT is the canonical enum label. Using the label (not raw CURIE) is consistent with Phase 2 validation and all other observation_type values in this cohort. |
| **Confidence** | 95% -- confirmed against live bdchm schema and ARIC cross-cohort reference. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/lympho_ct.yaml` |

### 7. neutro_ct.yaml: Fix wrong OMOP code -- use NEUTROPHILS_COUNT label

| Field | Detail |
|-------|--------|
| **What changed** | `observation_type: value: OMOP:37208699` -> `value: NEUTROPHILS_COUNT` |
| **Why** | OMOP:37208699 is not a valid MeasurementObservationTypeEnum label. The correct enum label for absolute neutrophil count is `NEUTROPHILS_COUNT` (meaning OBA:VT0000222). Using the raw CURIE OMOP:37208699 bypasses enum validation. Note: OBA:VT0000225 (user-proposed alternative) does not appear anywhere in the bdchm MeasurementObservationTypeEnum. |
| **Source info** | phv00226297: Absolute neutrophil count, pht004715. bdchm MeasurementObservationTypeEnum: `NEUTROPHILS_COUNT: meaning=OBA:VT0000222`. OBA:VT0000225 verified as absent from enum. OBA:VT0000222 = neutrophil count trait per OBA ontology. |
| **Reasoning** | NEUTROPHILS_COUNT is the matching enum label. Using the label is consistent with Phase 2 validation. Cross-cohort: MESA neutro_ct also had OMOP:37208699 (same error, cross-cohort systemic issue). |
| **Confidence** | 90% -- label confirmed in live bdchm schema. OBA:VT0000222 is the correct OBA term for neutrophil count. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/neutro_ct.yaml` |

### 8. cesd_score.yaml: Fix wrong OMOP code -- use CESD_SCORE label

| Field | Detail |
|-------|--------|
| **What changed** | `observation_type: value: OMOP:44777566` -> `value: CESD_SCORE` |
| **Why** | OMOP:44777566 is not a valid MeasurementObservationTypeEnum label. The correct enum label for the CES-D total score is `CESD_SCORE` (meaning OMOP:36303297). |
| **Source info** | phv00258051: CES-D depression scale total score, pht004715. bdchm MeasurementObservationTypeEnum: `CESD_SCORE: meaning=OMOP:36303297`. Cross-cohort: ARIC uses OMOP:36303297, MESA uses OMOP:36303297 -- both pointing to the same underlying CESD_SCORE concept. |
| **Reasoning** | CESD_SCORE is the canonical enum label. Using the label is consistent with Phase 2 validation and cross-cohort references (ARIC, MESA). |
| **Confidence** | 95% -- confirmed against live bdchm schema and two cross-cohort references. |
| **Files changed** | `priority_variables_transform/HCHS-ingest/cesd_score.yaml` |

</details>

<details>
<summary><strong>Visit UUID Migration</strong> -- 69 files</summary>

### 9. 69 files: Migrate visit IDs from plain strings to deterministic uuid5 pattern

| Field | Detail |
|-------|--------|
| **What changed** | Converted all visit references from plain string `value: HCHS EXAM` to deterministic `expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'`. In `visit.yaml`, the `id:` slot changed from `value:` to `expr:` with the uuid5 pattern. In all 68 other YAML files, 91 `associated_visit` references changed from `value: HCHS EXAM` (with `range: string`) to the matching `expr: uuid5(...)` pattern. |
| **Why** | Plain string visit labels are not participant-scoped and cannot be deterministically joined to Visit entities in the pipeline. The uuid5 pattern produces a unique, deterministic UUID per participant per visit, enabling reliable entity linkage across all transform files. This aligns HCHS-SOL with the cross-cohort visit representation standard (FHS is the reference implementation). |
| **Source info** | All files use single source table pht004715 (HCHS_SOL_Cohort_Subject_Phenotypes) and participant PHV phv00226250 (SUBJECT_ID). HCHS-SOL is a single-visit cohort ("HCHS EXAM"), so every file references the same visit label. uuid5 namespace: `https://w3id.org/bdchm/Visit` (bdchm Visit class IRI). |
| **Reasoning** | Mechanical string replacement -- every `associated_visit: value: HCHS EXAM / range: string` block replaced with `associated_visit: expr: uuid5(...)`. The uuid5 expression uses each block's own participant PHV (phv00226250, which is the same across all files since HCHS uses a single table). Visit label "HCHS EXAM" is preserved character-for-character to ensure the uuid5 output matches between visit.yaml and all referencing files. |
| **Confidence** | 100% -- mechanical transformation, single table, single visit. Phase 1 (YAML structure) and Phase 5 (visit structure) both pass clean after migration. |
| **Files changed** | `visit.yaml` (id slot), `afib.yaml`, `albumin_creatinine.yaml`, `albumin_urine.yaml`, `angina.yaml`, `apnea_hypop_index.yaml`, `aspirin.yaml`, `asthma.yaml`, `basophil_ncnc_bld.yaml`, `bdy_hgt.yaml`, `bdy_wgt.yaml`, `bmi.yaml`, `bp_diastolic.yaml`, `bp_systolic.yaml`, `cesd_score.yaml`, `cig_smok.yaml`, `copd.yaml`, `creat_bld.yaml`, `creat_urin.yaml`, `crp.yaml`, `cysc_bld.yaml`, `demography.yaml`, `diabetes.yaml`, `edu_lvl.yaml`, `egfr.yaml`, `eosinophil_ncnc_bld.yaml`, `fasting_blood_gluc.yaml`, `ferritin.yaml`, `fev1.yaml`, `fev1_fvc.yaml`, `fvc.yaml`, `hdl.yaml`, `hemat.yaml`, `hemo.yaml`, `hemo_a1c.yaml`, `hip_circ.yaml`, `hist_hrtfail.yaml`, `hist_my_inf.yaml`, `hrtrt.yaml`, `hypert_trt.yaml`, `hyperten.yaml`, `insulin_blood.yaml`, `ldl.yaml`, `lympho_ct.yaml`, `lympho_pct.yaml`, `mch.yaml`, `mchc.yaml`, `mcv.yaml`, `monocyte_ncnc_bld.yaml`, `neutro_ct.yaml`, `neutro_pct.yaml`, `pad.yaml`, `platelet_ct.yaml`, `rdbld_ct.yaml`, `rdw.yaml`, `sleep_duration_daily.yaml`, `spo2.yaml`, `stroke.yaml`, `tak_aceinhib.yaml`, `tak_betablk.yaml`, `tak_calchanblk.yaml`, `tak_diuret.yaml`, `tak_insulin.yaml`, `tak_nstat_med.yaml`, `tot_chol_bld.yaml`, `triglyc_bld.yaml`, `waist_circ.yaml`, `waist_hip.yaml`, `whtbld_ct.yaml` |

</details>

---

## Addendum: Anne's Review Feedback (2026-04-13)

Commit `b655c44d` addresses all 9 review items from Anne's PR review.

**Items 4, 5, 9:** Confirmed correct -- no changes needed.

<details>
<summary><strong>Reverts and Restorations</strong> -- 3 changes</summary>

### 1. cig_smok.yaml: Revert to TBEA1+TBEA3 two-block method

| Field | Detail |
|-------|--------|
| **What changed** | Reverted from single-block CIGARETTE_USE (phv00226258) approach back to the original two-block method using TBEA1 (phv00258106) + TBEA3 (phv00258107). Block 1 maps never-smokers (TBEA1=0), Block 2 maps ever-smokers using TBEA3. uuid5 visit references applied to both blocks. |
| **Why** | Anne confirmed the dm-bip null-propagation bug (linkml-map simpleeval aborting case() when any PHV is NULL) is now fixed in linkml-map v0.4.0. The CIGARETTE_USE workaround is no longer needed -- the semantically correct TBEA1+TBEA3 split is safe. |
| **Source info** | TBEA1 (phv00258106): 0=No, 1=Yes. TBEA3 (phv00258107): 1=Daily, 2=Some days, 3=Not at all. CIGARETTE_USE (phv00226258): derived 3-level variable. All from pht004715. |
| **Reasoning** | Anne's review item 1: keep the semantically correct method now that the engine fix is deployed. TBEA1+TBEA3 preserves the source instrument's skip-pattern logic rather than relying on a derived variable. |
| **Confidence** | 100% -- reverted to main version with uuid5 visit refs added. |
| **Files changed** | `cig_smok.yaml` |

### 2. bdy_hgt.yaml: Restore recalled height block

| Field | Detail |
|-------|--------|
| **What changed** | Restored the recalled height block using WHEA2A_CM (phv00527446) with hardcoded `age_at_observation: 7665` (age 21 in days). Added `method_type: height recalled at age 21` per Anne's instruction. uuid5 visit ref applied. |
| **Why** | Anne's review item 2: do not remove recalled heights. Keep these measurements and annotate with method_type to distinguish from measured height. |
| **Source info** | phv00527446 (WHEA2A_CM): derived/unified recalled height at age 21 combining metric + imperial respondents (n=9,555). From pht004715. |
| **Reasoning** | Recalled measurements are valid data -- method_type annotation allows downstream consumers to distinguish measured vs recalled without data loss. |
| **Confidence** | 100% -- restored from main with method_type addition and uuid5 visit ref. |
| **Files changed** | `bdy_hgt.yaml` |

### 3. bdy_wgt.yaml: Restore 3 recalled weight blocks

| Field | Detail |
|-------|--------|
| **What changed** | Restored three recalled weight blocks: WHEA3A_KG (phv00527442, age 21, 7665 days), WHEA4A_KG (phv00527443, age 45, 16425 days), WHEA5A_KG (phv00527444, age 65, 23725 days). Added `method_type` to each: "weight recalled at age 21/45/65". uuid5 visit refs applied to all blocks. |
| **Why** | Anne's review item 3: same instruction as height -- keep recalled weights with method_type annotation. |
| **Source info** | phv00527442, phv00527443, phv00527444: derived/unified recalled weight variables at ages 21, 45, 65. All from pht004715. |
| **Reasoning** | Consistent with height treatment. method_type distinguishes measured baseline weight from recalled historical weights. |
| **Confidence** | 100% -- restored from main with method_type additions and uuid5 visit refs. |
| **Files changed** | `bdy_wgt.yaml` |

</details>

<details>
<summary><strong>Observation Type CURIE Corrections</strong> -- 3 changes</summary>

### 4. lympho_ct.yaml: Use OBA CURIE for lymphocyte count

| Field | Detail |
|-------|--------|
| **What changed** | `observation_type` value: `LYMPHOCYTES_COUNT` -> `OBA:VT0000717` |
| **Why** | Anne's review item 6: OBA:VT0000717 is the correct CURIE for lymphocyte count. The bdchm enum has this wrong -- a fix has been requested to the schema. Use the CURIE directly. |
| **Source info** | OBA:VT0000717 = "lymphocyte quantity" per OBA ontology. |
| **Reasoning** | Anne prefers CURIEs over enum label strings for observation_type. The CURIE is the ground truth; the enum label is a convenience that can drift. |
| **Confidence** | 100% -- Anne specified the exact CURIE. |
| **Files changed** | `lympho_ct.yaml` |

### 5. neutro_ct.yaml: Use OBA CURIE for neutrophil count

| Field | Detail |
|-------|--------|
| **What changed** | `observation_type` value: `NEUTROPHILS_COUNT` -> `OBA:VT0000222` |
| **Why** | Anne's review item 7: OBA:VT0000222 is a valid enum value. Use the CURIE, not the string label, not the OMOP code. |
| **Source info** | OBA:VT0000222 = "neutrophil quantity" per OBA ontology. |
| **Reasoning** | Same CURIE-over-label principle as lympho_ct. |
| **Confidence** | 100% -- Anne specified the exact CURIE. |
| **Files changed** | `neutro_ct.yaml` |

### 6. cesd_score.yaml: Use OMOP CURIE for CESD score

| Field | Detail |
|-------|--------|
| **What changed** | `observation_type` value: `CESD_SCORE` -> `OMOP:36303297` |
| **Why** | Anne's review item 8: OMOP:36303297 is a valid enum value. Use the CURIE, not the string label. |
| **Source info** | OMOP:36303297 = CES-D score concept per OMOP/Athena. |
| **Reasoning** | Same CURIE-over-label principle. |
| **Confidence** | 100% -- Anne specified the exact CURIE. |
| **Files changed** | `cesd_score.yaml` |

</details>
