### PR TITLE
Use linkml-map's built-in trans-spec validator for CI

### DIFF
--- a/.github/workflows/validate_ingest_yamls.yml
+++ b/.github/workflows/validate_ingest_yamls.yml
@@ -26,7 +26,7 @@ jobs:
         run: pipx install poetry
 
       - name: Install dependencies.
-        run: poetry install
+        run: poetry lock --no-update && poetry install
 
       - name: Validate */*-ingest*/*.yaml files.
         run: poetry run python validate_ingest_yamls.py
@@ -48,7 +48,7 @@ jobs:
         run: pipx install poetry
 
       - name: Install dependencies.
-        run: poetry install
+        run: poetry lock --no-update && poetry install
 
       - name: Check PHV deduplication
         run: poetry run python check_phv_dedup.py

--- a/.github/workflows/validate_ingest_yamls.yml
+++ b/.github/workflows/validate_ingest_yamls.yml
@@ -26,7 +26,7 @@ jobs:
         run: pipx install poetry
 
       - name: Install dependencies.
-        run: poetry lock --no-update && poetry install
+        run: poetry lock && poetry install
 
       - name: Validate */*-ingest*/*.yaml files.
         run: poetry run python validate_ingest_yamls.py
@@ -48,7 +48,7 @@ jobs:
         run: pipx install poetry
 
       - name: Install dependencies.
-        run: poetry lock --no-update && poetry install
+        run: poetry lock && poetry install
 
       - name: Check PHV deduplication
         run: poetry run python check_phv_dedup.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "gspread (>=6.2.1,<7.0.0)",
     "gspread-dataframe (>=4.0.0,<5.0.0)",
     "tabulate (>=0.9.0,<0.10.0)",
-    "linkml-map (>=0.5.0,<1.0.0)"
+    "linkml-map @ git+https://github.com/linkml/linkml-map.git@main"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "gspread (>=6.2.1,<7.0.0)",
     "gspread-dataframe (>=4.0.0,<5.0.0)",
     "tabulate (>=0.9.0,<0.10.0)",
-    "linkml-map (>=0.4.0,<1.0.0)"
+    "linkml-map (>=0.5.0,<1.0.0)"
 ]
 
 

--- a/validate_ingest_yamls.py
+++ b/validate_ingest_yamls.py
@@ -4,9 +4,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from linkml_map.datamodel.transformer_model import TransformationSpecification
-from linkml_runtime.processing.referencevalidator import ReferenceValidator
-from linkml_runtime.utils.introspection import package_schemaview
+from linkml_map.validator import validate_spec
 
 # Known issues to be fixed by curation team. These files are excluded from
 # validation failures so CI stays green while issues are tracked separately.
@@ -17,24 +15,9 @@ KNOWN_ISSUES = {
 }
 
 
-def make_normalizer() -> ReferenceValidator:
-    normalizer = ReferenceValidator(
-        package_schemaview("linkml_map.datamodel.transformer_model")
-    )
-    normalizer.expand_all = True
-    return normalizer
-
-
-def validate_block(
-    block: dict, normalizer: ReferenceValidator, block_index: int
-) -> list[str]:
-    errors = []
-    try:
-        normalized = normalizer.normalize(block)
-        TransformationSpecification(**normalized)
-    except (TypeError, ValueError) as e:
-        errors.append(f"  block {block_index}: {e}")
-    return errors
+def validate_block(block: dict, block_index: int) -> list[str]:
+    errors = validate_spec(block)
+    return [f"  block {block_index}: {e}" for e in errors]
 
 
 def main() -> int:
@@ -49,7 +32,6 @@ def main() -> int:
         print(f"No YAML files found under {base_dir}")
         return 1
 
-    normalizer = make_normalizer()
     total_files = 0
     total_blocks = 0
     failed_files = []
@@ -79,7 +61,7 @@ def main() -> int:
 
         for i, block in enumerate(blocks):
             total_blocks += 1
-            file_errors.extend(validate_block(block, normalizer, i))
+            file_errors.extend(validate_block(block, i))
 
         if file_errors:
             failed_files.append((file_path, file_errors))


### PR DESCRIPTION
## Summary

- Swap `validate_ingest_yamls.py` from `ReferenceValidator` + `TransformationSpecification` instantiation to `linkml_map.validator.validate_spec` (added in linkml-map 0.5.0)
- The new validator uses JSON Schema with `additionalProperties: false`, catching unknown fields the old approach silently accepted
- Bump linkml-map constraint from `>=0.4.0` to `>=0.5.0`
- Add `poetry lock --no-update` to CI workflow so the stale lock file is regenerated

## Test plan

- [ ] CI `validate-yaml` job passes with the new validator
- [ ] CI `check-phv-dedup` job still passes (unrelated but same workflow)
- [ ] Verify no new failures from stricter validation (or add to KNOWN_ISSUES if legitimate)