### PR TITLE
Use dict-keyed form for nested class derivations

### DIFF
--- a/priority_variables_transform/ARIC-ingest/albumin_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/albumin_bld.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507050
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507050
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004051
@@ -33,10 +33,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203871
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203871
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/ARIC-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/ARIC-ingest/albumin_urine.yaml
@@ -12,13 +12,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506959
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506959
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006427
@@ -33,13 +33,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006427
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295249
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht006427
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295249
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006427
@@ -54,11 +54,11 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006427
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00295248} * ({phv00295250} * 0.01)"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht006427
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00295248} * ({phv00295250} * 0.01)"
+                unit:
+                  value: "mg/L"
+                  range: string

--- a/priority_variables_transform/ARIC-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/ARIC-ingest/bdy_hgt.yaml
@@ -16,14 +16,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012835
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00516590} * 2.54"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht012835
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00516590} * 2.54"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -40,14 +40,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00206817} == "I", {phv00206855} * 2.54), ({phv00206817} == "C", {phv00206855}))'
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00206817} == "I", {phv00206855} * 2.54), ({phv00206817} == "C", {phv00206855}))'
+                unit:
+                  value: "cm"
+                  range: string
 # COMMENTED OUT: ABI (Ankle Brachial Index) table — no unit metadata in dbGaP data dict.
 # Variable ABI5 (phv00294562) has empty unit field. Each exam already has proper cm height
 # from anthropometry/PFT forms. DCC used only pht004032 (ANTA01, confirmed cm) for ARIC height.
@@ -117,13 +117,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004032
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203151
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004032
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203151
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006467
@@ -142,13 +142,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006467
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00297562
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006467
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00297562
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006468
@@ -167,13 +167,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006468
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00511023
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006468
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00511023
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004035
@@ -190,13 +190,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004035
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203193
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004035
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203193
+                unit:
+                  value: "cm"
 # COMMENTED OUT: ECG Raw Epicare table — no unit metadata in dbGaP data dict.
 # Variable ECGRA278 (phv00514211) has empty unit field. Exam 2 already has proper height
 # from pht012835 (PFTB03, inches→cm via *2.54). DCC did not use ECG tables for height.
@@ -239,13 +239,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004034
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203175
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004034
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203175
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006469
@@ -262,13 +262,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006469
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00297646
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006469
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00297646
+                unit:
+                  value: "cm"
 # COMMENTED OUT: ECG Raw Epicare table — no unit metadata in dbGaP data dict.
 # Variable ECGRA278 (phv00515037) has empty unit field. Exam 3 already has proper cm height
 # from pht004034 (ANTC1, confirmed cm). DCC did not use ECG tables for height.
@@ -311,13 +311,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006419
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294838
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006419
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294838
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012855
@@ -334,13 +334,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012855
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00520006
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht012855
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00520006
+                unit:
+                  value: "cm"
 # COMMENTED OUT: Jackson-only cohort table — no unit metadata in dbGaP data dict.
 # Variable ECHA2 (phv00510684) has empty unit field. Exam 3 already has proper cm height
 # from pht004034 (ANTC1, confirmed cm). DCC did not use ECHA tables for height.

--- a/priority_variables_transform/ARIC-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/ARIC-ingest/bdy_wgt.yaml
@@ -14,14 +14,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004032
-            slot_derivations:
-              value_decimal:
-                expr: 'None if {phv00203154} is None or str({phv00203154}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203154}) * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004032
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if {phv00203154} is None or str({phv00203154}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203154}) * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004033
@@ -38,14 +38,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004033
-            slot_derivations:
-              value_decimal:
-                expr: 'None if {phv00203166} is None or str({phv00203166}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203166}) * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004033
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if {phv00203166} is None or str({phv00203166}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203166}) * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004034
@@ -62,14 +62,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004034
-            slot_derivations:
-              value_decimal:
-                expr: 'None if {phv00203176} is None or str({phv00203176}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203176}) * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004034
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if {phv00203176} is None or str({phv00203176}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203176}) * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004035
@@ -86,14 +86,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004035
-            slot_derivations:
-              value_decimal:
-                expr: 'None if {phv00203187} is None or str({phv00203187}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203187}) * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004035
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if {phv00203187} is None or str({phv00203187}) in ("A", "O", "M", "R", "N", "U", "T", "L", "H", "") else float({phv00203187}) * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006467
@@ -112,14 +112,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006467
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00297563
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht006467
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00297563
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006468
@@ -138,11 +138,11 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006468
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00511024
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht006468
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00511024
+                unit:
+                  value: kg
+                  range: string

--- a/priority_variables_transform/ARIC-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/ARIC-ingest/blood_pressure.yaml
@@ -8,46 +8,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210296}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210290
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210291
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210290
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210291
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004192
@@ -58,46 +58,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210296}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210281
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210282
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210281
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210282
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004192
@@ -108,46 +108,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210296}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210284
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210285
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210284
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210285
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004192
@@ -158,46 +158,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210296}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210286
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210286
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210286
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210286
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004192
@@ -208,46 +208,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210296}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210287
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210288
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210287
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210288
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004192
@@ -258,46 +258,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210296}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210289
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004192
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004192
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210289
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210289
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004192
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004192
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210289
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004193
@@ -308,46 +308,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210321}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210316
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210317
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210316
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210317
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004193
@@ -358,46 +358,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210321}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210307
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210308
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210307
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210308
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004193
@@ -408,46 +408,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210321}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210310
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210311
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210310
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210311
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004193
@@ -458,46 +458,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210321}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210313
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004193
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004193
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210314
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210313
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004193
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004193
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210314
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004194
@@ -508,46 +508,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210347}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210340
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210341
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210340
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210341
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004194
@@ -558,46 +558,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210347}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210331
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210332
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210331
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210332
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004194
@@ -608,46 +608,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210347}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210334
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210335
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210334
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210335
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004194
@@ -658,46 +658,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210347}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210337
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004194
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated random-zero reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004194
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210338
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210337
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004194
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated random-zero reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004194
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210338
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004195
@@ -708,46 +708,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210370}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004195
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004195
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210363
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004195
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004195
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210364
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004195
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004195
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210363
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004195
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004195
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210364
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004195
@@ -758,46 +758,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210370}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004195
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004195
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210357
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004195
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004195
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210358
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004195
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004195
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210357
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004195
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004195
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210358
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004195
@@ -808,46 +808,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00210370}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004195
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004195
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210360
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004195
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004195
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00210361
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004195
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004195
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210360
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004195
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004195
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00210361
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006480
@@ -858,46 +858,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00298028}) + ":ARIC Lab Form")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298043
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298044
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298043
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298044
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006480
@@ -908,46 +908,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00298028}) + ":ARIC Lab Form")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298034
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298035
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298034
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298035
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006480
@@ -958,46 +958,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00298028}) + ":ARIC Lab Form")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298037
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298038
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298037
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298038
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006480
@@ -1008,46 +1008,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00298028}) + ":ARIC Lab Form")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298040
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006480
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006480
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00298041
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298040
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006480
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006480
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00298041
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004027
@@ -1066,13 +1066,13 @@
           value: "ABI form measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004027
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00202843
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004027
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00202843
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004027
@@ -1091,13 +1091,13 @@
           value: "ABI form measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004027
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00202844
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004027
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00202844
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004028
@@ -1116,13 +1116,13 @@
           value: "ABI form measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004028
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00202852
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004028
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00202852
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004028
@@ -1141,13 +1141,13 @@
           value: "ABI form measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004028
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00202853
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004028
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00202853
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004029
@@ -1166,13 +1166,13 @@
           value: "ABI form measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004029
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00202862
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004029
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00202862
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004029
@@ -1191,13 +1191,13 @@
           value: "ABI form measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004029
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00202863
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004029
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00202863
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006414
@@ -1208,50 +1208,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294489}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294506
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294508
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294506
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294508
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006414
@@ -1262,50 +1262,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294489}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left arm"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294509
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left arm"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294511
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left arm"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294509
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left arm"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294511
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006414
@@ -1316,50 +1316,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294489}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right ankle"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294512
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right ankle"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294514
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right ankle"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294512
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right ankle"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294514
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006414
@@ -1370,50 +1370,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294489}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left ankle"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294515
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006414
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left ankle"
-              method_type:
-                value: "ABI form measurement"
-              age_at_observation:
-                expr: "{phv00294491} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006414
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294517
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left ankle"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294515
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006414
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left ankle"
+                method_type:
+                  value: "ABI form measurement"
+                age_at_observation:
+                  expr: "{phv00294491} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006414
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294517
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1432,13 +1432,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203315
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203315
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1457,13 +1457,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203316
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203316
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1482,13 +1482,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203317
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203317
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1507,13 +1507,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203318
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203318
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1532,13 +1532,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203319
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203319
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1557,13 +1557,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203320
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203320
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1582,13 +1582,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203321
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203321
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004041
@@ -1607,13 +1607,13 @@
           value: "ABI ultrasound measurement"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004041
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203322
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004041
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203322
+                unit:
+                  value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1624,46 +1624,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203334
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203335
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203334
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203335
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1674,46 +1674,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203336
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203337
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203336
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203337
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1724,46 +1724,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203338
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203339
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203338
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203339
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1774,46 +1774,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203340
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203341
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203340
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203341
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1824,46 +1824,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203342
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203343
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203342
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203343
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1874,46 +1874,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203344
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203345
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203344
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203345
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004042
@@ -1924,46 +1924,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203348}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203346
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004042
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004042
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203347
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203346
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004042
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004042
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203347
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -1974,46 +1974,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203358
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203359
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203358
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203359
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -2024,46 +2024,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203360
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203361
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203360
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203361
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -2074,46 +2074,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203362
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203363
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203362
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203363
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -2124,46 +2124,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203364
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203365
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203364
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203365
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -2174,46 +2174,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203366
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203367
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203366
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203367
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -2224,46 +2224,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203368
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203369
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203368
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203369
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004043
@@ -2274,46 +2274,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00203372}) + ":ARIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203370
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004043
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI ultrasound measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004043
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00203371
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203370
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004043
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI ultrasound measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004043
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00203371
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006415
@@ -2324,50 +2324,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294559}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294568
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294570
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294568
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294570
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006415
@@ -2378,50 +2378,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294559}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left arm"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294571
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left arm"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294573
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left arm"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294571
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left arm"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294573
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006415
@@ -2432,50 +2432,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294559}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right ankle"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294574
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right ankle"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294576
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right ankle"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294574
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right ankle"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294576
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006415
@@ -2486,50 +2486,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00294559}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left ankle"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294577
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006415
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Left ankle"
-              method_type:
-                value: "ABI derived calculation"
-              age_at_observation:
-                expr: "{phv00294561} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006415
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00294579
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left ankle"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294577
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006415
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Left ankle"
+                method_type:
+                  value: "ABI derived calculation"
+                age_at_observation:
+                  expr: "{phv00294561} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006415
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00294579
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004229
@@ -2540,46 +2540,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00215518}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004229
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004229
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215412
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004229
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004229
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215413
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004229
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004229
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215412
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004229
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004229
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215413
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004229
@@ -2590,46 +2590,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00215518}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004229
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004229
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215414
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004229
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004229
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215415
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004229
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004229
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215414
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004229
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004229
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215415
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004229
@@ -2640,46 +2640,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00215518}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004229
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004229
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215416
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004229
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004229
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215417
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004229
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004229
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215416
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004229
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004229
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215417
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004230
@@ -2690,46 +2690,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00215626}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004230
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004230
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215520
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004230
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004230
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215521
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004230
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004230
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215520
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004230
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004230
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215521
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004230
@@ -2740,46 +2740,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00215626}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004230
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004230
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215522
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004230
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004230
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215523
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004230
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004230
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215522
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004230
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004230
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215523
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004230
@@ -2790,46 +2790,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00215626}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004230
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004230
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215524
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004230
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Carotid distensibility measurement"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004230
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00215525
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004230
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004230
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215524
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004230
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Carotid distensibility measurement"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004230
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00215525
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004079
@@ -2840,43 +2840,43 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00205920}) + ":ARIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004079
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              method_type:
-                value: "Echocardiography measurement"
-              age_at_observation:
-                expr: "{phv00510683} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004079
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00205847
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht004079
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SUPINE_BODY_POSITION"
-              method_type:
-                value: "Echocardiography measurement"
-              age_at_observation:
-                expr: "{phv00510683} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004079
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00205848
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004079
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                method_type:
+                  value: "Echocardiography measurement"
+                age_at_observation:
+                  expr: "{phv00510683} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004079
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00205847
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht004079
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SUPINE_BODY_POSITION"
+                method_type:
+                  value: "Echocardiography measurement"
+                age_at_observation:
+                  expr: "{phv00510683} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004079
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00205848
+                        unit:
+                          value: "mm[Hg]"

--- a/priority_variables_transform/ARIC-ingest/bmi.yaml
+++ b/priority_variables_transform/ARIC-ingest/bmi.yaml
@@ -12,13 +12,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204719
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204719
+                unit:
+                  value: "kg/m2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012502
@@ -33,13 +33,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012502
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506861
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht012502
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506861
+                unit:
+                  value: "kg/m2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012811
@@ -54,10 +54,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012811
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00511714
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht012811
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00511714
+                unit:
+                  value: "kg/m2"

--- a/priority_variables_transform/ARIC-ingest/bnp.yaml
+++ b/priority_variables_transform/ARIC-ingest/bnp.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009477
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00419810
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht009477
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00419810
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -35,13 +35,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204185
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204185
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009477
@@ -58,13 +58,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009477
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00419811
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht009477
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00419811
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -79,13 +79,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204186
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204186
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -100,13 +100,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204184
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204184
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -121,13 +121,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206948
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206948
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -142,13 +142,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206947
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206947
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -163,13 +163,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206946
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206946
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -184,10 +184,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204179
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204179
+                unit:
+                  value: "pg/mL"

--- a/priority_variables_transform/ARIC-ingest/bun.yaml
+++ b/priority_variables_transform/ARIC-ingest/bun.yaml
@@ -12,10 +12,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203866
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203866
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/ARIC-ingest/carotid_imt.yaml
+++ b/priority_variables_transform/ARIC-ingest/carotid_imt.yaml
@@ -12,15 +12,15 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004207
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00211095} + {phv00211096} + {phv00211097} + {phv00211101}
-                  + {phv00211102} + {phv00211103})/6
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht004207
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00211095} + {phv00211096} + {phv00211097} + {phv00211101}
+                    + {phv00211102} + {phv00211103})/6
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the average internal carotid IMT far wall both sides from
             optimal, anterior, and posterior angle
@@ -38,15 +38,15 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004213
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00212601} + {phv00212602} + {phv00212603} + {phv00212607}
-                  + {phv00212608} + {phv00212609})/6
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht004213
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00212601} + {phv00212602} + {phv00212603} + {phv00212607}
+                    + {phv00212608} + {phv00212609})/6
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the average internal carotid IMT far wall both sides from
             optimal, anterior, and posterior angle
@@ -64,14 +64,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004223
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00213941} + {phv00213942})/2
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht004223
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00213941} + {phv00213942})/2
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the average internal carotid IMT far wall both sides
 - class_derivations:
@@ -88,16 +88,16 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004207
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00211054} + {phv00211055} + {phv00211053} + {phv00211059}
-                  + {phv00211060} + {phv00211061} + {phv00211081} + {phv00211082}
-                  + {phv00211083} + {phv00211087} + {phv00211088} + {phv00211089})/12
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht004207
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00211054} + {phv00211055} + {phv00211053} + {phv00211059}
+                    + {phv00211060} + {phv00211061} + {phv00211081} + {phv00211082}
+                    + {phv00211083} + {phv00211087} + {phv00211088} + {phv00211089})/12
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the maximum internal carotid IMT far and near walls both
             sides from optimal, posterior, and anterior angles
@@ -115,15 +115,15 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004213
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00212560} + {phv00212561} + {phv00212559} + {phv00212565}
-                  + {phv00212566} + {phv00212567})/6
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht004213
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00212560} + {phv00212561} + {phv00212559} + {phv00212565}
+                    + {phv00212566} + {phv00212567})/6
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the maximum internal carotid IMT near wall both sides from
             optimal, posterior, and anterior angles
@@ -141,14 +141,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004223
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00213911} + {phv00213912})/2
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht004223
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00213911} + {phv00213912})/2
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the maximum internal carotid IMT near wall both sides
 - class_derivations:
@@ -165,13 +165,13 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012850
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00519705} + {phv00519706})/2
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht012850
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00519705} + {phv00519706})/2
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the maximum internal carotid IMT near wall both sides

--- a/priority_variables_transform/ARIC-ingest/carotid_sten_left.yaml
+++ b/priority_variables_transform/ARIC-ingest/carotid_sten_left.yaml
@@ -16,10 +16,10 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004061
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204553
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004061
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204553
+                unit:
+                  value: "%"

--- a/priority_variables_transform/ARIC-ingest/carotid_sten_right.yaml
+++ b/priority_variables_transform/ARIC-ingest/carotid_sten_right.yaml
@@ -16,10 +16,10 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004061
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204552
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004061
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204552
+                unit:
+                  value: "%"

--- a/priority_variables_transform/ARIC-ingest/cesd_score.yaml
+++ b/priority_variables_transform/ARIC-ingest/cesd_score.yaml
@@ -14,13 +14,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507380
-              unit:
-                value: "{score}"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507380
+                unit:
+                  value: "{score}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -37,13 +37,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512381
-              unit:
-                value: "{score}"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512381
+                unit:
+                  value: "{score}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012855
@@ -58,13 +58,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012855
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519890
-              unit:
-                value: "{score}"
+          - Quantity:
+              populated_from: pht012855
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519890
+                unit:
+                  value: "{score}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -81,10 +81,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512128
-              unit:
-                value: "{score}"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512128
+                unit:
+                  value: "{score}"

--- a/priority_variables_transform/ARIC-ingest/chloride_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/chloride_bld.yaml
@@ -12,10 +12,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012851
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519777
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht012851
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519777
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/ARIC-ingest/creat_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/creat_bld.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206960
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206960
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -35,13 +35,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519803
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519803
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -58,13 +58,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519801
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519801
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -79,13 +79,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296596
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296596
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004100
@@ -100,13 +100,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004100
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296341
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004100
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296341
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -121,13 +121,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204180
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204180
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004100
@@ -142,13 +142,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004100
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296343
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004100
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296343
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -165,13 +165,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519800
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519800
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006427
@@ -186,13 +186,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006427
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295246
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006427
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295246
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004046
@@ -207,13 +207,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004046
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295065
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004046
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295065
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004046
@@ -228,13 +228,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004046
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295066
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004046
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295066
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -249,13 +249,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204188
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204188
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004061
@@ -270,13 +270,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004061
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295526
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004061
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295526
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004124
@@ -291,13 +291,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004124
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207682
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004124
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207682
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004051
@@ -312,13 +312,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203867
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203867
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -333,13 +333,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206961
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206961
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -354,13 +354,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296597
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296597
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -375,13 +375,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204187
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204187
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -396,13 +396,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506998
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506998
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004052
@@ -417,13 +417,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004052
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203883
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004052
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203883
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -440,13 +440,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519802
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519802
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004046
@@ -461,13 +461,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004046
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295067
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004046
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295067
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004100
@@ -482,13 +482,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004100
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296342
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004100
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296342
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -503,13 +503,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204189
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204189
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004061
@@ -524,13 +524,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004061
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295525
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004061
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295525
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -545,10 +545,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296595
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296595
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/ARIC-ingest/creat_urin.yaml
+++ b/priority_variables_transform/ARIC-ingest/creat_urin.yaml
@@ -12,13 +12,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506972
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506972
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006427
@@ -33,10 +33,10 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006427
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295250
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006427
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295250
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/ARIC-ingest/crp.yaml
+++ b/priority_variables_transform/ARIC-ingest/crp.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296696
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296696
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012511
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012511
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507554
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012511
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507554
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -56,10 +56,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519822
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519822
+                unit:
+                  value: "mg/L"

--- a/priority_variables_transform/ARIC-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/cysc_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519845
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519845
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519843
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519843
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519844
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519844
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006428
@@ -81,13 +81,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006428
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295532
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht006428
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295532
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -102,10 +102,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507076
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507076
+                unit:
+                  value: "mg/L"

--- a/priority_variables_transform/ARIC-ingest/d_dimer.yaml
+++ b/priority_variables_transform/ARIC-ingest/d_dimer.yaml
@@ -12,10 +12,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012826
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00515959
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht012826
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00515959
+                unit:
+                  value: "mg/L"

--- a/priority_variables_transform/ARIC-ingest/egfr.yaml
+++ b/priority_variables_transform/ARIC-ingest/egfr.yaml
@@ -12,13 +12,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012505
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507454
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012505
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507454
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -35,13 +35,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512303
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512303
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -58,13 +58,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519853
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519853
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -81,13 +81,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519849
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519849
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -104,13 +104,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512179
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512179
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -127,13 +127,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519848
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519848
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -150,13 +150,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507312
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507312
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -173,13 +173,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519854
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519854
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -196,13 +196,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519847
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519847
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -219,13 +219,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519850
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519850
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -242,13 +242,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519852
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519852
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -265,13 +265,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507389
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507389
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -288,13 +288,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512177
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512177
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -311,13 +311,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507388
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507388
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012502
@@ -332,13 +332,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012502
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506868
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012502
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506868
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -355,13 +355,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519851
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519851
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -378,13 +378,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512298
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512298
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -401,13 +401,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512178
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512178
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -424,13 +424,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512302
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512302
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -447,13 +447,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519855
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519855
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -470,10 +470,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519846
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519846
+                unit:
+                  value: "mL/min/{1.73_m2}"

--- a/priority_variables_transform/ARIC-ingest/factor_7.yaml
+++ b/priority_variables_transform/ARIC-ingest/factor_7.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004098
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206651
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht004098
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206651
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004099
@@ -33,10 +33,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004099
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206657
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht004099
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206657
+                unit:
+                  value: "%{normal}"

--- a/priority_variables_transform/ARIC-ingest/factor_8.yaml
+++ b/priority_variables_transform/ARIC-ingest/factor_8.yaml
@@ -12,11 +12,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004098
-            slot_derivations:
-              value_decimal:
-                # Factor VIII C value (string type); guard against non-numeric sentinels
-                expr: 'None if str({phv00206649}).strip() in ("", ".", "NA", "nan", "NaN") else float({phv00206649}) * 0.01'
-              unit:
-                value: "[IU]/mL"
+          - Quantity:
+              populated_from: pht004098
+              slot_derivations:
+                value_decimal:
+                  # Factor VIII C value (string type); guard against non-numeric sentinels
+                  expr: 'None if str({phv00206649}).strip() in ("", ".", "NA", "nan", "NaN") else float({phv00206649}) * 0.01'
+                unit:
+                  value: "[IU]/mL"

--- a/priority_variables_transform/ARIC-ingest/fam_income.yaml
+++ b/priority_variables_transform/ARIC-ingest/fam_income.yaml
@@ -12,23 +12,23 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004111
-            slot_derivations:
-              value_concept:
-                populated_from: phv00207402
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $24,999
-                  '6': $25,000 - $34,999
-                  '7': $35,999 - $49,999
-                  '8': '> $50,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht004111
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00207402
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $24,999
+                    '6': $25,000 - $34,999
+                    '7': $35,999 - $49,999
+                    '8': '> $50,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     Observation:
       populated_from: pht004145
@@ -43,22 +43,22 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004145
-            slot_derivations:
-              value_concept:
-                populated_from: phv00209018
-                value_mappings:
-                  A: < $5,000
-                  B: $5,000 - $7,999
-                  C: $8,000 - $11,999
-                  D: $12,000 - $15,999
-                  E: $16,000 - $24,999
-                  F: $25,000 - $34,999
-                  G: $35,999 - $49,999
-                  H: $50,000 - $74,999
-                  I: $75,000 - $99,999
-                  J: '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht004145
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00209018
+                  value_mappings:
+                    A: < $5,000
+                    B: $5,000 - $7,999
+                    C: $8,000 - $11,999
+                    D: $12,000 - $15,999
+                    E: $16,000 - $24,999
+                    F: $25,000 - $34,999
+                    G: $35,999 - $49,999
+                    H: $50,000 - $74,999
+                    I: $75,000 - $99,999
+                    J: '> $100,000'
+                unit:
+                  value: USD
+                  range: string

--- a/priority_variables_transform/ARIC-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/fast_gluc_bld.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004124
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207678
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004124
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207678
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296695
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296695
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -56,11 +56,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512077} * 18"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512077} * 18"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012813
@@ -77,11 +77,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012813
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00511990} * 18"
+          - Quantity:
+              populated_from: pht012813
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00511990} * 18"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -98,11 +98,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00507387} * 18"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00507387} * 18"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -119,8 +119,8 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512301} * 18"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512301} * 18"

--- a/priority_variables_transform/ARIC-ingest/fibrin.yaml
+++ b/priority_variables_transform/ARIC-ingest/fibrin.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004099
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206658
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004099
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206658
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004098
@@ -33,10 +33,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004098
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206650
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004098
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206650
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/ARIC-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/ARIC-ingest/fruit_serving.yaml
@@ -12,23 +12,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205071
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk" 
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205071
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk" 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -43,23 +43,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205289
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205289
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -74,23 +74,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205193
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205193
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -105,23 +105,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205068
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk" 
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205068
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk" 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -136,23 +136,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205291
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk" 
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205291
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk" 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -167,23 +167,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205191
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk" 
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205191
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk" 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -198,23 +198,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205192
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk" 
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205192
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk" 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -229,23 +229,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205290
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205290
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -260,23 +260,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205070
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205070
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -291,23 +291,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205072
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205072
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -322,23 +322,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205073
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205073
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -353,23 +353,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205292
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205292
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -384,23 +384,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205190
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205190
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -415,23 +415,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205069
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205069
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -446,23 +446,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205293
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205293
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -477,23 +477,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205288
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205288
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -508,23 +508,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205194
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205194
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -539,20 +539,20 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205189
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205189
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{#}/wk"

--- a/priority_variables_transform/ARIC-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/glucose_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204730
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204730
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519794
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519794
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519817
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519817
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004123
@@ -81,13 +81,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004123
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207663
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004123
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207663
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -104,13 +104,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519819
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519819
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -125,13 +125,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506985
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506985
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004052
@@ -146,13 +146,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004052
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203882
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004052
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203882
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -169,13 +169,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519818
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519818
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -192,13 +192,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519821
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519821
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -215,13 +215,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519820
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519820
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -238,11 +238,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204734} * 18"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204734} * 18"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -259,8 +259,8 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00507386} * 18"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00507386} * 18"

--- a/priority_variables_transform/ARIC-ingest/hdl.yaml
+++ b/priority_variables_transform/ARIC-ingest/hdl.yaml
@@ -14,13 +14,13 @@
           value: "Longitudinal analyte file"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519826
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519826
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -37,13 +37,13 @@
           value: "Longitudinal analyte file"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519828
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519828
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -60,13 +60,13 @@
           value: "Longitudinal analyte file"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519824
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519824
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012511
@@ -81,13 +81,13 @@
           value: "Lipid lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012511
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507550
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012511
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507550
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444
@@ -102,13 +102,13 @@
           value: "Lipid lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296693
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296693
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004124
@@ -123,13 +123,13 @@
           value: "Lipid lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004124
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207677
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004124
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207677
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004122
@@ -144,13 +144,13 @@
           value: "Lipid lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004122
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207651
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004122
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207651
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -167,13 +167,13 @@
           value: "Analysis derived (recalibrated)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204761
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204761
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -190,13 +190,13 @@
           value: "Longitudinal analyte file"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519825
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519825
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004123
@@ -211,13 +211,13 @@
           value: "Lipid lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004123
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207662
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004123
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207662
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -234,13 +234,13 @@
           value: "Longitudinal analyte file"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519827
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519827
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004064
@@ -257,11 +257,11 @@
           value: "Analysis derived (recalibrated, SI→mg/dL)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004064
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204867} * 38.67"
+          - Quantity:
+              populated_from: pht004064
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204867} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -278,11 +278,11 @@
           value: "Analysis derived (recalibrated, SI→mg/dL)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512244} * 38.67"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512244} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -299,11 +299,11 @@
           value: "Analysis derived (recalibrated, SI→mg/dL)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204765} * 38.67"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204765} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -320,11 +320,11 @@
           value: "Analysis derived (recalibrated, SI→mg/dL)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512074} * 38.67"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512074} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012813
@@ -341,11 +341,11 @@
           value: "Analysis derived (recalibrated, SI→mg/dL)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012813
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00511987} * 38.67"
+          - Quantity:
+              populated_from: pht012813
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00511987} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -362,8 +362,8 @@
           value: "Analysis derived (recalibrated, SI→mg/dL)"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00507329} * 38.67"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00507329} * 38.67"

--- a/priority_variables_transform/ARIC-ingest/hemat.yaml
+++ b/priority_variables_transform/ARIC-ingest/hemat.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004107
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207255
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004107
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207255
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207301
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207301
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004108
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207270
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207270
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206945
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206945
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -96,13 +96,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207289
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207289
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -117,13 +117,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294957
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294957
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -138,10 +138,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206944
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206944
+                unit:
+                  value: "%"

--- a/priority_variables_transform/ARIC-ingest/hemo.yaml
+++ b/priority_variables_transform/ARIC-ingest/hemo.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207288
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207288
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206942
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206942
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206943
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206943
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507167
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507167
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004108
@@ -96,13 +96,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207271
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207271
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -117,13 +117,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207300
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207300
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -138,13 +138,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294956
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294956
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004107
@@ -159,10 +159,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004107
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207256
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004107
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207256
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/ARIC-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/ARIC-ingest/hemo_a1c.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006427
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295245
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht006427
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295245
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -33,10 +33,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00506933
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00506933
+                unit:
+                  value: "%"

--- a/priority_variables_transform/ARIC-ingest/hip_circ.yaml
+++ b/priority_variables_transform/ARIC-ingest/hip_circ.yaml
@@ -16,13 +16,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004033
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203172
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004033
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203172
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004034
@@ -41,13 +41,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004034
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203178
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004034
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203178
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006419
@@ -66,13 +66,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006419
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294846
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006419
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294846
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004035
@@ -91,13 +91,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004035
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203189
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004035
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203189
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004032
@@ -116,10 +116,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004032
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203160
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004032
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203160
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/ARIC-ingest/hrtrt.yaml
+++ b/priority_variables_transform/ARIC-ingest/hrtrt.yaml
@@ -14,11 +14,11 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004194
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00210327} * 2"
+          - Quantity:
+              populated_from: pht004194
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00210327} * 2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004195
@@ -35,11 +35,11 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004195
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00210353} * 2"
+          - Quantity:
+              populated_from: pht004195
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00210353} * 2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004084
@@ -56,13 +56,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004084
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206256
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004084
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206256
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012824
@@ -81,13 +81,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012824
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00515687
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht012824
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00515687
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012822
@@ -106,13 +106,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012822
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00514035
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht012822
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00514035
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004088
@@ -129,13 +129,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004088
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206495
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004088
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206495
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004232
@@ -152,13 +152,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004232
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216047
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004232
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216047
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006415
@@ -177,13 +177,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006415
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294580
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht006415
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294580
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004085
@@ -200,13 +200,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004085
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206406
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004085
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206406
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004079
@@ -225,13 +225,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004079
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205915
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004079
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205915
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004087
@@ -248,13 +248,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206471
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206471
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004073
@@ -271,13 +271,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004073
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205564
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004073
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205564
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004076
@@ -294,13 +294,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004076
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205722
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004076
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205722
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004044
@@ -317,13 +317,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004044
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203507
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004044
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203507
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004083
@@ -340,13 +340,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004083
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206107
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004083
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206107
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004071
@@ -363,13 +363,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004071
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205414
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004071
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205414
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004074
@@ -386,13 +386,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205617
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205617
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004077
@@ -409,13 +409,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004077
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205779
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004077
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205779
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012819
@@ -432,13 +432,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012819
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512549
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht012819
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512549
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -455,13 +455,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206854
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206854
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004078
@@ -478,13 +478,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004078
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205820
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004078
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205820
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004072
@@ -501,13 +501,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004072
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205505
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004072
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205505
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004045
@@ -524,13 +524,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203655
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203655
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012820
@@ -547,13 +547,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012820
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512580
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht012820
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512580
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004085
@@ -570,13 +570,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004085
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206405
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004085
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206405
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004234
@@ -593,13 +593,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004234
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216881
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004234
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216881
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006414
@@ -618,13 +618,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006414
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294518
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht006414
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294518
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004075
@@ -641,13 +641,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004075
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205674
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004075
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205674
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004079
@@ -666,13 +666,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004079
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205900
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004079
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205900
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012823
@@ -691,13 +691,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012823
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00514861
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht012823
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00514861
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004045
@@ -714,13 +714,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203656
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203656
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004086
@@ -737,13 +737,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206444
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206444
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004233
@@ -760,13 +760,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004233
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216464
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004233
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216464
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004084
@@ -783,13 +783,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004084
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206255
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004084
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206255
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006436
@@ -806,13 +806,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006436
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295777
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht006436
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295777
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004044
@@ -829,13 +829,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004044
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203508
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004044
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203508
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004089
@@ -852,13 +852,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004089
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206521
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004089
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206521
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004080
@@ -875,13 +875,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004080
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205946
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004080
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205946
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012821
@@ -900,13 +900,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012821
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00513210
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht012821
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00513210
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004083
@@ -923,13 +923,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004083
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206106
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004083
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206106
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004231
@@ -946,10 +946,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004231
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00215630
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht004231
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00215630
+                unit:
+                  value: "{beats}/min"

--- a/priority_variables_transform/ARIC-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/ARIC-ingest/insulin_blood.yaml
@@ -12,11 +12,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004124
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00207683} * 6"
+          - Quantity:
+              populated_from: pht004124
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00207683} * 6"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004051
@@ -31,11 +31,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00203874} * 6"
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00203874} * 6"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -52,13 +52,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204739
-              unit:
-                value: "pmol/L"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204739
+                unit:
+                  value: "pmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444

--- a/priority_variables_transform/ARIC-ingest/ldl.yaml
+++ b/priority_variables_transform/ARIC-ingest/ldl.yaml
@@ -12,13 +12,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012511
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507552
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012511
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507552
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -35,13 +35,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519834
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519834
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -58,13 +58,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512071
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512071
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -81,13 +81,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519837
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519837
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -104,13 +104,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507332
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507332
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -127,13 +127,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519835
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519835
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444
@@ -148,13 +148,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296694
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296694
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004123
@@ -169,13 +169,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004123
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207664
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004123
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207664
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -192,13 +192,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512247
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512247
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004124
@@ -213,13 +213,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004124
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207680
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004124
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207680
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -236,13 +236,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519838
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519838
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -259,10 +259,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519836
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519836
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/ARIC-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/ARIC-ingest/lympho_ct.yaml
@@ -12,10 +12,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294954
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294954
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/ARIC-ingest/lympho_pct.yaml
+++ b/priority_variables_transform/ARIC-ingest/lympho_pct.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004107
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207261
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht004107
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207261
+                unit:
+                  value: "%{WBCs}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004108
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207276
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207276
+                unit:
+                  value: "%{WBCs}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -54,10 +54,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294964
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294964
+                unit:
+                  value: "%{WBCs}"

--- a/priority_variables_transform/ARIC-ingest/mch.yaml
+++ b/priority_variables_transform/ARIC-ingest/mch.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207302
-              unit:
-                value: "pg/{cell}"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207302
+                unit:
+                  value: "pg/{cell}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207290
-              unit:
-                value: "pg/{cell}"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207290
+                unit:
+                  value: "pg/{cell}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -54,10 +54,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294960
-              unit:
-                value: "pg/{cell}"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294960
+                unit:
+                  value: "pg/{cell}"

--- a/priority_variables_transform/ARIC-ingest/mchc.yaml
+++ b/priority_variables_transform/ARIC-ingest/mchc.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207303
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207303
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507204
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507204
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -54,10 +54,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294961
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294961
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/ARIC-ingest/mcv.yaml
+++ b/priority_variables_transform/ARIC-ingest/mcv.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507196
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507196
+                unit:
+                  value: "fL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004108
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207282
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207282
+                unit:
+                  value: "fL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207305
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207305
+                unit:
+                  value: "fL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207293
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207293
+                unit:
+                  value: "fL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -96,10 +96,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294959
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294959
+                unit:
+                  value: "fL"

--- a/priority_variables_transform/ARIC-ingest/mn_art_pres.yaml
+++ b/priority_variables_transform/ARIC-ingest/mn_art_pres.yaml
@@ -12,10 +12,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206929
-              unit:
-                value: "mm[Hg]"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206929
+                unit:
+                  value: "mm[Hg]"

--- a/priority_variables_transform/ARIC-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/monocyte_ncnc_bld.yaml
@@ -12,10 +12,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294968
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294968
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/ARIC-ingest/neutro_pct.yaml
+++ b/priority_variables_transform/ARIC-ingest/neutro_pct.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207274
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207274
+                unit:
+                  value: "%{WBCs}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004107
@@ -33,10 +33,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004107
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207259
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht004107
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207259
+                unit:
+                  value: "%{WBCs}"

--- a/priority_variables_transform/ARIC-ingest/nt_bnp.yaml
+++ b/priority_variables_transform/ARIC-ingest/nt_bnp.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204193
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204193
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204192
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204192
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206950
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206950
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296698
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296698
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -98,13 +98,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519839
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519839
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -119,13 +119,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206951
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206951
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -140,13 +140,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204190
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204190
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -161,13 +161,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206949
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206949
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004053
@@ -182,13 +182,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004053
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204194
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht004053
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204194
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -205,10 +205,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519840
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519840
+                unit:
+                  value: "pg/mL"

--- a/priority_variables_transform/ARIC-ingest/person.yaml
+++ b/priority_variables_transform/ARIC-ingest/person.yaml
@@ -18,124 +18,124 @@
           expr: 'case(({pht004049.phv00203832} is not None, {pht004049.phv00203832} * 365))'
         cause_of_death:
           class_derivations:
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00420047} is not None, "ICD10CM:" + str({pht004049.phv00420047})))'
-              order:
-                value: 1
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203820} is not None, "ICD10CM:" + str({pht004049.phv00203820})))'
-              order:
-                value: 2
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203822} is not None, "ICD10CM:" + str({pht004049.phv00203822})))'
-              order:
-                value: 3
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203824} is not None, "ICD10CM:" + str({pht004049.phv00203824})))'
-              order:
-                value: 4
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203826} is not None, "ICD10CM:" + str({pht004049.phv00203826})))'
-              order:
-                value: 5
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203828} is not None, "ICD10CM:" + str({pht004049.phv00203828})))'
-              order:
-                value: 6
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203829} is not None, "ICD10CM:" + str({pht004049.phv00203829})))'
-              order:
-                value: 7
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203821} is not None, "ICD10CM:" + str({pht004049.phv00203821})))'
-              order:
-                value: 8
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203823} is not None, "ICD10CM:" + str({pht004049.phv00203823})))'
-              order:
-                value: 9
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203825} is not None, "ICD10CM:" + str({pht004049.phv00203825})))'
-              order:
-                value: 10
-          - name: CauseOfDeath
-            populated_from: pht001440
-            joins:
-              pht004049:
-                source_key: phv00098579
-                lookup_key: phv00203839
-            slot_derivations:
-              cause:
-                expr: 'case(({pht004049.phv00203827} is not None, "ICD10CM:" + str({pht004049.phv00203827})))'
-              order:
-                value: 11
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00420047} is not None, "ICD10CM:" + str({pht004049.phv00420047})))'
+                order:
+                  value: 1
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203820} is not None, "ICD10CM:" + str({pht004049.phv00203820})))'
+                order:
+                  value: 2
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203822} is not None, "ICD10CM:" + str({pht004049.phv00203822})))'
+                order:
+                  value: 3
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203824} is not None, "ICD10CM:" + str({pht004049.phv00203824})))'
+                order:
+                  value: 4
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203826} is not None, "ICD10CM:" + str({pht004049.phv00203826})))'
+                order:
+                  value: 5
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203828} is not None, "ICD10CM:" + str({pht004049.phv00203828})))'
+                order:
+                  value: 6
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203829} is not None, "ICD10CM:" + str({pht004049.phv00203829})))'
+                order:
+                  value: 7
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203821} is not None, "ICD10CM:" + str({pht004049.phv00203821})))'
+                order:
+                  value: 8
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203823} is not None, "ICD10CM:" + str({pht004049.phv00203823})))'
+                order:
+                  value: 9
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203825} is not None, "ICD10CM:" + str({pht004049.phv00203825})))'
+                order:
+                  value: 10
+          - CauseOfDeath:
+              populated_from: pht001440
+              joins:
+                pht004049:
+                  source_key: phv00098579
+                  lookup_key: phv00203839
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht004049.phv00203827} is not None, "ICD10CM:" + str({pht004049.phv00203827})))'
+                order:
+                  value: 11

--- a/priority_variables_transform/ARIC-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/ARIC-ingest/platelet_ct.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294958
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294958
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004107
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004107
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207258
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004107
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207258
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004108
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207273
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207273
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507180
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507180
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -96,13 +96,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207294
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207294
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -117,10 +117,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207306
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207306
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/ARIC-ingest/pmv.yaml
+++ b/priority_variables_transform/ARIC-ingest/pmv.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507212
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507212
+                unit:
+                  value: "fL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -33,10 +33,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294963
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294963
+                unit:
+                  value: "fL"

--- a/priority_variables_transform/ARIC-ingest/potassium.yaml
+++ b/priority_variables_transform/ARIC-ingest/potassium.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203864
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203864
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012851
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012851
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519775
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht012851
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519775
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507115
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507115
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004052
@@ -75,10 +75,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004052
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203881
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht004052
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203881
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/ARIC-ingest/pr_ekg.yaml
+++ b/priority_variables_transform/ARIC-ingest/pr_ekg.yaml
@@ -14,13 +14,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004231
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00215631
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004231
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00215631
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004234
@@ -37,13 +37,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004234
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216882
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004234
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216882
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006436
@@ -60,13 +60,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006436
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295778
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht006436
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295778
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004232
@@ -83,13 +83,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004232
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216048
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004232
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216048
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004233
@@ -106,10 +106,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004233
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216465
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004233
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216465
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/ARIC-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/ARIC-ingest/qrs_ekg.yaml
@@ -14,13 +14,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004231
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00215632
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004231
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00215632
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004077
@@ -37,13 +37,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004077
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205780
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004077
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205780
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012823
@@ -62,13 +62,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012823
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00515036
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht012823
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00515036
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004072
@@ -85,13 +85,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004072
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205506
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004072
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205506
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006436
@@ -108,13 +108,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006436
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295779
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht006436
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295779
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012821
@@ -133,13 +133,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012821
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00513385
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht012821
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00513385
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004073
@@ -156,13 +156,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004073
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205565
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004073
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205565
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004074
@@ -179,13 +179,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205595
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205595
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004232
@@ -202,13 +202,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004232
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216049
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004232
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216049
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012824
@@ -227,13 +227,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012824
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00515862
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht012824
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00515862
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004233
@@ -250,13 +250,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004233
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216466
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004233
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216466
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004071
@@ -273,13 +273,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004071
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205437
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004071
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205437
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004078
@@ -296,13 +296,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004078
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205843
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004078
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205843
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004234
@@ -319,13 +319,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004234
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216883
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004234
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216883
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012822
@@ -344,13 +344,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012822
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00514210
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht012822
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00514210
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004075
@@ -367,13 +367,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004075
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205649
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004075
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205649
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004076
@@ -390,10 +390,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004076
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205723
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004076
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205723
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/ARIC-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/ARIC-ingest/qt_ekg.yaml
@@ -14,13 +14,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004231
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00215633
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004231
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00215633
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004234
@@ -37,13 +37,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004234
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216884
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004234
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216884
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004232
@@ -60,13 +60,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004232
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216050
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004232
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216050
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006436
@@ -83,13 +83,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006436
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00295780
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht006436
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00295780
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004233
@@ -106,13 +106,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004233
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00216467
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004233
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00216467
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004080
@@ -129,10 +129,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004080
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00205943
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht004080
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00205943
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/ARIC-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/ARIC-ingest/rdbld_ct.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294955
-              unit:
-                value: "10*6/uL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294955
+                unit:
+                  value: "10*6/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207287
-              unit:
-                value: "10*6/uL"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207287
+                unit:
+                  value: "10*6/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -54,10 +54,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207299
-              unit:
-                value: "10*6/uL"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207299
+                unit:
+                  value: "10*6/uL"

--- a/priority_variables_transform/ARIC-ingest/rdw.yaml
+++ b/priority_variables_transform/ARIC-ingest/rdw.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294962
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294962
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507208
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507208
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207292
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207292
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -75,10 +75,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207304
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207304
+                unit:
+                  value: "%"

--- a/priority_variables_transform/ARIC-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/ARIC-ingest/sleep_duration_daily.yaml
@@ -12,10 +12,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006479
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00298019
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht006479
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00298019
+                unit:
+                  value: "h"

--- a/priority_variables_transform/ARIC-ingest/sodium_blood.yaml
+++ b/priority_variables_transform/ARIC-ingest/sodium_blood.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206958
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206958
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206959
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206959
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012851
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012851
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519776
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht012851
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519776
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004051
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203863
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203863
+                unit:
+                  value: "mmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004052
@@ -96,10 +96,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004052
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203880
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht004052
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203880
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/ARIC-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/ARIC-ingest/sodium_intak.yaml
@@ -12,13 +12,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004139
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00208588
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht004139
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00208588
+                unit:
+                  value: "mg/d"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004036
@@ -33,13 +33,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004036
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203258
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht004036
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203258
+                unit:
+                  value: "mg/d"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004137
@@ -54,10 +54,10 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004137
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00208361
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht004137
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00208361
+                unit:
+                  value: "mg/d"

--- a/priority_variables_transform/ARIC-ingest/spirometry.yaml
+++ b/priority_variables_transform/ARIC-ingest/spirometry.yaml
@@ -8,114 +8,114 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00208835}) + ":ARIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004142
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004142
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00208817
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht004142
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004142
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00208819
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht004142
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011505"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004142
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00208824
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht004147
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004147
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht004147.phv00209100}'
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht004147
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3022891"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004147
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht004147.phv00209102}'
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht004147
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3024594"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004147
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht004147.phv00209109}'
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht004142
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004142
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00208817
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht004142
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004142
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00208819
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht004142
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011505"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004142
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00208824
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht004147
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004147
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht004147.phv00209100}'
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht004147
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3022891"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004147
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht004147.phv00209102}'
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht004147
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3024594"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004147
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht004147.phv00209109}'
+                        unit:
+                          value: "%"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht012835
@@ -126,102 +126,102 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00516587}) + ":ARIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht012835
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00516591} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012835
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00516615
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht012835
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00516591} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012835
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00516617
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht012835
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011505"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00516591} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012835
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00516622
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht004148
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004148
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht004148.phv00209121}'
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht004148
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3024594"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004148
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht004148.phv00209118}'
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht012835
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00516591} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012835
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00516615
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht012835
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00516591} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012835
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00516617
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht012835
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011505"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00516591} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012835
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00516622
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht004148
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004148
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht004148.phv00209121}'
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht004148
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3024594"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004148
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht004148.phv00209118}'
+                        unit:
+                          value: "%"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006467
@@ -232,166 +232,166 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00297546}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006467
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00297561} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006467
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297568} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006467
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00297561} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006467
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297572} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006467
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00297561} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006467
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297579} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006467
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3022891"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00297561} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006467
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297580} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006467
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3024594"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00297561} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006467
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00297582
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht012814
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3005600"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{pht012814.phv00512050} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012814
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht012814.phv00512107}'
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht012814
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011708"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{pht012814.phv00512050} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012814
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht012814.phv00512108}'
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht012814
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4196583"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Pre-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{pht012814.phv00512050} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012814
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht012814.phv00512109}'
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht006467
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00297561} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006467
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297568} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006467
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00297561} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006467
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297572} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006467
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00297561} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006467
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297579} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006467
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3022891"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00297561} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006467
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297580} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006467
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3024594"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00297561} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006467
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00297582
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht012814
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3005600"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{pht012814.phv00512050} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012814
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht012814.phv00512107}'
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht012814
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011708"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{pht012814.phv00512050} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012814
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht012814.phv00512108}'
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht012814
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4196583"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Pre-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{pht012814.phv00512050} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012814
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht012814.phv00512109}'
+                        unit:
+                          value: "%"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006468
@@ -402,163 +402,163 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00297599}) + ":ARIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006468
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00511022} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006468
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297614} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006468
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00511022} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006468
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297618} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006468
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00511022} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006468
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297625} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006468
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3022891"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00511022} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006468
-                  slot_derivations:
-                    value_decimal:
-                      expr: "{phv00297626} * 0.001"
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht006468
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3024594"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00511022} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006468
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00297628
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht012814
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3005600"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00512050} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012814
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht012814.phv00512107}'
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht012814
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011708"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00512050} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012814
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht012814.phv00512108}'
-                    unit:
-                      value: "%"
-          - name: MeasurementObservation
-            populated_from: pht012814
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4196583"
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Post-bronchodilator, spirometry
-              age_at_observation:
-                expr: '{phv00512050} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht012814
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{pht012814.phv00512109}'
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht006468
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00511022} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006468
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297614} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006468
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00511022} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006468
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297618} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006468
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00511022} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006468
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297625} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006468
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3022891"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00511022} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006468
+                      slot_derivations:
+                        value_decimal:
+                          expr: "{phv00297626} * 0.001"
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht006468
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3024594"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00511022} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006468
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00297628
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht012814
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3005600"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00512050} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012814
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht012814.phv00512107}'
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht012814
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011708"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00512050} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012814
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht012814.phv00512108}'
+                        unit:
+                          value: "%"
+          - MeasurementObservation:
+              populated_from: pht012814
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4196583"
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Post-bronchodilator, spirometry
+                age_at_observation:
+                  expr: '{phv00512050} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht012814
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{pht012814.phv00512109}'
+                        unit:
+                          value: "%"

--- a/priority_variables_transform/ARIC-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/tot_chol_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519812
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519812
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444
@@ -35,13 +35,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296691
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296691
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012511
@@ -56,13 +56,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012511
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507549
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012511
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507549
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004121
@@ -77,13 +77,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207635
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207635
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -100,13 +100,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519814
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519814
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -123,13 +123,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519813
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519813
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -146,13 +146,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519816
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519816
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -169,13 +169,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519815
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519815
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004064
@@ -192,13 +192,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004064
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204875} * 38.67"
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004064
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204875} * 38.67"
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -215,13 +215,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512073} * 38.67"
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512073} * 38.67"
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -238,13 +238,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00507328} * 38.67"
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00507328} * 38.67"
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012813
@@ -261,11 +261,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012813
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00511986} * 38.67"
+          - Quantity:
+              populated_from: pht012813
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00511986} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -282,11 +282,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204735} * 38.67"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204735} * 38.67"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -303,8 +303,8 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512243} * 38.67"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512243} * 38.67"

--- a/priority_variables_transform/ARIC-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/ARIC-ingest/triglyc_bld.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004123
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207661
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004123
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207661
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004121
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207636
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207636
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012511
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012511
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507551
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht012511
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507551
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004124
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004124
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207676
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004124
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207676
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004122
@@ -96,13 +96,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004122
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207649
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht004122
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207649
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006444
@@ -117,13 +117,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296692
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296692
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -140,11 +140,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512076} * 88.57"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512076} * 88.57"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012813
@@ -161,11 +161,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012813
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00511989} * 88.57"
+          - Quantity:
+              populated_from: pht012813
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00511989} * 88.57"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -182,11 +182,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204738} * 88.57"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204738} * 88.57"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012504
@@ -203,11 +203,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00507331} * 88.57"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00507331} * 88.57"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004064
@@ -224,11 +224,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004064
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00204877} * 88.57"
+          - Quantity:
+              populated_from: pht004064
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00204877} * 88.57"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -245,8 +245,8 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00512246} * 88.57"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00512246} * 88.57"

--- a/priority_variables_transform/ARIC-ingest/troponin.yaml
+++ b/priority_variables_transform/ARIC-ingest/troponin.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006444
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00296697
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht006444
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00296697
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206956
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206956
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206954
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206954
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206953
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206953
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -96,13 +96,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206957
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206957
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -117,13 +117,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206952
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206952
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004102
@@ -138,13 +138,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004102
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206955
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht004102
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206955
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -161,13 +161,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519841
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519841
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012853
@@ -184,10 +184,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00519842
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht012853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00519842
+                unit:
+                  value: "ng/mL"

--- a/priority_variables_transform/ARIC-ingest/vege_serving.yaml
+++ b/priority_variables_transform/ARIC-ingest/vege_serving.yaml
@@ -12,23 +12,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205297
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205297
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -43,23 +43,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205295
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205295
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -74,23 +74,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205298
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205298
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -105,23 +105,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205080
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205080
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -136,23 +136,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205205
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205205
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -167,23 +167,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205075
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205075
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -198,23 +198,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205079
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205079
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -229,23 +229,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205084
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205084
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -260,23 +260,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205074
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205074
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -291,23 +291,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205301
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205301
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -322,23 +322,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205203
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205203
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -353,23 +353,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205197
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205197
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -384,23 +384,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205199
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205199
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -415,23 +415,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205303
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205303
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -446,23 +446,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205198
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205198
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -477,23 +477,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205296
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205296
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -508,23 +508,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205081
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205081
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -539,23 +539,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205083
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205083
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -570,23 +570,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205078
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205078
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -601,23 +601,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205304
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205304
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -632,23 +632,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205077
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205077
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -663,23 +663,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205300
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205300
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -694,23 +694,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205076
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205076
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -725,23 +725,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205201
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205201
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -756,23 +756,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205200
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205200
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -787,23 +787,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205195
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205195
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -818,23 +818,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205294
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205294
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -849,23 +849,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205202
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205202
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -880,23 +880,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205299
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205299
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -911,23 +911,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205204
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205204
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004070
@@ -942,23 +942,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004070
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205302
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004070
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205302
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004068
@@ -973,23 +973,23 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004068
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205082
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004068
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205082
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004069
@@ -1004,20 +1004,20 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004069
-            slot_derivations:
-              value_concept:
-                populated_from: phv00205196
-                value_mappings:
-                  'A': 42
-                  'B': 35
-                  'C': 17.5
-                  'D': 7
-                  'E': 5.5
-                  'F': 3
-                  'G': 1
-                  'H': 0.5
-                  'I': 0
-              unit: 
-                value: "{servings}/wk"
+          - Quantity:
+              populated_from: pht004069
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00205196
+                  value_mappings:
+                    'A': 42
+                    'B': 35
+                    'C': 17.5
+                    'D': 7
+                    'E': 5.5
+                    'F': 3
+                    'G': 1
+                    'H': 0.5
+                    'I': 0
+                unit: 
+                  value: "{servings}/wk"

--- a/priority_variables_transform/ARIC-ingest/waist_circ.yaml
+++ b/priority_variables_transform/ARIC-ingest/waist_circ.yaml
@@ -16,13 +16,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004034
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203177
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004034
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203177
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004033
@@ -41,13 +41,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004033
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203171
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004033
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203171
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004035
@@ -66,13 +66,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004035
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203188
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004035
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203188
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004032
@@ -91,13 +91,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004032
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203159
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht004032
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203159
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006419
@@ -116,10 +116,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006419
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294845
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006419
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294845
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/ARIC-ingest/waist_hip.yaml
+++ b/priority_variables_transform/ARIC-ingest/waist_hip.yaml
@@ -14,13 +14,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012504
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507315
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht012504
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507315
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012814
@@ -37,13 +37,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512059
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht012814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512059
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012815
@@ -60,13 +60,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00512232
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht012815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00512232
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012813
@@ -83,13 +83,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012813
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00511974
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht012813
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00511974
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004063
@@ -106,13 +106,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004063
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204723
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht004063
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204723
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004064
@@ -129,10 +129,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004064
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00204872
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht004064
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00204872
+                unit:
+                  value: "{ratio}"

--- a/priority_variables_transform/ARIC-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/ARIC-ingest/whtbld_ct.yaml
@@ -12,13 +12,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004108
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207272
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004108
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207272
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006422
@@ -33,13 +33,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006422
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00294954
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht006422
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00294954
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004107
@@ -54,13 +54,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004107
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207257
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004107
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207257
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004110
@@ -75,13 +75,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004110
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207298
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004110
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207298
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004109
@@ -96,13 +96,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004109
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00207286
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht004109
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00207286
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012503
@@ -117,10 +117,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012503
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00507184
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht012503
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00507184
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/ARIC-ingest/willeb_fac.yaml
+++ b/priority_variables_transform/ARIC-ingest/willeb_fac.yaml
@@ -12,10 +12,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004098
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00206654
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht004098
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00206654
+                unit:
+                  value: "%{normal}"

--- a/priority_variables_transform/CARDIA-ingest/albumin_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/albumin_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001557
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112409
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht001557
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112409
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/CARDIA-ingest/albumin_creatinine.yaml
+++ b/priority_variables_transform/CARDIA-ingest/albumin_creatinine.yaml
@@ -14,13 +14,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001849
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120679
-              unit:
-                value: "mg/g"
+          - Quantity:
+              populated_from: pht001849
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120679
+                unit:
+                  value: "mg/g"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001803
@@ -37,10 +37,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001803
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119620
-              unit:
-                value: "mg/g"
+          - Quantity:
+              populated_from: pht001803
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119620
+                unit:
+                  value: "mg/g"

--- a/priority_variables_transform/CARDIA-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/CARDIA-ingest/albumin_urine.yaml
@@ -14,15 +14,15 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001849
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120678
-                expr: "None if str({phv00120678}) in ('M', 'L', 'H', '') else float({phv00120678}) * 10"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht001849
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120678
+                  expr: "None if str({phv00120678}) in ('M', 'L', 'H', '') else float({phv00120678}) * 10"
+                unit:
+                  value: "mg/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001803
@@ -39,12 +39,12 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001803
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119618
-                expr: "None if str({phv00119618}) in ('M', 'L', 'H', '') else float({phv00119618}) * 10"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht001803
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119618
+                  expr: "None if str({phv00119618}) in ('M', 'L', 'H', '') else float({phv00119618}) * 10"
+                unit:
+                  value: "mg/L"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/alcohol_servings.yaml
+++ b/priority_variables_transform/CARDIA-ingest/alcohol_servings.yaml
@@ -14,13 +14,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001568
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112962
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht001568
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112962
+                unit:
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001568
@@ -37,13 +37,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001568
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112961
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht001568
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112961
+                unit:
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001568
@@ -60,13 +60,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001568
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112960
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht001568
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112960
+                unit:
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001568
@@ -81,13 +81,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001568
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00112960} + {phv00112961} + {phv00112962}"
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001568
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00112960} + {phv00112961} + {phv00112962}"
+                unit:
+                  value: '{servings}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001655
@@ -102,13 +102,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001655
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00115417} + {phv00115418} + {phv00115419}"
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001655
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00115417} + {phv00115418} + {phv00115419}"
+                unit:
+                  value: '{servings}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001760
@@ -123,13 +123,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001760
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00118418} + {phv00118419} + {phv00118420}"
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001760
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00118418} + {phv00118419} + {phv00118420}"
+                unit:
+                  value: '{servings}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001600
@@ -144,13 +144,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001600
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00114307} + {phv00114308} + {phv00114309}"
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001600
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00114307} + {phv00114308} + {phv00114309}"
+                unit:
+                  value: '{servings}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001714
@@ -165,13 +165,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001714
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00116947} + {phv00116948} + {phv00116949}"
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001714
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00116947} + {phv00116948} + {phv00116949}"
+                unit:
+                  value: '{servings}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001565
@@ -186,13 +186,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001565
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00112862} + {phv00112863} + {phv00112864} + {phv00112865}) * 7
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001565
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00112862} + {phv00112863} + {phv00112864} + {phv00112865}) * 7
+                unit:
+                  value: '{servings}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001712
@@ -207,10 +207,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001712
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00116914} + {phv00116915} + {phv00116916} + {phv00116917}) * 7
-              unit:
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001712
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00116914} + {phv00116915} + {phv00116916} + {phv00116917}) * 7
+                unit:
+                  value: '{servings}/wk'

--- a/priority_variables_transform/CARDIA-ingest/ast_sgot.yaml
+++ b/priority_variables_transform/CARDIA-ingest/ast_sgot.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001557
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112406
-              unit:
-                value: "[IU]/L"
+          - Quantity:
+              populated_from: pht001557
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112406
+                unit:
+                  value: "[IU]/L"

--- a/priority_variables_transform/CARDIA-ingest/basophil_ncnc_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/basophil_ncnc_bld.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190611}) == 'M' else float({phv00190611})"
-              unit:
-                value: "10*3/uL"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190611}) == 'M' else float({phv00190611})"
+                unit:
+                  value: "10*3/uL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/CARDIA-ingest/bdy_hgt.yaml
@@ -16,15 +16,15 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001781
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00118957
-                expr: "None if str({phv00118957}) in ('M', '') else float({phv00118957}) * 2.54"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht001781
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00118957
+                  expr: "None if str({phv00118957}) in ('M', '') else float({phv00118957}) * 2.54"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001626
@@ -43,15 +43,15 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001626
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114609
-                expr: "None if str({phv00114609}) in ('M', '') else float({phv00114609}) * 2.54"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht001626
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114609
+                  expr: "None if str({phv00114609}) in ('M', '') else float({phv00114609}) * 2.54"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001667
@@ -70,15 +70,15 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001667
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115704
-                expr: "None if str({phv00115704}) in ('M', '') else float({phv00115704}) * 2.54"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht001667
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115704
+                  expr: "None if str({phv00115704}) in ('M', '') else float({phv00115704}) * 2.54"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001795
@@ -97,15 +97,15 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001795
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119506
-                expr: "None if str({phv00119506}) in ('M', '') else float({phv00119506}) * 2.54"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht001795
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119506
+                  expr: "None if str({phv00119506}) in ('M', '') else float({phv00119506}) * 2.54"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001857
@@ -124,13 +124,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001857
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120994
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001857
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120994
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001671
@@ -149,13 +149,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001671
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115856
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001671
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115856
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001632
@@ -174,13 +174,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001632
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114829
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001632
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114829
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001706
@@ -199,13 +199,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001706
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116480
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001706
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116480
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -224,13 +224,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117230
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117230
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001755
@@ -249,13 +249,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001755
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00118136
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001755
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00118136
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -274,13 +274,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119093
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119093
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -299,13 +299,13 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113634
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113634
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001756
@@ -324,10 +324,10 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001756
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00118250
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001756
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00118250
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/CARDIA-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/CARDIA-ingest/bdy_wgt.yaml
@@ -16,14 +16,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001671
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00115857}) == 'M' else float({phv00115857}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001671
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00115857}) == 'M' else float({phv00115857}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001790
@@ -42,14 +42,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001790
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00119262}) == 'M' else float({phv00119262}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001790
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00119262}) == 'M' else float({phv00119262}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001749
@@ -68,14 +68,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001749
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117926}) == 'M' else float({phv00117926}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001749
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117926}) == 'M' else float({phv00117926}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001725
@@ -94,14 +94,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001725
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117443}) == 'M' else float({phv00117443}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001725
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117443}) == 'M' else float({phv00117443}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -120,14 +120,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00119094}) == 'M' else float({phv00119094}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00119094}) == 'M' else float({phv00119094}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001857
@@ -146,14 +146,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001857
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120996}) == 'M' else float({phv00120996}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001857
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120996}) == 'M' else float({phv00120996}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -172,14 +172,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117231}) == 'M' else float({phv00117231}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117231}) == 'M' else float({phv00117231}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001795
@@ -198,14 +198,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001795
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00119573}) == 'M' else float({phv00119573}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001795
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00119573}) == 'M' else float({phv00119573}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001725
@@ -224,14 +224,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001725
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117442}) == 'M' else float({phv00117442}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001725
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117442}) == 'M' else float({phv00117442}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001632
@@ -250,14 +250,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001632
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00114831}) == 'M' else float({phv00114831}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001632
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00114831}) == 'M' else float({phv00114831}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001790
@@ -276,14 +276,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001790
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00119261}) == 'M' else float({phv00119261}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001790
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00119261}) == 'M' else float({phv00119261}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -302,14 +302,14 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00113635}) == 'M' else float({phv00113635}) * 0.45359237"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00113635}) == 'M' else float({phv00113635}) * 0.45359237"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001706
@@ -328,10 +328,10 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001706
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116479
-              unit:
-                value: "kg"
+          - Quantity:
+              populated_from: pht001706
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116479
+                unit:
+                  value: "kg"

--- a/priority_variables_transform/CARDIA-ingest/bilirubin_tot.yaml
+++ b/priority_variables_transform/CARDIA-ingest/bilirubin_tot.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001557
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112405
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001557
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112405
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/CARDIA-ingest/blood_pressure.yaml
@@ -8,46 +8,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00112462}) + ":CARDIA YEAR 0")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001560
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              method_type:
-                value: "Seated random-zero average"
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: "Right arm"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001560
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00112494
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001560
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              method_type:
-                value: "Seated random-zero average"
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: "Right arm"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001560
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00112495
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001560
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                method_type:
+                  value: "Seated random-zero average"
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: "Right arm"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001560
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00112494
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001560
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                method_type:
+                  value: "Seated random-zero average"
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: "Right arm"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001560
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00112495
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001650
@@ -58,47 +58,47 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00115203}) + ":CARDIA YEAR 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001650
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              # age_at_observation:
-                # expr: "{nan} * 365"
-              method_type:
-                value: "Seated random-zero average"
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: "Right arm"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001650
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115205
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001650
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              # age_at_observation:
-                # expr: "{nan} * 365"
-              method_type:
-                value: "Seated random-zero average"
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: "Right arm"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001650
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115204
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001650
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                # age_at_observation:
+                  # expr: "{nan} * 365"
+                method_type:
+                  value: "Seated random-zero average"
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: "Right arm"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001650
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115205
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001650
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                # age_at_observation:
+                  # expr: "{nan} * 365"
+                method_type:
+                  value: "Seated random-zero average"
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: "Right arm"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001650
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115204
+                        unit:
+                          value: "mm[Hg]"

--- a/priority_variables_transform/CARDIA-ingest/bmi.yaml
+++ b/priority_variables_transform/CARDIA-ingest/bmi.yaml
@@ -12,14 +12,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00113661}) == 'M' else float({phv00113661})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00113661}) == 'M' else float({phv00113661})"
+                unit:
+                  value: "kg/m2"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001671
@@ -34,14 +34,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001671
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00115869}) == 'M' else float({phv00115869})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht001671
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00115869}) == 'M' else float({phv00115869})"
+                unit:
+                  value: "kg/m2"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -56,14 +56,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117249}) == 'M' else float({phv00117249})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117249}) == 'M' else float({phv00117249})"
+                unit:
+                  value: "kg/m2"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -78,14 +78,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00119120}) == 'M' else float({phv00119120})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00119120}) == 'M' else float({phv00119120})"
+                unit:
+                  value: "kg/m2"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001857
@@ -100,14 +100,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001857
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00121003}) == 'M' else float({phv00121003})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht001857
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00121003}) == 'M' else float({phv00121003})"
+                unit:
+                  value: "kg/m2"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003298
@@ -124,14 +124,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190563}) == 'M' else float({phv00190563})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190563}) == 'M' else float({phv00190563})"
+                unit:
+                  value: "kg/m2"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001632
@@ -146,11 +146,11 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001632
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00114862}) == 'M' else float({phv00114862})"
-              unit:
-                value: "kg/m2"
-                range: string
+          - Quantity:
+              populated_from: pht001632
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00114862}) == 'M' else float({phv00114862})"
+                unit:
+                  value: "kg/m2"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/bnp.yaml
+++ b/priority_variables_transform/CARDIA-ingest/bnp.yaml
@@ -12,11 +12,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001674
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00115951}) == 'M' else float({phv00115951})"
-              unit:
-                value: "pg/mL"
-                range: string
+          - Quantity:
+              populated_from: pht001674
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00115951}) == 'M' else float({phv00115951})"
+                unit:
+                  value: "pg/mL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/cac_score.yaml
+++ b/priority_variables_transform/CARDIA-ingest/cac_score.yaml
@@ -14,14 +14,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190613}) == 'M' else float({phv00190613})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190613}) == 'M' else float({phv00190613})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001754
@@ -36,14 +36,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001754
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00118019}) == 'M' else float({phv00118019})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001754
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00118019}) == 'M' else float({phv00118019})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001854
@@ -58,14 +58,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001854
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120784}) == 'M' else float({phv00120784})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001854
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120784}) == 'M' else float({phv00120784})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001854
@@ -80,14 +80,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001854
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120785}) == 'M' else float({phv00120785})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001854
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120785}) == 'M' else float({phv00120785})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001854
@@ -102,14 +102,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001854
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120786}) == 'M' else float({phv00120786})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001854
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120786}) == 'M' else float({phv00120786})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001854
@@ -124,14 +124,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001854
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120787}) == 'M' else float({phv00120787})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001854
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120787}) == 'M' else float({phv00120787})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001854
@@ -146,14 +146,14 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001854
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120812}) == 'M' else float({phv00120812})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001854
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120812}) == 'M' else float({phv00120812})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001854
@@ -168,11 +168,11 @@
           value: "computed tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001854
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00120813}) == 'M' else float({phv00120813})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001854
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00120813}) == 'M' else float({phv00120813})"
+                unit:
+                  value: "{score}"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/cesd_score.yaml
+++ b/priority_variables_transform/CARDIA-ingest/cesd_score.yaml
@@ -12,14 +12,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001676
-            slot_derivations:
-              value_integer:
-                expr: "None if str({phv00116000}) == 'M' else int({phv00116000})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001676
+              slot_derivations:
+                value_integer:
+                  expr: "None if str({phv00116000}) == 'M' else int({phv00116000})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001788
@@ -34,14 +34,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001788
-            slot_derivations:
-              value_integer:
-                expr: "None if str({phv00119231}) == 'M' else int({phv00119231})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001788
+              slot_derivations:
+                value_integer:
+                  expr: "None if str({phv00119231}) == 'M' else int({phv00119231})"
+                unit:
+                  value: "{score}"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001824
@@ -56,11 +56,11 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001824
-            slot_derivations:
-              value_integer:
-                expr: "None if str({phv00120325}) == 'M' else int({phv00120325})"
-              unit:
-                value: "{score}"
-                range: string
+          - Quantity:
+              populated_from: pht001824
+              slot_derivations:
+                value_integer:
+                  expr: "None if str({phv00120325}) == 'M' else int({phv00120325})"
+                unit:
+                  value: "{score}"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/creat_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/creat_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001753
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00118008
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001753
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00118008
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001807
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001807
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119692
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001807
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119692
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/creat_urin.yaml
+++ b/priority_variables_transform/CARDIA-ingest/creat_urin.yaml
@@ -14,13 +14,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001849
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120675
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001849
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120675
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001803
@@ -37,13 +37,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001803
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119619
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001803
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119619
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001852
@@ -60,12 +60,12 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001852
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120751
-                expr: "None if str({phv00120751}) in ('M', 'L', 'H', '') else float({phv00120751}) * 100"
-              unit:
-                value: "mg/dL"
-                range: string
+          - Quantity:
+              populated_from: pht001852
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120751
+                  expr: "None if str({phv00120751}) in ('M', 'L', 'H', '') else float({phv00120751}) * 100"
+                unit:
+                  value: "mg/dL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/crp.yaml
+++ b/priority_variables_transform/CARDIA-ingest/crp.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120758
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht001853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120758
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001853
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001853
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120759
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht001853
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120759
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001705
@@ -60,10 +60,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001705
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116475
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht001705
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116475
+                unit:
+                  value: "mg/L"

--- a/priority_variables_transform/CARDIA-ingest/eosinophil_ncnc_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/eosinophil_ncnc_bld.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190610}) == 'M' else float({phv00190610})"
-              unit:
-                value: "10*3/uL"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190610}) == 'M' else float({phv00190610})"
+                unit:
+                  value: "10*3/uL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/factor_7.yaml
+++ b/priority_variables_transform/CARDIA-ingest/factor_7.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001739
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117556
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001739
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117556
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001694
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001694
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116361
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001694
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116361
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001739
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001739
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117563
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001739
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117563
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001642
@@ -83,10 +83,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001642
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115090
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001642
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115090
+                unit:
+                  value: "%{normal}"

--- a/priority_variables_transform/CARDIA-ingest/factor_8.yaml
+++ b/priority_variables_transform/CARDIA-ingest/factor_8.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001739
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00117557} * 0.01"
+          - Quantity:
+              populated_from: pht001739
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00117557} * 0.01"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001694
@@ -35,8 +35,8 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001694
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00116362} * 0.01"
+          - Quantity:
+              populated_from: pht001694
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00116362} * 0.01"

--- a/priority_variables_transform/CARDIA-ingest/fam_income.yaml
+++ b/priority_variables_transform/CARDIA-ingest/fam_income.yaml
@@ -15,26 +15,26 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001653
-            slot_derivations:
-              value_concept:
-                populated_from: phv00115383
-                value_mappings:
-                  '0': No response
-                  '1': Less than $5,000
-                  '2': $5,000 through $11,999
-                  '3': $12,000 through $15,999
-                  '4': $16,000 through $24,999
-                  '5': $25,000 through $34,999
-                  '6': $35,000 through $49,999
-                  '7': $50,000 through $74,999
-                  '8': $75,000 and greater
-                  '9': Don't know
-                  '10': No response
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001653
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00115383
+                  value_mappings:
+                    '0': No response
+                    '1': Less than $5,000
+                    '2': $5,000 through $11,999
+                    '3': $12,000 through $15,999
+                    '4': $16,000 through $24,999
+                    '5': $25,000 through $34,999
+                    '6': $35,000 through $49,999
+                    '7': $50,000 through $74,999
+                    '8': $75,000 and greater
+                    '9': Don't know
+                    '10': No response
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001708
@@ -52,26 +52,26 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001708
-            slot_derivations:
-              value_concept:
-                populated_from: phv00116607
-                value_mappings:
-                  '0': No response
-                  '1': Less than $5,000
-                  '2': $5,000 through $11,999
-                  '3': $12,000 through $15,999
-                  '4': $16,000 through $24,999
-                  '5': $25,000 through $34,999
-                  '6': $35,000 through $49,999
-                  '7': $50,000 through $74,999
-                  '8': $75,000 and greater
-                  '9': Don't know
-                  'M': None
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001708
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00116607
+                  value_mappings:
+                    '0': No response
+                    '1': Less than $5,000
+                    '2': $5,000 through $11,999
+                    '3': $12,000 through $15,999
+                    '4': $16,000 through $24,999
+                    '5': $25,000 through $34,999
+                    '6': $35,000 through $49,999
+                    '7': $50,000 through $74,999
+                    '8': $75,000 and greater
+                    '9': Don't know
+                    'M': None
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001758
@@ -89,25 +89,25 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001758
-            slot_derivations:
-              value_concept:
-                populated_from: phv00118339
-                value_mappings:
-                  '0': No response
-                  '1': Less than $5,000
-                  '2': $5,000 through $11,999
-                  '3': $12,000 through $15,999
-                  '4': $16,000 through $24,999
-                  '5': $25,000 through $34,999
-                  '6': $35,000 through $49,999
-                  '7': $50,000 through $74,999
-                  '8': $75,000 and greater
-                  '9': Don't know
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001758
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00118339
+                  value_mappings:
+                    '0': No response
+                    '1': Less than $5,000
+                    '2': $5,000 through $11,999
+                    '3': $12,000 through $15,999
+                    '4': $16,000 through $24,999
+                    '5': $25,000 through $34,999
+                    '6': $35,000 through $49,999
+                    '7': $50,000 through $74,999
+                    '8': $75,000 and greater
+                    '9': Don't know
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001855
@@ -125,23 +125,23 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001855
-            slot_derivations:
-              value_concept:
-                expr: "case(({phv00120947} != None, str({phv00120947})))"
-                value_mappings:
-                  '1': Less than $5,000
-                  '2': $5,000 through $11,999
-                  '3': $12,000 through $15,999
-                  '4': $16,000 through $24,999
-                  '5': $25,000 through $34,999
-                  '6': $35,000 through $49,999
-                  '7': $50,000 through $74,999
-                  '8': Don't know
-                  '9': No response
-                  '10': $75,000 through $99,999
-                  '11': $100,000 and greater
-              unit:
-                expr: "case(({phv00120947} != None, 'USD'))"
-                range: string
+          - Quantity:
+              populated_from: pht001855
+              slot_derivations:
+                value_concept:
+                  expr: "case(({phv00120947} != None, str({phv00120947})))"
+                  value_mappings:
+                    '1': Less than $5,000
+                    '2': $5,000 through $11,999
+                    '3': $12,000 through $15,999
+                    '4': $16,000 through $24,999
+                    '5': $25,000 through $34,999
+                    '6': $35,000 through $49,999
+                    '7': $50,000 through $74,999
+                    '8': Don't know
+                    '9': No response
+                    '10': $75,000 through $99,999
+                    '11': $100,000 and greater
+                unit:
+                  expr: "case(({phv00120947} != None, 'USD'))"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/fast_gluc_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001845
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120661
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001845
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120661
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001799
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001799
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119598
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001799
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119598
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/fibrin.yaml
+++ b/priority_variables_transform/CARDIA-ingest/fibrin.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001692
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116349
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001692
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116349
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001694
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001694
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116363
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001694
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116363
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001736
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001736
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117550
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001736
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117550
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001739
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001739
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117558
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001739
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117558
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001642
@@ -106,10 +106,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001642
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115091
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001642
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115091
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/CARDIA-ingest/fruit_serving.yaml
@@ -12,13 +12,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001565
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00112712} + {phv00112713} + {phv00112714} + {phv00112715} + {phv00112716}) * 7
-              unit: 
-                value: '{#}/wk'
+          - Quantity:
+              populated_from: pht001565
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00112712} + {phv00112713} + {phv00112714} + {phv00112715} + {phv00112716}) * 7
+                unit: 
+                  value: '{#}/wk'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001712
@@ -33,13 +33,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001712
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00116764} + {phv00116765} + {phv00116766} + {phv00116767} + {phv00116768}) * 7
-              unit: 
-                value: '{#}/wk' 
+          - Quantity:
+              populated_from: pht001712
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00116764} + {phv00116765} + {phv00116766} + {phv00116767} + {phv00116768}) * 7
+                unit: 
+                  value: '{#}/wk' 
 
 - class_derivations:
     MeasurementObservation:
@@ -55,13 +55,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001713
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116930
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht001713
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116930
+                unit: 
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001566
@@ -76,10 +76,10 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001566
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112878
-              unit: 
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht001566
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112878
+                unit: 
+                  value: "{#}/wk"

--- a/priority_variables_transform/CARDIA-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/glucose_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001557
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112414
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001557
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112414
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001737
@@ -37,11 +37,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001737
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117552
-              unit:
-                value: "mg/dL"
-                range: string
+          - Quantity:
+              populated_from: pht001737
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117552
+                unit:
+                  value: "mg/dL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/hdl.yaml
+++ b/priority_variables_transform/CARDIA-ingest/hdl.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001848
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120670
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001848
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120670
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001588
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001588
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113702
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001588
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113702
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001695
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001695
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116371
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001695
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116371
+                unit:
+                  value: "mg/dL"
 
 - class_derivations:
     MeasurementObservation:
@@ -84,13 +84,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117572
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117572
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001802
@@ -107,10 +107,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119613
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119613
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/hemat.yaml
+++ b/priority_variables_transform/CARDIA-ingest/hemat.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112689
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112689
+                unit:
+                  value: "%"

--- a/priority_variables_transform/CARDIA-ingest/hemo.yaml
+++ b/priority_variables_transform/CARDIA-ingest/hemo.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112688
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112688
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/CARDIA-ingest/hip_circ.yaml
+++ b/priority_variables_transform/CARDIA-ingest/hip_circ.yaml
@@ -18,13 +18,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001671
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115860
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001671
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115860
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -45,13 +45,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117248
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117248
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -72,13 +72,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119118
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119118
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -99,13 +99,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113648
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113648
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -126,13 +126,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113649
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113649
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -153,13 +153,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119098
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119098
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -180,13 +180,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117236
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117236
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -207,13 +207,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117235
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117235
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -234,13 +234,13 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113658
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113658
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -261,10 +261,10 @@
           value: "Hip"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119097
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119097
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/CARDIA-ingest/hrtrt.yaml
+++ b/priority_variables_transform/CARDIA-ingest/hrtrt.yaml
@@ -12,13 +12,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114016
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114016
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -33,13 +33,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114024
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114024
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -54,13 +54,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114012
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114012
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -75,13 +75,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117848
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117848
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -96,13 +96,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114040
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114040
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -117,13 +117,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117822
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117822
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001860
@@ -138,13 +138,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001860
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00121046
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001860
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00121046
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -159,13 +159,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114028
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114028
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -180,13 +180,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117864
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117864
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -201,13 +201,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114036
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114036
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -222,13 +222,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117856
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117856
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -243,13 +243,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114009
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114009
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -264,13 +264,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117860
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117860
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -285,13 +285,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117832
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117832
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -306,13 +306,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117836
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117836
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -327,13 +327,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117840
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117840
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -348,13 +348,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117844
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117844
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001684
@@ -369,13 +369,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001684
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116216
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001684
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116216
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -390,13 +390,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114020
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114020
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -411,13 +411,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117852
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117852
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001860
@@ -432,13 +432,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001860
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00121035
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001860
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00121035
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -453,13 +453,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114032
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114032
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001860
@@ -474,13 +474,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001860
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00121041
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001860
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00121041
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001593
@@ -495,13 +495,13 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001593
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00114006
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001593
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00114006
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001747
@@ -516,10 +516,10 @@
           value: OBA:1001087
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117829
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117829
+                unit:
+                  value: "{beats}/min"

--- a/priority_variables_transform/CARDIA-ingest/icam.yaml
+++ b/priority_variables_transform/CARDIA-ingest/icam.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116396
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht001699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116396
+                unit:
+                  value: "ng/mL"

--- a/priority_variables_transform/CARDIA-ingest/il6.yaml
+++ b/priority_variables_transform/CARDIA-ingest/il6.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001862
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00121064
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht001862
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00121064
+                unit:
+                  value: "pg/mL"

--- a/priority_variables_transform/CARDIA-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/CARDIA-ingest/insulin_blood.yaml
@@ -12,15 +12,15 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001587
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113698
-                expr: "None if str({phv00113698}) in ('M', 'L', 'H', '') else float({phv00113698}) * 6.945"
-              unit:
-                value: "pmol/L"
-                range: string
+          - Quantity:
+              populated_from: pht001587
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113698
+                  expr: "None if str({phv00113698}) in ('M', 'L', 'H', '') else float({phv00113698}) * 6.945"
+                unit:
+                  value: "pmol/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001740
@@ -35,15 +35,15 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001740
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117565
-                expr: "None if str({phv00117565}) in ('M', 'L', 'H', '') else float({phv00117565}) * 6.945"
-              unit:
-                value: "pmol/L"
-                range: string
+          - Quantity:
+              populated_from: pht001740
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117565
+                  expr: "None if str({phv00117565}) in ('M', 'L', 'H', '') else float({phv00117565}) * 6.945"
+                unit:
+                  value: "pmol/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001740
@@ -58,12 +58,12 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001740
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117566
-                expr: "None if str({phv00117566}) in ('M', 'L', 'H', '') else float({phv00117566}) * 6.945"
-              unit:
-                value: "pmol/L"
-                range: string
+          - Quantity:
+              populated_from: pht001740
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117566
+                  expr: "None if str({phv00117566}) in ('M', 'L', 'H', '') else float({phv00117566}) * 6.945"
+                unit:
+                  value: "pmol/L"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/isoprostane_8_epi_pgf2a.yaml
+++ b/priority_variables_transform/CARDIA-ingest/isoprostane_8_epi_pgf2a.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001847
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120666
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht001847
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120666
+                unit:
+                  value: "pg/mL"

--- a/priority_variables_transform/CARDIA-ingest/ldl.yaml
+++ b/priority_variables_transform/CARDIA-ingest/ldl.yaml
@@ -14,13 +14,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001848
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120671
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001848
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120671
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001742
@@ -37,13 +37,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117573
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117573
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001802
@@ -60,13 +60,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119616
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119616
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001588
@@ -83,13 +83,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001588
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113703
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001588
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113703
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001695
@@ -106,10 +106,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001695
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116372
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001695
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116372
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/CARDIA-ingest/lympho_ct.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00112691}) == 'M' else float({phv00112691})"
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00112691}) == 'M' else float({phv00112691})"
+                unit:
+                  value: "10*3/uL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003298
@@ -37,11 +37,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190609}) == 'M' else float({phv00190609})"
-              unit:
-                value: "10*3/uL"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190609}) == 'M' else float({phv00190609})"
+                unit:
+                  value: "10*3/uL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/mch.yaml
+++ b/priority_variables_transform/CARDIA-ingest/mch.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                expr: "({phv00112688} / {phv00112687}) * 10"
-              unit:
-                value: "pg/{cell}"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  expr: "({phv00112688} / {phv00112687}) * 10"
+                unit:
+                  value: "pg/{cell}"

--- a/priority_variables_transform/CARDIA-ingest/mn_art_pres.yaml
+++ b/priority_variables_transform/CARDIA-ingest/mn_art_pres.yaml
@@ -16,14 +16,14 @@
           value: "Right arm"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001684
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00116215}) == 'M' else float({phv00116215})"
-              unit:
-                value: "mm[Hg]"
-                range: string
+          - Quantity:
+              populated_from: pht001684
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00116215}) == 'M' else float({phv00116215})"
+                unit:
+                  value: "mm[Hg]"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001633
@@ -42,11 +42,11 @@
           value: "Right arm"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001633
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00114868}) == 'M' else float({phv00114868})"
-              unit:
-                value: "mm[Hg]"
-                range: string
+          - Quantity:
+              populated_from: pht001633
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00114868}) == 'M' else float({phv00114868})"
+                unit:
+                  value: "mm[Hg]"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/monocyte_ncnc_bld.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190608}) == 'M' else float({phv00190608})"
-              unit:
-                value: "10*3/uL"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190608}) == 'M' else float({phv00190608})"
+                unit:
+                  value: "10*3/uL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/neutro_ct.yaml
+++ b/priority_variables_transform/CARDIA-ingest/neutro_ct.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190607}) == 'M' else float({phv00190607})"
-              unit:
-                value: "10*3/uL"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190607}) == 'M' else float({phv00190607})"
+                unit:
+                  value: "10*3/uL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/neutro_pct.yaml
+++ b/priority_variables_transform/CARDIA-ingest/neutro_pct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00112694}) == 'M' else float({phv00112694})"
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00112694}) == 'M' else float({phv00112694})"
+                unit:
+                  value: "%{WBCs}"

--- a/priority_variables_transform/CARDIA-ingest/person.yaml
+++ b/priority_variables_transform/CARDIA-ingest/person.yaml
@@ -16,58 +16,58 @@
           expr: 'case(({pht001748.phv00117878} is not None, "OMOP:434489"))'
         cause_of_death:
           class_derivations:
-          - name: CauseOfDeath
-            populated_from: pht001559
-            joins:
-              pht001748:
-                source_key: phv00112417
-                lookup_key: phv00117878
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001748.phv00117890} is not None, "ICD9CM:" + str({pht001748.phv00117890})))'
-              order:
-                value: 1
-          - name: CauseOfDeath
-            populated_from: pht001559
-            joins:
-              pht001748:
-                source_key: phv00112417
-                lookup_key: phv00117878
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001748.phv00117891} is not None, "ICD9CM:" + str({pht001748.phv00117891})))'
-              order:
-                value: 2
-          - name: CauseOfDeath
-            populated_from: pht001559
-            joins:
-              pht001748:
-                source_key: phv00112417
-                lookup_key: phv00117878
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001748.phv00117892} is not None, "ICD9CM:" + str({pht001748.phv00117892})))'
-              order:
-                value: 3
-          - name: CauseOfDeath
-            populated_from: pht001559
-            joins:
-              pht001748:
-                source_key: phv00112417
-                lookup_key: phv00117878
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001748.phv00117893} is not None, "ICD9CM:" + str({pht001748.phv00117893})))'
-              order:
-                value: 4
-          - name: CauseOfDeath
-            populated_from: pht001559
-            joins:
-              pht001748:
-                source_key: phv00112417
-                lookup_key: phv00117878
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001748.phv00117894} is not None, "ICD9CM:" + str({pht001748.phv00117894})))'
-              order:
-                value: 5
+          - CauseOfDeath:
+              populated_from: pht001559
+              joins:
+                pht001748:
+                  source_key: phv00112417
+                  lookup_key: phv00117878
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001748.phv00117890} is not None, "ICD9CM:" + str({pht001748.phv00117890})))'
+                order:
+                  value: 1
+          - CauseOfDeath:
+              populated_from: pht001559
+              joins:
+                pht001748:
+                  source_key: phv00112417
+                  lookup_key: phv00117878
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001748.phv00117891} is not None, "ICD9CM:" + str({pht001748.phv00117891})))'
+                order:
+                  value: 2
+          - CauseOfDeath:
+              populated_from: pht001559
+              joins:
+                pht001748:
+                  source_key: phv00112417
+                  lookup_key: phv00117878
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001748.phv00117892} is not None, "ICD9CM:" + str({pht001748.phv00117892})))'
+                order:
+                  value: 3
+          - CauseOfDeath:
+              populated_from: pht001559
+              joins:
+                pht001748:
+                  source_key: phv00112417
+                  lookup_key: phv00117878
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001748.phv00117893} is not None, "ICD9CM:" + str({pht001748.phv00117893})))'
+                order:
+                  value: 4
+          - CauseOfDeath:
+              populated_from: pht001559
+              joins:
+                pht001748:
+                  source_key: phv00112417
+                  lookup_key: phv00117878
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001748.phv00117894} is not None, "ICD9CM:" + str({pht001748.phv00117894})))'
+                order:
+                  value: 5

--- a/priority_variables_transform/CARDIA-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/CARDIA-ingest/platelet_ct.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00112690}) in ('M', 'L', 'H', '') else float({phv00112690})"
-              unit:
-                value: "10*3/uL"
-                range: string
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00112690}) in ('M', 'L', 'H', '') else float({phv00112690})"
+                unit:
+                  value: "10*3/uL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/potassium.yaml
+++ b/priority_variables_transform/CARDIA-ingest/potassium.yaml
@@ -12,14 +12,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001745
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117627}) == 'M' else float({phv00117627})"
-              unit:
-                value: "mmol/L"
-                range: string
+          - Quantity:
+              populated_from: pht001745
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117627}) == 'M' else float({phv00117627})"
+                unit:
+                  value: "mmol/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001746
@@ -34,11 +34,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001746
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00117741}) == 'M' else float({phv00117741})"
-              unit:
-                value: "mmol/L"
-                range: string
+          - Quantity:
+              populated_from: pht001746
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00117741}) == 'M' else float({phv00117741})"
+                unit:
+                  value: "mmol/L"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/pselectin.yaml
+++ b/priority_variables_transform/CARDIA-ingest/pselectin.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190595}) == 'M' else float({phv00190595})"
-              unit:
-                value: "ng/mL"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190595}) == 'M' else float({phv00190595})"
+                unit:
+                  value: "ng/mL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/CARDIA-ingest/rdbld_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112687
-              unit:
-                value: "10*6/uL"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112687
+                unit:
+                  value: "10*6/uL"

--- a/priority_variables_transform/CARDIA-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/CARDIA-ingest/sleep_duration_daily.yaml
@@ -14,13 +14,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001687
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116294
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht001687
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116294
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001839
@@ -37,10 +37,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001839
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120534
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht001839
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120534
+                unit:
+                  value: "h"

--- a/priority_variables_transform/CARDIA-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/CARDIA-ingest/sodium_intak.yaml
@@ -14,13 +14,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001638
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115050
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht001638
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115050
+                unit:
+                  value: "mg/d"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001592
@@ -37,13 +37,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001592
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113961
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht001592
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113961
+                unit:
+                  value: "mg/d"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001591
@@ -60,13 +60,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001591
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113867
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht001591
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113867
+                unit:
+                  value: "mg/d"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001746
@@ -83,13 +83,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117742
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht001746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117742
+                unit:
+                  value: "mg/d"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001745
@@ -106,10 +106,10 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001745
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117628
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht001745
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117628
+                unit:
+                  value: "mg/d"

--- a/priority_variables_transform/CARDIA-ingest/spirometry.yaml
+++ b/priority_variables_transform/CARDIA-ingest/spirometry.yaml
@@ -8,46 +8,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00113261}) + ":CARDIA YEAR 0")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001575
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001575
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00113403
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001575
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001575
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00113402
-                    unit:
-                      value: "L"
+          - MeasurementObservation:
+              populated_from: pht001575
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001575
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00113403
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001575
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001575
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00113402
+                        unit:
+                          value: "L"
 
 - class_derivations:
     MeasurementObservationSet:
@@ -59,242 +59,242 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00114613}) + ":CARDIA YEAR 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114628
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114676
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114616
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114640
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114664
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114652
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114694
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114651
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114663
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114615
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114675
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114627
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001627
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001627
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00114639
-                    unit:
-                      value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114628
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114676
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114616
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114640
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114664
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114652
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114694
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114651
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114663
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114615
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114675
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114627
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001627
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001627
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00114639
+                        unit:
+                          value: "L"
 
 - class_derivations:
     MeasurementObservationSet:
@@ -306,204 +306,204 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00115618}) + ":CARDIA YEAR 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115621
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115645
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115657
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115669
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115633
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115656
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115620
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115668
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115644
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115632
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001667
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001667
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00115687
-                    unit:
-                      value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115621
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115645
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115657
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115669
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115633
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115656
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115620
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115668
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115644
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115632
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001667
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001667
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00115687
+                        unit:
+                          value: "L"
 
 - class_derivations:
     MeasurementObservationSet:
@@ -515,366 +515,366 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00118837}) + ":CARDIA YEAR 10")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118924
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118876
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118864
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118942
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118912
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118900
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118888
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118840
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118852
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118863
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118941
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118923
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118911
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118839
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118875
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118899
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118851
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001781
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: "{phv00118959} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001781
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118887
-                    unit:
-                      value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118924
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118876
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118864
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118942
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118912
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118900
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118888
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118840
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118852
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118863
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118941
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118923
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118911
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118839
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118875
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118899
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118851
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001781
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: "{phv00118959} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001781
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118887
+                        unit:
+                          value: "L"
 
 - class_derivations:
     MeasurementObservationSet:
@@ -886,43 +886,43 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00118962}) + ":CARDIA YEAR 10")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118971
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00118970
-                    unit:
-                      value: "L"
+          - MeasurementObservation:
+              populated_from: pht001782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118971
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00118970
+                        unit:
+                          value: "L"

--- a/priority_variables_transform/CARDIA-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/tot_chol_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001588
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113700
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001588
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113700
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001695
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001695
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116369
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001695
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116369
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/CARDIA-ingest/triglyc_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119614
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119614
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001695
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001695
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116373
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001695
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116373
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001588
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001588
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113701
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001588
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113701
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001848
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001848
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120668
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001848
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120668
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001742
@@ -106,10 +106,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117574
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117574
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/CARDIA-ingest/troponin.yaml
+++ b/priority_variables_transform/CARDIA-ingest/troponin.yaml
@@ -12,14 +12,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001869
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00121285}) == 'M' else float({phv00121285})"
-              unit:
-                value: "ng/mL"
-                range: string
+          - Quantity:
+              populated_from: pht001869
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00121285}) == 'M' else float({phv00121285})"
+                unit:
+                  value: "ng/mL"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001871
@@ -34,11 +34,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001871
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00121501}) == 'M' else float({phv00121501})"
-              unit:
-                value: "ng/mL"
-                range: string
+          - Quantity:
+              populated_from: pht001871
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00121501}) == 'M' else float({phv00121501})"
+                unit:
+                  value: "ng/mL"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/vege_serving.yaml
+++ b/priority_variables_transform/CARDIA-ingest/vege_serving.yaml
@@ -12,13 +12,13 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001565
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00112717} + {phv00112718} + {phv00112721} + {phv00112725} + {phv00112723} + {phv00112722} + {phv00112724} + {phv00112719} + {phv00112726} + {phv00112727} + {phv00112720}) * 7
-              unit: 
-                value: '{servings}/wk' 
+          - Quantity:
+              populated_from: pht001565
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00112717} + {phv00112718} + {phv00112721} + {phv00112725} + {phv00112723} + {phv00112722} + {phv00112724} + {phv00112719} + {phv00112726} + {phv00112727} + {phv00112720}) * 7
+                unit: 
+                  value: '{servings}/wk' 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001712
@@ -33,10 +33,10 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001712
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00116769} + {phv00116770} + {phv00116773} + {phv00116777} + {phv00116775} + {phv00116774} + {phv00116776} + {phv00116771} + {phv00116778} + {phv00116779} + {phv00116772}) * 7
-              unit: 
-                value: '{servings}/wk'
+          - Quantity:
+              populated_from: pht001712
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00116769} + {phv00116770} + {phv00116773} + {phv00116777} + {phv00116775} + {phv00116774} + {phv00116776} + {phv00116771} + {phv00116778} + {phv00116779} + {phv00116772}) * 7
+                unit: 
+                  value: '{servings}/wk'

--- a/priority_variables_transform/CARDIA-ingest/waist_circ.yaml
+++ b/priority_variables_transform/CARDIA-ingest/waist_circ.yaml
@@ -18,13 +18,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119095
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119095
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -45,13 +45,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113659
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113659
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001785
@@ -72,13 +72,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001785
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00119096
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001785
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00119096
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -99,13 +99,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113651
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113651
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001671
@@ -126,13 +126,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001671
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115859
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001671
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115859
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -153,13 +153,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117234
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117234
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001583
@@ -180,13 +180,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001583
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00113650
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001583
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00113650
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001857
@@ -207,13 +207,13 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001857
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00120998
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001857
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00120998
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001720
@@ -234,10 +234,10 @@
           value: "Abdomen"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001720
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117233
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001720
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117233
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/CARDIA-ingest/waist_hip.yaml
+++ b/priority_variables_transform/CARDIA-ingest/waist_hip.yaml
@@ -16,11 +16,11 @@
           value: STANDING_POSITION
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003298
-            slot_derivations:
-              value_decimal:
-                expr: "None if str({phv00190567}) == 'M' else float({phv00190567})"
-              unit:
-                value: "{ratio}"
-                range: string
+          - Quantity:
+              populated_from: pht003298
+              slot_derivations:
+                value_decimal:
+                  expr: "None if str({phv00190567}) == 'M' else float({phv00190567})"
+                unit:
+                  value: "{ratio}"
+                  range: string

--- a/priority_variables_transform/CARDIA-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/CARDIA-ingest/whtbld_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001563
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00112686
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht001563
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00112686
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/CARDIA-ingest/willeb_fac.yaml
+++ b/priority_variables_transform/CARDIA-ingest/willeb_fac.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001694
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116364
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001694
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116364
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001739
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001739
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117560
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001739
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117560
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001739
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001739
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00117559
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001739
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00117559
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001642
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001642
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00115092
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001642
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00115092
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001694
@@ -106,10 +106,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001694
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00116365
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht001694
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00116365
+                unit:
+                  value: "%{normal}"

--- a/priority_variables_transform/CHS-ingest/albumin_bld.yaml
+++ b/priority_variables_transform/CHS-ingest/albumin_bld.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100046
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100046
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100429
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100429
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105868
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105868
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,14 +88,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106995
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106995
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -113,11 +113,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110487
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110487
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/alcohol_servings.yaml
+++ b/priority_variables_transform/CHS-ingest/alcohol_servings.yaml
@@ -13,14 +13,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100084
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100084
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100502
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100502
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001474
@@ -63,14 +63,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00101954
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00101954
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001475
@@ -88,14 +88,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00102972
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00102972
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001489
@@ -113,14 +113,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104954
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104954
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -138,14 +138,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106404
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106404
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -163,14 +163,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00107280
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00107280
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001492
@@ -188,14 +188,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108155
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108155
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001493
@@ -213,14 +213,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108834
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108834
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -238,14 +238,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110481
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110481
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -261,14 +261,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00197486} + {phv00197487} + {phv00197488}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00197486} + {phv00197487} + {phv00197488}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -284,11 +284,11 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00198833} + {phv00198834} + {phv00198835}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00198833} + {phv00198834} + {phv00198835}'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/apnea_hypop_index.yaml
+++ b/priority_variables_transform/CHS-ingest/apnea_hypop_index.yaml
@@ -11,17 +11,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_concept:
-                populated_from: phv00198702
-                value_mappings:
-                  '0': '< 50'
-                  '1': '>50'
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00198702
+                  value_mappings:
+                    '0': '< 50'
+                    '1': '>50'
+                unit:
+                  value: /h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -35,18 +35,18 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_concept:
-                populated_from: phv00199979
-                value_mappings:
-                  '0': '< 50'
-                  '1': '>50'
-                  '8': None
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00199979
+                  value_mappings:
+                    '0': '< 50'
+                    '1': '>50'
+                    '8': None
+                unit:
+                  value: /h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -60,14 +60,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197745
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197745
+                unit:
+                  value: /h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -81,14 +81,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200047
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200047
+                unit:
+                  value: /h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -102,14 +102,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197725
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197725
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 0% desat
           range: string
@@ -126,14 +126,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197726
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197726
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 2% desat
           range: string
@@ -150,14 +150,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197727
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197727
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 3% desat
           range: string
@@ -174,14 +174,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197728
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197728
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 4% desat
           range: string
@@ -198,14 +198,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197729
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197729
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 5% desat
           range: string
@@ -222,14 +222,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197730
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197730
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 0% desat or arousal
           range: string
@@ -246,14 +246,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197731
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197731
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 2% desat or arousal
           range: string
@@ -270,14 +270,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197732
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197732
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 3% desat or arousal
           range: string
@@ -294,14 +294,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197733
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197733
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 4% desat or arousal
           range: string
@@ -318,14 +318,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197734
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197734
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rdi at 5% desat or arousal
           range: string
@@ -342,14 +342,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197735
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197735
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall supine rdi at 0% desat
           range: string
@@ -366,14 +366,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197736
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197736
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall supine rdi at 2% desat
           range: string
@@ -390,14 +390,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197737
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197737
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall supine rdi at 3% desat
           range: string
@@ -414,14 +414,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197738
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197738
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall supine rdi at 4% desat
           range: string
@@ -438,14 +438,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197739
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197739
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall supine rdi at 5% desat
           range: string
@@ -462,14 +462,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197740
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197740
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-supine rdi at 0% desat
           range: string
@@ -486,14 +486,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197741
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197741
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-supine rdi at 2% desat
           range: string
@@ -510,14 +510,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197742
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197742
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-supine rdi at 3% desat
           range: string
@@ -534,14 +534,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197743
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197743
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-supine rdi at 4% desat
           range: string
@@ -558,14 +558,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197744
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197744
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-supine rdi at 5% desat
           range: string
@@ -582,14 +582,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197745
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197745
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive (all desats) apnea hypopnea (4% desat) index)
           range: string
@@ -606,14 +606,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197746
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197746
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rem rdi at 0% desat
           range: string
@@ -630,14 +630,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197747
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197747
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rem rdi at 2% desat
           range: string
@@ -654,14 +654,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197748
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197748
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rem rdi at 3% desat
           range: string
@@ -678,14 +678,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197749
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197749
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rem rdi at 4% desat
           range: string
@@ -702,14 +702,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197750
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197750
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall rem rdi at 5% desat
           range: string
@@ -726,14 +726,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197751
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197751
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-rem rdi at 0% desat
           range: string
@@ -750,14 +750,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197752
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197752
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-rem rdi at 2% desat
           range: string
@@ -774,14 +774,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197753
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197753
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-rem rdi at 3% desat
           range: string
@@ -798,14 +798,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197754
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197754
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-rem rdi at 4% desat
           range: string
@@ -822,14 +822,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197755
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197755
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: overall non-rem rdi at 5% desat
           range: string
@@ -846,14 +846,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197756
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197756
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea index all desats
           range: string
@@ -870,14 +870,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197757
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197757
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea index 4% desats
           range: string
@@ -894,14 +894,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197758
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197758
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea index 4% or arousal
           range: string
@@ -918,14 +918,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197759
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197759
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea index all desats
           range: string
@@ -942,14 +942,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197760
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197760
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea index 4% desats
           range: string
@@ -966,14 +966,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197761
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197761
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea index 4% or arousal
           range: string
@@ -990,14 +990,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197921
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197921
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) overall
           range: string
@@ -1014,14 +1014,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197926
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197926
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) overall
           range: string
@@ -1038,14 +1038,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197931
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197931
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) overall
           range: string
@@ -1062,14 +1062,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197936
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197936
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) overall
           range: string
@@ -1086,14 +1086,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197941
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197941
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) overall
           range: string
@@ -1110,14 +1110,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197946
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197946
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) overall
           range: string
@@ -1134,14 +1134,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197951
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197951
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) overall
           range: string
@@ -1158,14 +1158,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197956
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197956
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) overall
           range: string
@@ -1182,14 +1182,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197961
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197961
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) overall
           range: string
@@ -1206,14 +1206,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197966
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197966
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) overall
           range: string
@@ -1230,14 +1230,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197971
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197971
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) overall
           range: string
@@ -1254,14 +1254,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197976
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197976
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) overall
           range: string
@@ -1278,14 +1278,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197993
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197993
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) associated with arousal
           range: string
@@ -1302,14 +1302,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197998
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197998
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) associated with arousal
           range: string
@@ -1326,14 +1326,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198003
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198003
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) associated with arousal
           range: string
@@ -1350,14 +1350,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198008
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198008
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) associated with arousal
           range: string
@@ -1374,14 +1374,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198013
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198013
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) associated with arousal
           range: string
@@ -1398,14 +1398,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198018
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198018
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) associated with arousal
           range: string
@@ -1422,14 +1422,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198023
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198023
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) associated with arousal
           range: string
@@ -1446,14 +1446,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198028
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198028
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) associated with arousal
           range: string
@@ -1470,14 +1470,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198033
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198033
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) associated with arousal
           range: string
@@ -1494,14 +1494,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198038
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198038
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) associated with arousal
           range: string
@@ -1518,14 +1518,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198043
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198043
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) associated with arousal
           range: string
@@ -1542,14 +1542,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198048
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198048
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) associated with arousal
           range: string
@@ -1566,14 +1566,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198092
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198092
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 2% desaturation
           range: string
@@ -1590,14 +1590,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198097
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198097
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 2% desaturation
           range: string
@@ -1614,14 +1614,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198102
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198102
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 2% desaturation
           range: string
@@ -1638,14 +1638,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198107
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198107
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 2% desaturation
           range: string
@@ -1662,14 +1662,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198112
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198112
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 2% desaturation
           range: string
@@ -1686,14 +1686,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198117
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198117
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 2% desaturation
           range: string
@@ -1710,14 +1710,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198122
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198122
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 2% desaturation
           range: string
@@ -1734,14 +1734,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198127
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198127
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 2% desaturation
           range: string
@@ -1758,14 +1758,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198132
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198132
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 2% desaturation
           range: string
@@ -1782,14 +1782,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198137
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198137
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 2% desaturation
           range: string
@@ -1806,14 +1806,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198142
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198142
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 2% desaturation
           range: string
@@ -1830,14 +1830,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198147
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198147
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 2% desaturation
           range: string
@@ -1854,14 +1854,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198164
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198164
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 2% desaturation or arousal
           range: string
@@ -1878,14 +1878,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198169
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198169
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 2% desaturation or arousal
           range: string
@@ -1902,14 +1902,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198174
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198174
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 2% desaturation or arousal
           range: string
@@ -1926,14 +1926,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198179
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198179
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 2% desaturation or arousal
           range: string
@@ -1950,14 +1950,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198184
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198184
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 2% desaturation or arousal
           range: string
@@ -1974,14 +1974,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198189
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198189
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 2% desaturation or arousal
           range: string
@@ -1998,14 +1998,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198194
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198194
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 2% desaturation or arousal
           range: string
@@ -2022,14 +2022,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198199
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198199
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 2% desaturation or arousal
           range: string
@@ -2046,14 +2046,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198204
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198204
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 2% desaturation or arousal
           range: string
@@ -2070,14 +2070,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198209
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198209
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 2% desaturation or
             arousal
@@ -2095,14 +2095,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198214
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198214
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 2% desaturation or
             arousal
@@ -2120,14 +2120,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198219
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198219
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 2% desaturation or
             arousal
@@ -2145,14 +2145,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198236
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198236
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 3% desaturation
           range: string
@@ -2169,14 +2169,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198241
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198241
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 3% desaturation
           range: string
@@ -2193,14 +2193,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198246
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198246
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 3% desaturation
           range: string
@@ -2217,14 +2217,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198251
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198251
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 3% desaturation
           range: string
@@ -2241,14 +2241,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198256
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198256
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 3% desaturation
           range: string
@@ -2265,14 +2265,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198261
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198261
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 3% desaturation
           range: string
@@ -2289,14 +2289,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198266
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198266
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 3% desaturation
           range: string
@@ -2313,14 +2313,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198271
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198271
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 3% desaturation
           range: string
@@ -2337,14 +2337,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198276
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198276
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 3% desaturation
           range: string
@@ -2361,14 +2361,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198281
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198281
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 3% desaturation
           range: string
@@ -2385,14 +2385,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198286
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198286
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 3% desaturation
           range: string
@@ -2409,14 +2409,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198291
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198291
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 3% desaturation
           range: string
@@ -2433,14 +2433,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198308
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198308
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 3% desaturation or arousal
           range: string
@@ -2457,14 +2457,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198313
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198313
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 3% desaturation or arousal
           range: string
@@ -2481,14 +2481,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198318
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198318
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 3% desaturation or arousal
           range: string
@@ -2505,14 +2505,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198323
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198323
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 3% desaturation or arousal
           range: string
@@ -2529,14 +2529,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198328
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198328
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 3% desaturation or arousal
           range: string
@@ -2553,14 +2553,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198333
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198333
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 3% desaturation or arousal
           range: string
@@ -2577,14 +2577,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198338
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198338
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 3% desaturation or arousal
           range: string
@@ -2601,14 +2601,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198343
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198343
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 3% desaturation or arousal
           range: string
@@ -2625,14 +2625,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198348
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198348
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 3% desaturation or arousal
           range: string
@@ -2649,14 +2649,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198353
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198353
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 3% desaturation or
             arousal
@@ -2674,14 +2674,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198358
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198358
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 3% desaturation or
             arousal
@@ -2699,14 +2699,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198363
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198363
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 3% desaturation or
             arousal
@@ -2724,14 +2724,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198380
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198380
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 4% desaturation
           range: string
@@ -2748,14 +2748,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198385
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198385
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 4% desaturation
           range: string
@@ -2772,14 +2772,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198390
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198390
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 4% desaturation
           range: string
@@ -2796,14 +2796,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198395
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198395
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 4% desaturation
           range: string
@@ -2820,14 +2820,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198400
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198400
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 4% desaturation
           range: string
@@ -2844,14 +2844,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198405
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198405
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 4% desaturation
           range: string
@@ -2868,14 +2868,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198410
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198410
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 4% desaturation
           range: string
@@ -2892,14 +2892,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198415
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198415
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 4% desaturation
           range: string
@@ -2916,14 +2916,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198420
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198420
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 4% desaturation
           range: string
@@ -2940,14 +2940,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198425
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198425
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 4% desaturation
           range: string
@@ -2964,14 +2964,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198430
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198430
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 4% desaturation
           range: string
@@ -2988,14 +2988,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198435
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198435
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 4% desaturation
           range: string
@@ -3012,14 +3012,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198452
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198452
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 4% desaturation or arousal
           range: string
@@ -3036,14 +3036,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198457
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198457
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 4% desaturation or arousal
           range: string
@@ -3060,14 +3060,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198462
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198462
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 4% desaturation or arousal
           range: string
@@ -3084,14 +3084,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198467
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198467
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 4% desaturation or arousal
           range: string
@@ -3108,14 +3108,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198472
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198472
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 4% desaturation or arousal
           range: string
@@ -3132,14 +3132,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198477
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198477
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 4% desaturation or arousal
           range: string
@@ -3156,14 +3156,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198482
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198482
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 4% desaturation or arousal
           range: string
@@ -3180,14 +3180,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198487
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198487
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 4% desaturation or arousal
           range: string
@@ -3204,14 +3204,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198492
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198492
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 4% desaturation or arousal
           range: string
@@ -3228,14 +3228,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198497
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198497
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 4% desaturation or
             arousal
@@ -3253,14 +3253,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198502
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198502
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 4% desaturation or
             arousal
@@ -3278,14 +3278,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198507
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198507
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 4% desaturation or
             arousal
@@ -3303,14 +3303,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198524
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198524
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 5% desaturation
           range: string
@@ -3327,14 +3327,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198529
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198529
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 5% desaturation
           range: string
@@ -3351,14 +3351,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198534
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198534
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 5% desaturation
           range: string
@@ -3375,14 +3375,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198539
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198539
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 5% desaturation
           range: string
@@ -3399,14 +3399,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198544
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198544
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 5% desaturation
           range: string
@@ -3423,14 +3423,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198549
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198549
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 5% desaturation
           range: string
@@ -3447,14 +3447,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198554
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198554
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 5% desaturation
           range: string
@@ -3471,14 +3471,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198559
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198559
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 5% desaturation
           range: string
@@ -3495,14 +3495,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198564
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198564
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 5% desaturation
           range: string
@@ -3519,14 +3519,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198569
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198569
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 5% desaturation
           range: string
@@ -3543,14 +3543,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198574
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198574
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 5% desaturation
           range: string
@@ -3567,14 +3567,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198579
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198579
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 5% desaturation
           range: string
@@ -3591,14 +3591,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198596
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198596
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (back position) 5% desaturation or arousal
           range: string
@@ -3615,14 +3615,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198601
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198601
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in rem (other position) 5% desaturation or arousal
           range: string
@@ -3639,14 +3639,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198606
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198606
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (back position) 5% desaturation or arousal
           range: string
@@ -3663,14 +3663,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198611
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198611
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: hypopnea rdi in nrem (other position) 5% desaturation or arousal
           range: string
@@ -3687,14 +3687,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198616
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198616
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (back position) 5% desaturation or arousal
           range: string
@@ -3711,14 +3711,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198621
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198621
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in rem (other position) 5% desaturation or arousal
           range: string
@@ -3735,14 +3735,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198626
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198626
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (back position) 5% desaturation or arousal
           range: string
@@ -3759,14 +3759,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198631
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198631
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: central apnea rdi in nrem (other position) 5% desaturation or arousal
           range: string
@@ -3783,14 +3783,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198636
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198636
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (back position) 5% desaturation or arousal
           range: string
@@ -3807,14 +3807,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198641
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198641
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in rem (other position) 5% desaturation or
             arousal
@@ -3832,14 +3832,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198646
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198646
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (back position) 5% desaturation or
             arousal
@@ -3857,14 +3857,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198651
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198651
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: obstructive apnea rdi in nrem (other position) 5% desaturation or
             arousal
@@ -3882,14 +3882,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200027
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200027
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 0% desat
           range: string
@@ -3906,14 +3906,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200028
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200028
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 2% desat
           range: string
@@ -3930,14 +3930,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200029
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200029
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 3% desat
           range: string
@@ -3954,14 +3954,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200030
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200030
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 4% desat
           range: string
@@ -3978,14 +3978,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200031
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200031
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 5% desat
           range: string
@@ -4002,14 +4002,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200032
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200032
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 0% desat or arousal
           range: string
@@ -4026,14 +4026,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200033
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200033
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 2% desat or arousal
           range: string
@@ -4050,14 +4050,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200034
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200034
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 3% desat or arousal
           range: string
@@ -4074,14 +4074,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200035
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200035
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 4% desat or arousal
           range: string
@@ -4098,14 +4098,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200036
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200036
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rdi at 5% desat or arousal
           range: string
@@ -4122,14 +4122,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200037
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200037
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall supine rdi at 0% desat
           range: string
@@ -4146,14 +4146,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200038
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200038
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall supine rdi at 2% desat
           range: string
@@ -4170,14 +4170,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200039
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200039
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall supine rdi at 3% desat
           range: string
@@ -4194,14 +4194,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200040
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200040
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall supine rdi at 4% desat
           range: string
@@ -4218,14 +4218,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200041
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200041
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall supine rdi at 5% desat
           range: string
@@ -4242,14 +4242,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200042
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200042
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-supine rdi at 0% desat
           range: string
@@ -4266,14 +4266,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200043
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200043
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-supine rdi at 2% desat
           range: string
@@ -4290,14 +4290,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200044
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200044
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-supine rdi at 3% desat
           range: string
@@ -4314,14 +4314,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200045
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200045
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-supine rdi at 4% desat
           range: string
@@ -4338,14 +4338,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200046
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200046
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-supine rdi at 5% desat
           range: string
@@ -4362,14 +4362,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200047
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200047
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - obstructive apnea (all desats) hypopnea (4% desat) index
           range: string
@@ -4386,14 +4386,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200048
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200048
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rem rdi at 0% desat
           range: string
@@ -4410,14 +4410,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200049
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200049
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rem rdi at 2% desat
           range: string
@@ -4434,14 +4434,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200050
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200050
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rem rdi at 3% desat
           range: string
@@ -4458,14 +4458,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200051
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200051
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rem rdi at 4% desat
           range: string
@@ -4482,14 +4482,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200052
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200052
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall rem rdi at 5% desat
           range: string
@@ -4506,14 +4506,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200053
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200053
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-rem rdi at 0% desat
           range: string
@@ -4530,14 +4530,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200054
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200054
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-rem rdi at 2% desat
           range: string
@@ -4554,14 +4554,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200055
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200055
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-rem rdi at 3% desat
           range: string
@@ -4578,14 +4578,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200056
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200056
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-rem rdi at 4% desat
           range: string
@@ -4602,14 +4602,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200057
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200057
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - overall non-rem rdi at 5% desat
           range: string
@@ -4626,14 +4626,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200058
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200058
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - obstructive apnea index all desats
           range: string
@@ -4650,14 +4650,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200059
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200059
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - obstructive apnea index at 4% desats
           range: string
@@ -4674,14 +4674,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200060
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200060
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - obstructive apnea index at 4% or arousal
           range: string
@@ -4698,14 +4698,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200061
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200061
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - central apnea index all desats
           range: string
@@ -4722,14 +4722,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200062
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200062
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - central apnea index at 4% desats
           range: string
@@ -4746,14 +4746,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00200063
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00200063
+                unit:
+                  value: /h
+                  range: string
         method_type:
           value: calculated - central apnea index at 4% or arousal
           range: string

--- a/priority_variables_transform/CHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/CHS-ingest/bdy_hgt.yaml
@@ -17,14 +17,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099550
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099550
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -44,14 +44,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100382
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100382
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -71,14 +71,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105412
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105412
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -96,14 +96,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106775
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106775
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -123,14 +123,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110375
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110375
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -148,11 +148,11 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00198933} / 10'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00198933} / 10'
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/CHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/CHS-ingest/bdy_wgt.yaml
@@ -17,17 +17,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099349
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099349
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001450
@@ -48,17 +48,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099153
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099153
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -78,17 +78,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100383
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100383
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -109,17 +109,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100355
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100355
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001475
@@ -139,17 +139,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00102454
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00102454
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -169,17 +169,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105414
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105414
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -199,17 +199,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106140
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106140
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -229,17 +229,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106776
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106776
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -259,17 +259,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110376
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110376
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001474
@@ -290,14 +290,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00101671
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: kg
-              unit:
-                value: kg
-                range: string 
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00101671
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: kg
+                unit:
+                  value: kg
+                  range: string 

--- a/priority_variables_transform/CHS-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/CHS-ingest/blood_pressure.yaml
@@ -8,54 +8,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00098771}) + ":CHS BASELINE 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001450
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00098799} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001450
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099441
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001450
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00098799} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001450
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099442
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001450
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00098799} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001450
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099441
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001450
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00098799} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001450
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099442
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001452
@@ -66,54 +66,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00100285}) + ":CHS BASELINE BOTH")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001452
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00100487} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001452
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00100435
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001452
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00100487} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001452
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00100436
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001452
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00100487} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001452
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00100435
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001452
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00100487} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001452
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00100436
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001488
@@ -124,54 +124,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00103781}) + ":CHS YEAR 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001488
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00104377} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001488
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00104020
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001488
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00104377} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001488
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00104021
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001488
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00104377} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001488
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00104020
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001488
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00104377} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001488
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00104021
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001489
@@ -182,54 +182,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00104468}) + ":CHS YEAR 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001489
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00104783} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001489
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00104697
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001489
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00104783} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001489
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00104698
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001489
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00104783} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001489
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00104697
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001489
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00104783} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001489
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00104698
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001490
@@ -240,54 +240,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00105099}) + ":CHS YEAR 5 NEW")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001490
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00105622} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001490
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00105432
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001490
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00105622} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001490
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00105433
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001490
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00105622} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001490
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00105432
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001490
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00105622} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001490
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00105433
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001491
@@ -298,54 +298,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00106520}) + ":CHS YEAR 5 OLD")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001491
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00106844} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001491
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00106794
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001491
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00106844} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001491
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00106795
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001491
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00106844} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001491
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00106794
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001491
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00106844} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001491
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00106795
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001492
@@ -356,54 +356,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00107443}) + ":CHS YEAR 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001492
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00107780} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001492
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00107774
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001492
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00107780} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001492
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00107775
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001492
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00107780} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001492
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00107774
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001492
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00107780} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001492
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00107775
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001493
@@ -414,54 +414,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00108303}) + ":CHS YEAR 7")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001493
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00108813} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001493
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00108830
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001493
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00108813} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001493
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00108831
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001493
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00108813} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001493
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00108830
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001493
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00108813} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001493
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00108831
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001474
@@ -472,54 +472,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00101324}) + ":CHS YEAR 10")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001474
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00102006} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001474
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00101961
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001474
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00102006} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001474
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00101960
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001474
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00102006} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001474
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00101961
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001474
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00102006} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001474
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00101960
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001475
@@ -530,54 +530,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00102174}) + ":CHS YEAR 11")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001475
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00102583} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001475
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00102574
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001475
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00102583} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001475
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00102575
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001475
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00102583} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001475
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00102574
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001475
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00102583} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001475
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00102575
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001495
@@ -588,54 +588,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00109768}) + ":CHS YEAR 9")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001495
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00109855} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001495
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00110337
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001495
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00109855} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001495
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00110338
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001495
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00109855} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001495
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00110337
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001495
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00109855} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001495
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00110338
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003699
@@ -646,50 +646,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00197394}) + ":CHS PSG 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003699
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003699
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00197434
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003699
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003699
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00197435
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003699
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003699
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00197434
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003699
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003699
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00197435
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003700
@@ -700,51 +700,51 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00198805}) + ":CHS PSG 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003700
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00198807} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003700
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00198928
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003700
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: "Seated random-zero average"
-              age_at_observation:
-                expr: '{phv00198807} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003700
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00198929
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003700
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00198807} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003700
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00198928
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003700
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: "Seated random-zero average"
+                age_at_observation:
+                  expr: '{phv00198807} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003700
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00198929
+                        unit:
+                          value: mm[Hg]
+                          range: string

--- a/priority_variables_transform/CHS-ingest/bmi.yaml
+++ b/priority_variables_transform/CHS-ingest/bmi.yaml
@@ -15,14 +15,14 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099468
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099468
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -40,14 +40,14 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100386
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100386
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -65,14 +65,14 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105306
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105306
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,14 +88,14 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106840
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106840
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -113,14 +113,14 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110612
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110612
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -136,11 +136,11 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00198926
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00198926
+                unit:
+                  value: kg/m2
+                  range: string

--- a/priority_variables_transform/CHS-ingest/cac_score.yaml
+++ b/priority_variables_transform/CHS-ingest/cac_score.yaml
@@ -19,11 +19,11 @@
           value: "Computed Tomography"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001459
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100691
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001459
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100691
+                unit:
+                  value: '{score}'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/carotid_imt.yaml
+++ b/priority_variables_transform/CHS-ingest/carotid_imt.yaml
@@ -11,14 +11,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001468
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100864
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht001468
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100864
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the mean far wall intima media t (var=CCA_FWME)
           range: string
@@ -35,14 +35,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001468
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100865
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht001468
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100865
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the mean far wall intima-media t
           range: string
@@ -65,14 +65,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001473
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00101265} + {phv00101277}) / 2
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht001473
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00101265} + {phv00101277}) / 2
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: mean of YEAR 5 FAR WALL MAX, R. COMMON and YEAR 5 FAR WALL MAX, L.
             COMMON
@@ -96,15 +96,15 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001473
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00101238} + {phv00101239} + {phv00101250} + {phv00101251})
-                  / 4
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht001473
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00101238} + {phv00101239} + {phv00101250} + {phv00101251})
+                    / 4
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: mean of four measurements, BL REREAD NEAR WALL MAX, R. COMMON and
             BL REREAD FAR WALL MAX, R. COMMON and BL REREAD NEAR WALL MAX, L. COMMON
@@ -129,15 +129,15 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001473
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00101265} + {phv00101277} + {phv00101264} + {phv00101276})
-                  / 4
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht001473
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00101265} + {phv00101277} + {phv00101264} + {phv00101276})
+                    / 4
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: mean of four measurements, YEAR 5 NEAR WALL MAX, R. COMMON and YEAR
             5 FAR WALL MAX, R. COMMON and YEAR 5 NEAR WALL MAX, L. COMMON and YEAR

--- a/priority_variables_transform/CHS-ingest/carotid_sten_left.yaml
+++ b/priority_variables_transform/CHS-ingest/carotid_sten_left.yaml
@@ -23,18 +23,18 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001473
-            slot_derivations:
-              value_concept:
-                populated_from: phv00101303
-                value_mappings:
-                  '0': 0
-                  '1': 1-24
-                  '2': 25-49
-                  '3': 50-74
-                  '4': 75-99
-                  '5': 100                    
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001473
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00101303
+                  value_mappings:
+                    '0': 0
+                    '1': 1-24
+                    '2': 25-49
+                    '3': 50-74
+                    '4': 75-99
+                    '5': 100                    
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/carotid_sten_right.yaml
+++ b/priority_variables_transform/CHS-ingest/carotid_sten_right.yaml
@@ -23,18 +23,18 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001473
-            slot_derivations:
-              value_concept:
-                populated_from: phv00101302
-                value_mappings:
-                  '0': 0
-                  '1': 1-24
-                  '2': 25-49
-                  '3': 50-74
-                  '4': 75-99
-                  '5': 100
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001473
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00101302
+                  value_mappings:
+                    '0': 0
+                    '1': 1-24
+                    '2': 25-49
+                    '3': 50-74
+                    '4': 75-99
+                    '5': 100
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/crp.yaml
+++ b/priority_variables_transform/CHS-ingest/crp.yaml
@@ -15,14 +15,14 @@
           value: adjusted original value
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100499
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100499
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -38,14 +38,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106421
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106421
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -61,11 +61,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00107353
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00107353
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/CHS-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/CHS-ingest/cysc_bld.yaml
@@ -13,11 +13,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001462
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100770
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001462
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100770
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/CHS-ingest/d_dimer.yaml
+++ b/priority_variables_transform/CHS-ingest/d_dimer.yaml
@@ -15,14 +15,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001449
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00098765
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001449
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00098765
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001449
@@ -40,14 +40,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001449
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00098768
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001449
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00098768
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001457
@@ -63,11 +63,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001457
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100687
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001457
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100687
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/CHS-ingest/edu_lvl.yaml
+++ b/priority_variables_transform/CHS-ingest/edu_lvl.yaml
@@ -11,22 +11,22 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_concept:
-                populated_from: phv00098802
-                value_mappings:
-                  '8': 8TH_GRADE_OR_LESS
-                  '9': HIGH_SCHOOL_NO_DIPLOMA
-                  '10': HIGH_SCHOOL_NO_DIPLOMA
-                  '11': HIGH_SCHOOL_NO_DIPLOMA
-                  '12': HIGH_SCHOOL_GRADUATE_GED
-                  '14': SOME_COLLEGE_OR_TECH_NO_DEGREE
-                  '17': SOME_COLLEGE_OR_TECH_NO_DEGREE
-                  '18': SOME_COLLEGE_OR_TECH_NO_DEGREE
-                  '20': COLLEGE_OR_TECH_WITH_DEGREE
-                  '21': MASTERS_OR_DOCTORAL_DEGREE
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00098802
+                  value_mappings:
+                    '8': 8TH_GRADE_OR_LESS
+                    '9': HIGH_SCHOOL_NO_DIPLOMA
+                    '10': HIGH_SCHOOL_NO_DIPLOMA
+                    '11': HIGH_SCHOOL_NO_DIPLOMA
+                    '12': HIGH_SCHOOL_GRADUATE_GED
+                    '14': SOME_COLLEGE_OR_TECH_NO_DEGREE
+                    '17': SOME_COLLEGE_OR_TECH_NO_DEGREE
+                    '18': SOME_COLLEGE_OR_TECH_NO_DEGREE
+                    '20': COLLEGE_OR_TECH_WITH_DEGREE
+                    '21': MASTERS_OR_DOCTORAL_DEGREE
 - class_derivations:
     Observation:
       populated_from: pht001490
@@ -40,19 +40,19 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_concept:
-                populated_from: phv00105119
-                value_mappings:
-                  '6': 8TH_GRADE_OR_LESS
-                  '7': 8TH_GRADE_OR_LESS
-                  '8': 8TH_GRADE_OR_LESS
-                  '9': HIGH_SCHOOL_NO_DIPLOMA
-                  '10': HIGH_SCHOOL_NO_DIPLOMA
-                  '11': HIGH_SCHOOL_NO_DIPLOMA
-                  '12': HIGH_SCHOOL_GRADUATE_GED
-                  '18': SOME_COLLEGE_OR_TECH_NO_DEGREE
-                  '20': COLLEGE_OR_TECH_WITH_DEGREE
-                  '21': MASTERS_OR_DOCTORAL_DEGREE
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00105119
+                  value_mappings:
+                    '6': 8TH_GRADE_OR_LESS
+                    '7': 8TH_GRADE_OR_LESS
+                    '8': 8TH_GRADE_OR_LESS
+                    '9': HIGH_SCHOOL_NO_DIPLOMA
+                    '10': HIGH_SCHOOL_NO_DIPLOMA
+                    '11': HIGH_SCHOOL_NO_DIPLOMA
+                    '12': HIGH_SCHOOL_GRADUATE_GED
+                    '18': SOME_COLLEGE_OR_TECH_NO_DEGREE
+                    '20': COLLEGE_OR_TECH_WITH_DEGREE
+                    '21': MASTERS_OR_DOCTORAL_DEGREE

--- a/priority_variables_transform/CHS-ingest/factor_7.yaml
+++ b/priority_variables_transform/CHS-ingest/factor_7.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100038
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100038
+                unit:
+                  value: '%{Normal}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100424
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100424
+                unit:
+                  value: '%{Normal}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100503
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100503
+                unit:
+                  value: '%{Normal}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -88,14 +88,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105863
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105863
+                unit:
+                  value: '%{Normal}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -113,11 +113,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106988
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106988
+                unit:
+                  value: '%{Normal}'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/factor_8.yaml
+++ b/priority_variables_transform/CHS-ingest/factor_8.yaml
@@ -13,11 +13,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00100039} * 0.01'
-              unit:
-                value: '[IU]/mL'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00100039} * 0.01'
+                unit:
+                  value: '[IU]/mL'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/fam_income.yaml
+++ b/priority_variables_transform/CHS-ingest/fam_income.yaml
@@ -11,24 +11,24 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_concept:
-                populated_from: phv00108778
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $24,999
-                  '6': $25,000 - $34,999
-                  '7': $35,000 - $49,999
-                  '8': $50,000 - $74,999
-                  '9': $75,000 - $99,999
-                  '10': '> $100,000'
-              unit:
-                value: USD
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00108778
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $24,999
+                    '6': $25,000 - $34,999
+                    '7': $35,000 - $49,999
+                    '8': $50,000 - $74,999
+                    '9': $75,000 - $99,999
+                    '10': '> $100,000'
+                unit:
+                  value: USD
 - class_derivations:
     Observation:
       populated_from: pht001494
@@ -42,24 +42,24 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_concept:
-                populated_from: phv00109486
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $24,999
-                  '6': $25,000 - $34,999
-                  '7': $35,000 - $49,999
-                  '8': $50,000 - $74,999
-                  '9': $75,000 - $99,999
-                  '10': '> $100,000'
-              unit:
-                value: USD
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00109486
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $24,999
+                    '6': $25,000 - $34,999
+                    '7': $35,000 - $49,999
+                    '8': $50,000 - $74,999
+                    '9': $75,000 - $99,999
+                    '10': '> $100,000'
+                unit:
+                  value: USD
 - class_derivations:
     Observation:
       populated_from: pht001495
@@ -73,21 +73,21 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_concept:
-                populated_from: phv00110162
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $24,999
-                  '6': $25,000 - $34,999
-                  '7': $35,000 - $49,999
-                  '8': $50,000 - $74,999
-                  '9': $75,000 - $99,999
-                  '10': '> $100,000'
-              unit:
-                value: USD
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00110162
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $24,999
+                    '6': $25,000 - $34,999
+                    '7': $35,000 - $49,999
+                    '8': $50,000 - $74,999
+                    '9': $75,000 - $99,999
+                    '10': '> $100,000'
+                unit:
+                  value: USD

--- a/priority_variables_transform/CHS-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/CHS-ingest/fast_gluc_bld.yaml
@@ -15,11 +15,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110485
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110485
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/fibrin.yaml
+++ b/priority_variables_transform/CHS-ingest/fibrin.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100037
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100037
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100423
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100423
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105862
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105862
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106987
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106987
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/CHS-ingest/fruit_serving.yaml
@@ -13,14 +13,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00099896} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00099896} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -38,11 +38,11 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105773} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105773} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/CHS-ingest/glucose_bld.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100045
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100045
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100427
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100427
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105867
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105867
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106994
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106994
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/hdl.yaml
+++ b/priority_variables_transform/CHS-ingest/hdl.yaml
@@ -10,14 +10,14 @@
           expr: case(({phv00099923} >= 12, 'OMOP:4041720'), (True, 'OBA:VT0000184'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100042
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100042
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00099923} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -35,14 +35,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100426
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100426
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -58,14 +58,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105865
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105865
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -81,11 +81,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106991
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106991
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/hemat.yaml
+++ b/priority_variables_transform/CHS-ingest/hemat.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099860
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099860
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100413
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100413
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105618
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105618
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106920
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106920
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/hemo.yaml
+++ b/priority_variables_transform/CHS-ingest/hemo.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099859
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099859
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100412
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100412
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105617
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105617
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106919
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106919
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/hip_circ.yaml
+++ b/priority_variables_transform/CHS-ingest/hip_circ.yaml
@@ -19,14 +19,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099350
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099350
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -48,14 +48,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100384
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100384
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -77,14 +77,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105415
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105415
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -106,11 +106,11 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106777
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106777
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/CHS-ingest/hrtrt.yaml
+++ b/priority_variables_transform/CHS-ingest/hrtrt.yaml
@@ -15,14 +15,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00099357} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00099357} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -43,14 +43,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00099380} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00099380} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate supine
           range: string
@@ -71,14 +71,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00099387} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00099387} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate standing
           range: string
@@ -99,14 +99,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00099427} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00099427} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -127,14 +127,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00099429} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00099429} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -153,14 +153,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099700
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099700
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -179,14 +179,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100054
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100054
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -204,14 +204,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00100389} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00100389} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -232,14 +232,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00100396} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00100396} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate supine
           range: string
@@ -260,14 +260,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00100399} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00100399} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate standing
           range: string
@@ -288,14 +288,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00101728} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00101728} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -316,14 +316,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00101730} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00101730} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -344,14 +344,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00101754
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00101754
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -372,14 +372,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00101773} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00101773} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -400,14 +400,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00101969
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00101969
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001475
@@ -425,14 +425,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00102470} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00102470} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -453,14 +453,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00102497
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00102497
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -481,14 +481,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00102548} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00102548} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -509,14 +509,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00102550} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00102550} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -537,14 +537,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00102591
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00102591
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001488
@@ -560,14 +560,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001488
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00104009} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001488
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00104009} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -586,14 +586,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001488
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104315
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001488
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104315
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -612,14 +612,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001488
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104326
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001488
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104326
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001489
@@ -637,14 +637,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00104686} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00104686} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -665,14 +665,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00104740} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00104740} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -693,14 +693,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00104742} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00104742} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -721,14 +721,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104964
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104964
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -749,14 +749,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104980
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104980
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -774,14 +774,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105423} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105423} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -802,14 +802,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105455} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105455} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate supine
           range: string
@@ -830,14 +830,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105462} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105462} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate standing
           range: string
@@ -858,14 +858,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105839} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105839} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -886,14 +886,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105841} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105841} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -914,14 +914,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106347
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106347
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -939,14 +939,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106374
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106374
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -967,14 +967,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00106785} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00106785} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -995,14 +995,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00106817} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00106817} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate supine
           range: string
@@ -1023,14 +1023,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00106824} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00106824} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate standing
           range: string
@@ -1051,14 +1051,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00106963} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00106963} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -1079,14 +1079,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00106965} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00106965} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -1107,14 +1107,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00107286
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00107286
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -1132,14 +1132,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00107310
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00107310
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -1160,14 +1160,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00107483} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00107483} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -1188,14 +1188,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00107485} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00107485} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -1216,14 +1216,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00107753} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00107753} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -1244,14 +1244,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108162
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108162
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001492
@@ -1269,14 +1269,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108186
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108186
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -1297,14 +1297,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00108484} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00108484} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -1325,14 +1325,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108516
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108516
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -1353,14 +1353,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108784
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108784
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001493
@@ -1378,14 +1378,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108926
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108926
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1406,14 +1406,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00109248
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00109248
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -1434,14 +1434,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00109303} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00109303} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -1462,14 +1462,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00109305} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00109305} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -1490,14 +1490,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00109315
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00109315
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -1515,14 +1515,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00109861
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00109861
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -1540,14 +1540,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00110268} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00110268} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate
           range: string
@@ -1568,14 +1568,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00110316} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00110316} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate before chair stands
           range: string
@@ -1596,14 +1596,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00110318} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00110318} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 30 second heart rate after chair stands
           range: string
@@ -1624,14 +1624,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110498
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110498
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: 60 second heart rate
           range: string
@@ -1650,14 +1650,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199731
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199731
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1676,14 +1676,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199734
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199734
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1702,14 +1702,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199737
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199737
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1728,14 +1728,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199740
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199740
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1754,14 +1754,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199743
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199743
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1780,14 +1780,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199746
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199746
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1806,14 +1806,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199749
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199749
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1832,14 +1832,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199752
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199752
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1858,14 +1858,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199755
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199755
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1884,14 +1884,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199758
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199758
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1910,14 +1910,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199761
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199761
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1936,14 +1936,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199764
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199764
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1962,14 +1962,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199767
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199767
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -1988,14 +1988,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199770
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199770
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -2014,14 +2014,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199773
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199773
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string
@@ -2040,14 +2040,14 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00199776
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00199776
+                unit:
+                  value: '{beats}/min'
+                  range: string
         method_type:
           value: average
           range: string

--- a/priority_variables_transform/CHS-ingest/icam.yaml
+++ b/priority_variables_transform/CHS-ingest/icam.yaml
@@ -15,11 +15,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001449
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00098764
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001449
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00098764
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/il6.yaml
+++ b/priority_variables_transform/CHS-ingest/il6.yaml
@@ -15,11 +15,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100500
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100500
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/CHS-ingest/insulin_blood.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00100044} * 6'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00100044} * 6'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00100428} * 6'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00100428} * 6'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105866} * 6'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105866} * 6'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00106993} * 6'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00106993} * 6'
+                unit:
+                  value: pmol/L
+                  range: string

--- a/priority_variables_transform/CHS-ingest/ldl.yaml
+++ b/priority_variables_transform/CHS-ingest/ldl.yaml
@@ -11,14 +11,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100282
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100282
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: adjusted
           range: string
@@ -37,14 +37,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100492
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100492
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: adjusted
           range: string
@@ -63,14 +63,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106416
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106416
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: adjusted
           range: string
@@ -89,14 +89,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00107344
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00107344
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: adjusted
           range: string

--- a/priority_variables_transform/CHS-ingest/lppla2_act.yaml
+++ b/priority_variables_transform/CHS-ingest/lppla2_act.yaml
@@ -15,11 +15,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001449
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00098770
-              unit:
-                value: nmol/min/mL
-                range: string
+          - Quantity:
+              populated_from: pht001449
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00098770
+                unit:
+                  value: nmol/min/mL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/lppla2_mass.yaml
+++ b/priority_variables_transform/CHS-ingest/lppla2_mass.yaml
@@ -15,11 +15,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001449
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00098769
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001449
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00098769
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/person.yaml
+++ b/priority_variables_transform/CHS-ingest/person.yaml
@@ -20,25 +20,25 @@
           expr: 'case(({pht001464.phv00100774} == 1, "OMOP:434489"), ({pht001464.phv00100774} == 0, "OMOP:4230556"))'
         cause_of_death:
           class_derivations:
-          - name: CauseOfDeath
-            populated_from: pht001447
-            joins:
-              pht001464:
-                source_key: phv00098755
-                lookup_key: phv00100773
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001464.phv00100775} == 1, "ICD10CM:I20-I25"), ({pht001464.phv00100775} == 2, "ICD10CM:I60-I69"), ({pht001464.phv00100775} == 3, "ICD10CM:I70"), ({pht001464.phv00100775} == 4, "ICD10CM:I00-I99"))'
-              order:
-                value: 1
-          - name: CauseOfDeath
-            populated_from: pht001447
-            joins:
-              pht001466:
-                source_key: phv00098755
-                lookup_key: phv00100808
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001466.phv00100832} == 1, "ICD10CM:I20-I25"), ({pht001466.phv00100832} == 2, "ICD10CM:I60-I69"), ({pht001466.phv00100832} == 3, "ICD10CM:I70"), ({pht001466.phv00100832} == 4, "ICD10CM:I00-I99"))'
-              order:
-                value: 2
+          - CauseOfDeath:
+              populated_from: pht001447
+              joins:
+                pht001464:
+                  source_key: phv00098755
+                  lookup_key: phv00100773
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001464.phv00100775} == 1, "ICD10CM:I20-I25"), ({pht001464.phv00100775} == 2, "ICD10CM:I60-I69"), ({pht001464.phv00100775} == 3, "ICD10CM:I70"), ({pht001464.phv00100775} == 4, "ICD10CM:I00-I99"))'
+                order:
+                  value: 1
+          - CauseOfDeath:
+              populated_from: pht001447
+              joins:
+                pht001466:
+                  source_key: phv00098755
+                  lookup_key: phv00100808
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001466.phv00100832} == 1, "ICD10CM:I20-I25"), ({pht001466.phv00100832} == 2, "ICD10CM:I60-I69"), ({pht001466.phv00100832} == 3, "ICD10CM:I70"), ({pht001466.phv00100832} == 4, "ICD10CM:I00-I99"))'
+                order:
+                  value: 2

--- a/priority_variables_transform/CHS-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/CHS-ingest/platelet_ct.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099861
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099861
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100414
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100414
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105619
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105619
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106921
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106921
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/potassium.yaml
+++ b/priority_variables_transform/CHS-ingest/potassium.yaml
@@ -13,14 +13,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100047
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100047
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -38,14 +38,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100430
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100430
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -63,14 +63,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105869
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105869
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -88,11 +88,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106996
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106996
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/CHS-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/CHS-ingest/qrs_ekg.yaml
@@ -15,14 +15,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100061
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100061
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -40,14 +40,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100451
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100451
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001474
@@ -65,14 +65,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001474
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00101976
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001474
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00101976
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001475
@@ -90,14 +90,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00102977
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00102977
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001488
@@ -115,14 +115,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001488
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104332
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001488
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104332
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001489
@@ -140,14 +140,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001489
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00104986
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001489
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00104986
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -165,14 +165,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106353
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106353
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -190,14 +190,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00107292
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00107292
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001492
@@ -215,14 +215,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001492
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108168
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001492
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108168
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001493
@@ -240,14 +240,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001493
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00108791
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001493
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00108791
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001494
@@ -265,14 +265,14 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00109322
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00109322
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -290,11 +290,11 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00109868
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00109868
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/CHS-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/CHS-ingest/sleep_duration_daily.yaml
@@ -15,14 +15,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001460
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100712
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht001460
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100712
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001460
@@ -40,14 +40,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001460
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100713
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht001460
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100713
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -63,14 +63,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00197566
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00197566
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -86,14 +86,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                expr: "case(({phv00197658} == 9999, None), (True, {phv00197658}))"
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  expr: "case(({phv00197658} == 9999, None), (True, {phv00197658}))"
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -109,14 +109,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                expr: "case(({phv00197659} == 9000, None), ({phv00197659} == 9999, None), (True, {phv00197659}))"
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  expr: "case(({phv00197659} == 9000, None), ({phv00197659} == 9999, None), (True, {phv00197659}))"
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003699
@@ -132,14 +132,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003699
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00197707} / 60'
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003699
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00197707} / 60'
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -155,14 +155,14 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00199793} / 60'
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00199793} / 60'
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003700
@@ -178,11 +178,11 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003700
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00200010} / 60'
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003700
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00200010} / 60'
+                unit:
+                  value: h
+                  range: string

--- a/priority_variables_transform/CHS-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/CHS-ingest/sodium_intak.yaml
@@ -13,14 +13,14 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100131
-              unit:
-                value: mg/d
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100131
+                unit:
+                  value: mg/d
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001494
@@ -38,11 +38,11 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001494
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00109552
-              unit:
-                value: mg/d
-                range: string
+          - Quantity:
+              populated_from: pht001494
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00109552
+                unit:
+                  value: mg/d
+                  range: string

--- a/priority_variables_transform/CHS-ingest/spirometry.yaml
+++ b/priority_variables_transform/CHS-ingest/spirometry.yaml
@@ -22,186 +22,186 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00099663}) + ":CHS BASELINE 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099664
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099665
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011505"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "calculated"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099666
-                    unit:
-                      value: "%"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099670
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3022891"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099671
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3024594"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00099672} * 100'
-                    unit:
-                      value: "%"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3005600"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "calculated"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099667
-                    unit:
-                      value: "%"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011708"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "calculated"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099668
-                    unit:
-                      value: "%"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001451
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4196583"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "calculated"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001451
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00099669
-                    unit:
-                      value: "%"
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099664
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099665
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011505"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "calculated"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099666
+                        unit:
+                          value: "%"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099670
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3022891"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099671
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3024594"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00099672} * 100'
+                        unit:
+                          value: "%"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3005600"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "calculated"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099667
+                        unit:
+                          value: "%"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011708"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "calculated"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099668
+                        unit:
+                          value: "%"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001451
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4196583"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "calculated"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001451
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00099669
+                        unit:
+                          value: "%"
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001492
@@ -212,94 +212,94 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00107443}) + ":CHS YEAR 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001492
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00107780} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001492
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00107762
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001492
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00107780} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001492
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00107763
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001492
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00107780} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001492
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00107764
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001492
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011708"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00107780} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001492
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00107765
-                    unit:
-                      value: "%"
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001492
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00107780} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001492
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00107762
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001492
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00107780} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001492
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00107763
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001492
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00107780} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001492
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00107764
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001492
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011708"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00107780} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001492
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00107765
+                        unit:
+                          value: "%"
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001495
@@ -310,91 +310,91 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00109768}) + ":CHS YEAR 9")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001495
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00109855} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001495
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00110364
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001495
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00109855} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001495
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00110365
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001495
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3002094"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00109855} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001495
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00110359
-                    unit:
-                      value: "L"
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001495
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011708"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-              method_type:
-                value: "spirometry"
-              age_at_observation:
-                expr: '{phv00109855} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001495
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00110360
-                    unit:
-                      value: "%"
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001495
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00109855} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001495
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00110364
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001495
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00109855} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001495
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00110365
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001495
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3002094"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00109855} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001495
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00110359
+                        unit:
+                          value: "L"
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001495
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011708"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                method_type:
+                  value: "spirometry"
+                age_at_observation:
+                  expr: '{phv00109855} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001495
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00110360
+                        unit:
+                          value: "%"
+                          range: string

--- a/priority_variables_transform/CHS-ingest/spo2.yaml
+++ b/priority_variables_transform/CHS-ingest/spo2.yaml
@@ -13,17 +13,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_concept:
-                populated_from: phv00110401
-                value_mappings:
-                  '0': '<90'
-                  '1': '>90'
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00110401
+                  value_mappings:
+                    '0': '<90'
+                    '1': '>90'
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -39,14 +39,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110402
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110402
+                unit:
+                  value: '%'
+                  range: string
         method_type:
           value: baseline
           range: string
@@ -65,14 +65,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110418
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110418
+                unit:
+                  value: '%'
+                  range: string
         method_type:
           value: exercise
           range: string

--- a/priority_variables_transform/CHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/CHS-ingest/tot_chol_bld.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100491
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100491
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: adjusted
           range: string

--- a/priority_variables_transform/CHS-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/CHS-ingest/triglyc_bld.yaml
@@ -10,14 +10,14 @@
           expr: case(({phv00099923} >= 12, 'OMOP:4041722'), (True, 'OBA:VT0002644'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001451
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100041
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001451
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100041
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00099923} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -35,14 +35,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100425
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100425
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -56,14 +56,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105864
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105864
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -79,11 +79,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106990
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106990
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/CHS-ingest/vege_serving.yaml
+++ b/priority_variables_transform/CHS-ingest/vege_serving.yaml
@@ -15,11 +15,11 @@
           value: "Food Frequency Questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00105771} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00105771} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/CHS-ingest/waist_circ.yaml
+++ b/priority_variables_transform/CHS-ingest/waist_circ.yaml
@@ -19,14 +19,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001450
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00099351
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001450
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00099351
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001452
@@ -48,14 +48,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100385
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100385
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001475
@@ -77,14 +77,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001475
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00102455
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001475
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00102455
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001490
@@ -106,14 +106,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001490
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00105416
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001490
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00105416
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001491
@@ -135,14 +135,14 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001491
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00106778
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001491
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00106778
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001495
@@ -164,11 +164,11 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001495
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00110377
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001495
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00110377
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/CHS-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/CHS-ingest/whtbld_ct.yaml
@@ -15,11 +15,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001452
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00100411
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001452
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00100411
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/COPDGene-ingest/alcohol.yaml
+++ b/priority_variables_transform/COPDGene-ingest/alcohol.yaml
@@ -19,12 +19,12 @@
           value: OMOP:35609491
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                expr: "case(({phv00568915} == '0', 0), ({phv00568915} == '1',\
-                  \ 0), ({phv00568915} == '2', 1), ({phv00568915} == '3', 3),\
-                  \ ({phv00568915} == '4', 5))"
-              unit:
-                value: '{#}/wk'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  expr: "case(({phv00568915} == '0', 0), ({phv00568915} == '1',\
+                    \ 0), ({phv00568915} == '2', 1), ({phv00568915} == '3', 3),\
+                    \ ({phv00568915} == '4', 5))"
+                unit:
+                  value: '{#}/wk'

--- a/priority_variables_transform/COPDGene-ingest/basophil_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/basophil_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569142
-              unit:
-                value: '10*3/uL'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569142
+                unit:
+                  value: '10*3/uL'

--- a/priority_variables_transform/COPDGene-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/COPDGene-ingest/bdy_hgt.yaml
@@ -19,10 +19,10 @@
           value: anthropometry
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00159592
-              unit:
-                value: cm
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00159592
+                unit:
+                  value: cm

--- a/priority_variables_transform/COPDGene-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/COPDGene-ingest/bdy_wgt.yaml
@@ -19,10 +19,10 @@
           value: anthropometry
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00159591
-              unit:
-                value: kg
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00159591
+                unit:
+                  value: kg

--- a/priority_variables_transform/COPDGene-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/COPDGene-ingest/blood_pressure.yaml
@@ -13,43 +13,43 @@
             uuid5('https://w3id.org/bdchm/Visit', str({phv00159568}) + ':COPDGene P3B')))
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: automated sphygmomanometer
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159590
-                    unit:
-                      value: 'mm[Hg]'
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: automated sphygmomanometer
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159583
-                    unit:
-                      value: 'mm[Hg]'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: automated sphygmomanometer
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159590
+                        unit:
+                          value: 'mm[Hg]'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: automated sphygmomanometer
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159583
+                        unit:
+                          value: 'mm[Hg]'

--- a/priority_variables_transform/COPDGene-ingest/bmi.yaml
+++ b/priority_variables_transform/COPDGene-ingest/bmi.yaml
@@ -19,10 +19,10 @@
           value: calculated
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00159593
-              unit:
-                value: kg/m2
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00159593
+                unit:
+                  value: kg/m2

--- a/priority_variables_transform/COPDGene-ingest/eosinophil_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/eosinophil_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569140
-              unit:
-                value: '10*3/uL'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569140
+                unit:
+                  value: '10*3/uL'

--- a/priority_variables_transform/COPDGene-ingest/hemat.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hemat.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569146
-              unit:
-                value: '%'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569146
+                unit:
+                  value: '%'

--- a/priority_variables_transform/COPDGene-ingest/hemo.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hemo.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569145
-              unit:
-                value: g/dL
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569145
+                unit:
+                  value: g/dL

--- a/priority_variables_transform/COPDGene-ingest/hrt_rt.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hrt_rt.yaml
@@ -21,10 +21,10 @@
           value: resting vital signs
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00159584
-              unit:
-                expr: '{beats}/min'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00159584
+                unit:
+                  expr: '{beats}/min'

--- a/priority_variables_transform/COPDGene-ingest/lymphocyte_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/lymphocyte_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569136
-              unit:
-                value: '10*3/uL'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569136
+                unit:
+                  value: '10*3/uL'

--- a/priority_variables_transform/COPDGene-ingest/mch.yaml
+++ b/priority_variables_transform/COPDGene-ingest/mch.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569148
-              unit:
-                value: pg
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569148
+                unit:
+                  value: pg

--- a/priority_variables_transform/COPDGene-ingest/mchc.yaml
+++ b/priority_variables_transform/COPDGene-ingest/mchc.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569149
-              unit:
-                value: g/dL
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569149
+                unit:
+                  value: g/dL

--- a/priority_variables_transform/COPDGene-ingest/mcv.yaml
+++ b/priority_variables_transform/COPDGene-ingest/mcv.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569147
-              unit:
-                value: fL
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569147
+                unit:
+                  value: fL

--- a/priority_variables_transform/COPDGene-ingest/monocyte_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/monocyte_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569138
-              unit:
-                value: '10*3/uL'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569138
+                unit:
+                  value: '10*3/uL'

--- a/priority_variables_transform/COPDGene-ingest/neutrophil_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/neutrophil_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569134
-              unit:
-                value: '10*3/uL'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569134
+                unit:
+                  value: '10*3/uL'

--- a/priority_variables_transform/COPDGene-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/platelet_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569150
-              unit:
-                value: 10*3/uL
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569150
+                unit:
+                  value: 10*3/uL

--- a/priority_variables_transform/COPDGene-ingest/rbc.yaml
+++ b/priority_variables_transform/COPDGene-ingest/rbc.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569144
-              unit:
-                value: '10*6/uL'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569144
+                unit:
+                  value: '10*6/uL'

--- a/priority_variables_transform/COPDGene-ingest/spirometry.yaml
+++ b/priority_variables_transform/COPDGene-ingest/spirometry.yaml
@@ -14,162 +14,162 @@
             uuid5('https://w3id.org/bdchm/Visit', str({phv00159568}) + ':COPDGene P3B')))
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159853
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159854
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00159855} * 100'
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Hankinson
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00569175
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Hankinson
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00569177
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: Hankinson
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00569179} * 100'
-                    unit:
-                      value: '%'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159853
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159854
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00159855} * 100'
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Hankinson
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00569175
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Hankinson
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00569177
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: Hankinson
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00569179} * 100'
+                        unit:
+                          value: '%'
 # Post-bronchodilator spirometry observation set
 - class_derivations:
     MeasurementObservationSet:
@@ -186,163 +186,163 @@
             uuid5('https://w3id.org/bdchm/Visit', str({phv00159568}) + ':COPDGene P3B')))
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159851
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159852
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00159850} * 100'
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011708
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159848
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht002239
-            slot_derivations:
-              observation_type:
-                value: OMOP:3005600
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00568808} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht002239
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00159849
-                    unit:
-                      value: '%'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159851
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159852
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00159850} * 100'
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011708
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159848
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht002239
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3005600
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00568808} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht002239
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00159849
+                        unit:
+                          value: '%'

--- a/priority_variables_transform/COPDGene-ingest/spo2.yaml
+++ b/priority_variables_transform/COPDGene-ingest/spo2.yaml
@@ -19,10 +19,10 @@
           value: resting pulse oximetry
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00159589} <= 1, {phv00159589} * 100), (True, {phv00159589}))
-              unit:
-                value: '%'
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00159589} <= 1, {phv00159589} * 100), (True, {phv00159589}))
+                unit:
+                  value: '%'

--- a/priority_variables_transform/COPDGene-ingest/waist_circ.yaml
+++ b/priority_variables_transform/COPDGene-ingest/waist_circ.yaml
@@ -21,10 +21,10 @@
           value: Abdomen
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00568826
-              unit:
-                value: cm
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00568826
+                unit:
+                  value: cm

--- a/priority_variables_transform/COPDGene-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/COPDGene-ingest/whtbld_ct.yaml
@@ -19,10 +19,10 @@
           value: CBC
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002239
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00569133
-              unit:
-                value: 10*3/uL
+          - Quantity:
+              populated_from: pht002239
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00569133
+                unit:
+                  value: 10*3/uL

--- a/priority_variables_transform/FHS-ingest/albumin_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/albumin_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007562} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007562} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008089} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008089} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172164
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172164
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227048
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227048
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -115,14 +115,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081013
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081013
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -138,11 +138,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276864
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276864
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/FHS-ingest/albumin_urine.yaml
@@ -15,28 +15,28 @@
           value: 'immunoturbidometric assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                         ({phv00071895} > 3, {phv00071895}),
-                         (True, None)
-                      )'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                           ({phv00071895} > 3, {phv00071895}),
+                           (True, None)
+                        )'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                value: '3.0'
-                range: string
-              unit:
-                value: mg/L
-                range: string                    
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  value: '3.0'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000016
@@ -52,24 +52,24 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000016
-            slot_derivations:
-              value_concept:
-                populated_from: phv00002422
-                value_mappings:
-                  'NEGATIVE': 0
-                  '10': 100
-                  '30': 300
-                  '100': 1000
-                  '300': 3000
-                  '20': 200
-                  '5': 50
-                  '200': 2000
-                  '40': 400
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000016
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00002422
+                  value_mappings:
+                    'NEGATIVE': 0
+                    '10': 100
+                    '30': 300
+                    '100': 1000
+                    '300': 3000
+                    '20': 200
+                    '5': 50
+                    '200': 2000
+                    '40': 400
+                unit:
+                  value: mg/L
+                  range: string
         method_type: 
           value: dipstick
 - class_derivations:
@@ -87,25 +87,25 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_concept:
-                populated_from: phv00007968
-                value_mappings:
-                  '10': 100
-                  '0': 0
-                  '1': 10
-                  '3': 30
-                  '3000': 30000
-                  '2000': 20000
-                  '1000': 10000
-                  '3003': 30030
-                  '9000': 90000
-                  '1003': 10030
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00007968
+                  value_mappings:
+                    '10': 100
+                    '0': 0
+                    '1': 10
+                    '3': 30
+                    '3000': 30000
+                    '2000': 20000
+                    '1000': 10000
+                    '3003': 30030
+                    '9000': 90000
+                    '1003': 10030
+                unit:
+                  value: mg/L
+                  range: string
         method_type: 
           value: dipstick
 - class_derivations:
@@ -123,20 +123,20 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000032
-            slot_derivations:
-              value_concept:
-                populated_from: phv00008722
-                value_mappings:
-                  'TRACE': 100
-                  'NEG': 0
-                  'SM': 300
-                  'MOD': 1000
-                  '300-2000 LG': '> 3000'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000032
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00008722
+                  value_mappings:
+                    'TRACE': 100
+                    'NEG': 0
+                    'SM': 300
+                    'MOD': 1000
+                    '300-2000 LG': '> 3000'
+                unit:
+                  value: mg/L
+                  range: string
         method_type: 
           value: dipstick
 - class_derivations:
@@ -154,24 +154,24 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000017
-            slot_derivations:
-              value_concept:
-                populated_from: phv00002662
-                value_mappings:
-                  'NEGATIVE': 0
-                  '10': 100
-                  '30': 300
-                  '100': 1000
-                  '300': 3000
-                  '20': 200
-                  '5': 50
-                  '200': 2000
-                  '40': 400
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000017
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00002662
+                  value_mappings:
+                    'NEGATIVE': 0
+                    '10': 100
+                    '30': 300
+                    '100': 1000
+                    '300': 3000
+                    '20': 200
+                    '5': 50
+                    '200': 2000
+                    '40': 400
+                unit:
+                  value: mg/L
+                  range: string
         method_type: 
           value: dipstick
 - class_derivations:
@@ -191,29 +191,29 @@
           value: 'urine assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_concept:
-                expr: 'case(
-                         ({phv00172161} > 3.0, {phv00172161}),
-                         ({phv00227069} == 1, None),
-                         (True, {phv00172161})
-                      )'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_concept:
+                  expr: 'case(
+                           ({phv00172161} > 3.0, {phv00172161}),
+                           ({phv00227069} == 1, None),
+                           (True, {phv00172161})
+                        )'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                value: '3.0'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  value: '3.0'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -229,28 +229,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                         ({phv00071895} > 3, {phv00071895}),
-                         (True, None)
-                      )'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                           ({phv00071895} > 3, {phv00071895}),
+                           (True, None)
+                        )'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                value: '3.0'
-                range: string
-              unit:
-                value: mg/L
-                range: string                       
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  value: '3.0'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string                       
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -268,18 +268,18 @@
           value: 'urine assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                        ({phv00227045} > 3.0, {phv00227045}),
-                        ({phv00227069} == 1, None),
-                        (True, {phv00227045})
-                      )'                  
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                          ({phv00227045} > 3.0, {phv00227045}),
+                          ({phv00227069} == 1, None),
+                          (True, {phv00227045})
+                        )'                  
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004363
@@ -297,29 +297,29 @@
           value: 'turbidometric assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004363
-            slot_derivations:
-              value_concept:
-                expr: 'case(
-                        ({phv00219547} > 3.0, {phv00219547}),
-                        ({phv00219549} == 1, None),
-                        (True, {phv00219547})
-                      )'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004363
+              slot_derivations:
+                value_concept:
+                  expr: 'case(
+                          ({phv00219547} > 3.0, {phv00219547}),
+                          ({phv00219549} == 1, None),
+                          (True, {phv00219547})
+                        )'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004363
-            slot_derivations:
-              value_decimal:
-                value: '3.0'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004363
+              slot_derivations:
+                value_decimal:
+                  value: '3.0'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000313
@@ -337,22 +337,22 @@
           value: immunoturbidometric
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000313
-            slot_derivations:
-              value_concept:
-                populated_from: phv00036493
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000313
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00036493
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004363
-            slot_derivations:
-              value_decimal:
-                value: '3.0'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004363
+              slot_derivations:
+                value_decimal:
+                  value: '3.0'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/FHS-ingest/alt_sgpt.yaml
+++ b/priority_variables_transform/FHS-ingest/alt_sgpt.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008098
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008098
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -38,28 +38,28 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00172166} > 5.0, {phv00172166}), 
-                        ({phv00172202} == 1, None), 
-                        (True, {phv00172166})
-                      )'
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00172166} > 5.0, {phv00172166}), 
+                          ({phv00172202} == 1, None), 
+                          (True, {phv00172166})
+                        )'
+                unit:
+                  value: '[IU]/L'
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                value: '5.0'
-                range: string
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  value: '5.0'
+                  range: string
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -77,29 +77,29 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                        ({phv00227050} > 5.0, {phv00227050}),
-                        ({phv00227066} == 1, None), 
-                        (True, {phv00227050})
-                      )'
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                          ({phv00227050} > 5.0, {phv00227050}),
+                          ({phv00227066} == 1, None), 
+                          (True, {phv00227050})
+                        )'
+                unit:
+                  value: '[IU]/L'
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                value: '5.0'
-                range: string
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  value: '5.0'
+                  range: string
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -117,11 +117,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081020
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081020
+                unit:
+                  value: '[IU]/L'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/apnea_hypop_index.yaml
+++ b/priority_variables_transform/FHS-ingest/apnea_hypop_index.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_concept:
-                populated_from: phv00056501
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00056501
+                unit:
+                  value: /h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -36,14 +36,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055553
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055553
+                unit:
+                  value: /h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000397
@@ -59,11 +59,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000397
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00057941
-              unit:
-                value: /h
-                range: string               
+          - Quantity:
+              populated_from: pht000397
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00057941
+                unit:
+                  value: /h
+                  range: string               

--- a/priority_variables_transform/FHS-ingest/ast_sgot.yaml
+++ b/priority_variables_transform/FHS-ingest/ast_sgot.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007567
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007567
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008093
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008093
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081021
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081021
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172165
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172165
+                unit:
+                  value: '[IU]/L'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -115,11 +115,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227049
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227049
+                unit:
+                  value: '[IU]/L'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/basophil_ncnc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/basophil_ncnc_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172197
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172197
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -40,11 +40,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227044
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227044
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/FHS-ingest/bdy_hgt.yaml
@@ -17,14 +17,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000680} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000680} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -44,14 +44,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000539} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000539} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -71,14 +71,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000744} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000744} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000012
@@ -98,14 +98,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000012
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00001367} / 100) * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000012
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00001367} / 100) * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -125,14 +125,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00001564} / 100) * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00001564} / 100) * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000014
@@ -152,14 +152,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000014
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00001808} / 100) * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000014
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00001808} / 100) * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000015
@@ -179,14 +179,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000015
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00002023} / 100) * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000015
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00002023} / 100) * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000016
@@ -206,14 +206,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000016
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00002207} / 100) * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000016
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00002207} / 100) * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000017
@@ -233,14 +233,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000017
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00002428} / 100) * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000017
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00002428} / 100) * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000018
@@ -260,14 +260,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000018
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002671} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000018
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002671} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000019
@@ -287,14 +287,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000019
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003245} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000019
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003245} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000020
@@ -312,14 +312,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000020
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003303} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000020
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003303} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000021
@@ -339,14 +339,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000021
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003669} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000021
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003669} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -366,14 +366,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004085} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004085} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000023
@@ -393,14 +393,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000023
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004527} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000023
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004527} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000024
@@ -420,14 +420,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000024
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005542} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000024
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005542} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000025
@@ -447,14 +447,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000025
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005922} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000025
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005922} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000026
@@ -474,14 +474,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006034} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006034} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000027
@@ -501,14 +501,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000027
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006329} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000027
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006329} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000028
@@ -528,14 +528,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000028
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006673} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000028
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006673} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000029
@@ -555,14 +555,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000029
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007101} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000029
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007101} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000030
@@ -582,14 +582,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007570} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007570} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -609,14 +609,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007677
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007677
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -636,14 +636,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007679} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007679} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000032
@@ -663,14 +663,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000032
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008714} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000032
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008714} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000033
@@ -690,14 +690,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000033
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008763} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000033
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008763} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000034
@@ -717,14 +717,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000034
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00009553} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000034
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00009553} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000035
@@ -744,14 +744,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010109} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010109} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -771,14 +771,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010499} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010499} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -798,14 +798,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00021231} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00021231} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -825,14 +825,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055258
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055258
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000397
@@ -852,14 +852,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000397
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00056840} / 10'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000397
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00056840} / 10'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000692
@@ -879,14 +879,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000692
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00070555} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000692
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00070555} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000747
@@ -906,14 +906,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000747
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00072337} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000747
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00072337} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003094
@@ -933,14 +933,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003094
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00177539} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003094
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00177539} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004814
@@ -960,14 +960,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004814
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251062} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004814
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251062} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004815
@@ -987,14 +987,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004815
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251535} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004815
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251535} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -1014,14 +1014,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254284} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254284} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005141
@@ -1041,14 +1041,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005141
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254766} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht005141
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254766} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005142
@@ -1068,14 +1068,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005142
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00255158} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht005142
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00255158} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006005
@@ -1095,14 +1095,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006005
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00274053} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006005
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00274053} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006007
@@ -1122,14 +1122,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006007
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00274883} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006007
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00274883} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006007
@@ -1147,14 +1147,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006008
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00275241} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006008
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00275241} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -1174,14 +1174,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277042} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277042} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -1201,14 +1201,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277043} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277043} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -1226,14 +1226,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00520301} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00520301} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1253,14 +1253,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369944} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369944} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1280,14 +1280,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369945} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369945} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1307,14 +1307,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369946} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369946} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1334,14 +1334,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369947} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369947} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1361,14 +1361,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369948} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369948} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1388,14 +1388,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369949} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369949} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1415,14 +1415,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369950} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369950} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1442,14 +1442,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369951} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369951} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1469,14 +1469,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369952} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369952} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1496,14 +1496,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369953} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369953} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1523,14 +1523,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369954} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369954} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1550,14 +1550,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369955} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369955} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1577,14 +1577,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369956} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369956} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1604,14 +1604,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369957} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369957} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1631,14 +1631,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369958} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369958} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1658,14 +1658,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369959} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369959} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1685,14 +1685,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369960} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369960} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1712,14 +1712,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369961} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369961} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1739,14 +1739,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369962} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369962} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1766,14 +1766,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369963} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369963} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1793,14 +1793,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369964} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369964} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1820,14 +1820,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369965} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369965} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1847,14 +1847,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369966} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369966} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1874,14 +1874,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369967} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369967} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1901,14 +1901,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369968} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369968} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1928,14 +1928,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369969} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369969} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1955,14 +1955,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423918} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423918} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1982,14 +1982,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423919} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423919} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -2009,14 +2009,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423920} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423920} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -2036,11 +2036,11 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423921} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423921} * 2.54'
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/FHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/FHS-ingest/bdy_wgt.yaml
@@ -17,14 +17,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007676
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007676
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -44,14 +44,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277055} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277055} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -71,14 +71,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277056} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277056} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -96,14 +96,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00520310} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00520310} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -123,14 +123,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370126} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370126} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -150,24 +150,24 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00370127} < 300, {phv00370127} * 0.453592), (True, "'ULOD'"))
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00370127} < 300, {phv00370127} * 0.453592), (True, "'ULOD'"))
+                unit:
+                  value: kg
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: 300 * 0.453592
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: 300 * 0.453592
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -187,14 +187,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370128} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370128} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -214,14 +214,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370129} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370129} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -241,14 +241,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370130} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370130} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -268,14 +268,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370131} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370131} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -295,14 +295,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370132} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370132} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -322,14 +322,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370133} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370133} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -349,14 +349,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370134} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370134} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -376,14 +376,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370135} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370135} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -403,14 +403,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370136} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370136} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -430,14 +430,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370137} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370137} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -457,14 +457,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370138} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370138} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -484,14 +484,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370139} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370139} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -511,14 +511,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370140} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370140} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -538,14 +538,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370141} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370141} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -565,14 +565,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370142} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370142} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -592,14 +592,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370143} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370143} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -619,24 +619,24 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00370144} < 300, {phv00370144} * 0.453592), (True, "'ULOD'"))
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00370144} < 300, {phv00370144} * 0.453592), (True, "'ULOD'"))
+                unit:
+                  value: kg
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: 300 * 0.453592
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: 300 * 0.453592
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -656,24 +656,24 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00370145} < 300, {phv00370145} * 0.453592), (True, "'ULOD'"))
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00370145} < 300, {phv00370145} * 0.453592), (True, "'ULOD'"))
+                unit:
+                  value: kg
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: 300 * 0.453592
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: 300 * 0.453592
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -693,24 +693,24 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00370146} < 300, {phv00370146} * 0.453592), (True, "'ULOD'"))
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00370146} < 300, {phv00370146} * 0.453592), (True, "'ULOD'"))
+                unit:
+                  value: kg
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: 300 * 0.453592
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: 300 * 0.453592
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -730,24 +730,24 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00370147} < 300, {phv00370147} * 0.453592), (True, "'ULOD'"))
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00370147} < 300, {phv00370147} * 0.453592), (True, "'ULOD'"))
+                unit:
+                  value: kg
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: 300 * 0.453592
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: 300 * 0.453592
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -767,24 +767,24 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00370148} < 300, {phv00370148} * 0.453592), (True, "'ULOD'"))
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00370148} < 300, {phv00370148} * 0.453592), (True, "'ULOD'"))
+                unit:
+                  value: kg
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: 300 * 0.453592
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: 300 * 0.453592
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -804,14 +804,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370149} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370149} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -831,14 +831,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370150} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370150} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -858,14 +858,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370151} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370151} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -885,14 +885,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370152} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370152} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -912,14 +912,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370153} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370153} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -939,14 +939,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370154} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370154} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -966,14 +966,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370155} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370155} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -993,14 +993,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370156} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370156} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1020,14 +1020,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370157} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370157} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1047,14 +1047,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423945} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423945} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1074,14 +1074,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423946} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423946} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1101,14 +1101,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423947} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423947} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1128,14 +1128,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423948} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423948} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1153,14 +1153,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00544874} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00544874} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1178,14 +1178,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00544875} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00544875} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1203,14 +1203,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00544876} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00544876} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1228,14 +1228,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00544877} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00544877} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1253,14 +1253,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00544878} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00544878} * 0.453592'
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1278,11 +1278,11 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00544879} * 0.453592'
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00544879} * 0.453592'
+                unit:
+                  value: kg
+                  range: string

--- a/priority_variables_transform/FHS-ingest/bilirubin_con.yaml
+++ b/priority_variables_transform/FHS-ingest/bilirubin_con.yaml
@@ -15,11 +15,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008097
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008097
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/bilirubin_tot.yaml
+++ b/priority_variables_transform/FHS-ingest/bilirubin_tot.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007564
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007564
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008090
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008090
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -65,25 +65,25 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00081026} >= 0.1, {phv00081026}), (True, None))
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00081026} >= 0.1, {phv00081026}), (True, None))
+                unit:
+                  value: mg/dL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                value: '0.1'
-                range: string
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  value: '0.1'
+                  range: string
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -101,14 +101,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172167
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172167
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -126,14 +126,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227051
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227051
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005144
@@ -151,11 +151,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005144
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255363
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht005144
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255363
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/FHS-ingest/blood_pressure.yaml
@@ -8,54 +8,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010138}) + ":FHS OFFSPRING EXAM 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000035
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000035
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00009905
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000035
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000035
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00009906
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000035
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000035
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00009905
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000035
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000035
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00009906
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000036
@@ -66,54 +66,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00010139}) + ":FHS OFFSPRING EXAM 7")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000036
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000036
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00010360
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000036
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000036
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00010361
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000036
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000036
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00010360
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000036
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000036
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00010361
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000074
@@ -124,54 +124,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00021427}) + ":FHS GENERATION 3 EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000074
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000074
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00021092
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000074
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000074
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00021093
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000074
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000074
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00021092
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000074
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000074
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00021093
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000692
@@ -182,54 +182,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00070736}) + ":FHS ORIGINAL EXAM 28")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000692
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177984} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000692
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00070375
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000692
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177984} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000692
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00070376
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000692
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177984} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000692
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00070375
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000692
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177984} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000692
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00070376
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000747
@@ -240,54 +240,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00072044}) + ":FHS OFFSPRING EXAM 8")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000747
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000747
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00072138
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000747
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000747
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00072139
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000747
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000747
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00072138
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000747
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000747
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00072139
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003094
@@ -299,54 +299,54 @@
             ({phv00177238} == ''72'', ''FHS OMNI 2 EXAM 2''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003094
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003094
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00177352
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003094
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003094
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00177354
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003094
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003094
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00177352
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003094
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003094
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00177354
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004814
@@ -357,54 +357,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00250718}) + ":FHS OMNI 1 EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004814
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004814
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00250915
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004814
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004814
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00250916
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht004814
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004814
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00250915
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004814
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004814
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00250916
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht004815
@@ -415,54 +415,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00251262}) + ":FHS OMNI 1 EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004815
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004815
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00251341
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004815
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004815
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00251342
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht004815
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004815
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00251341
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004815
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004815
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00251342
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht005140
@@ -474,54 +474,54 @@
             VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht005140
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: 'case(({phv00254011} == 1, {pht003099.phv00177946} * 365), ({phv00254011} == 7, {pht003099.phv00177936} * 365))'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005140
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00254087
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005140
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: 'case(({phv00254011} == 1, {pht003099.phv00177946} * 365), ({phv00254011} == 7, {pht003099.phv00177936} * 365))'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005140
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00254089
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht005140
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: 'case(({phv00254011} == 1, {pht003099.phv00177946} * 365), ({phv00254011} == 7, {pht003099.phv00177936} * 365))'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005140
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00254087
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005140
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: 'case(({phv00254011} == 1, {pht003099.phv00177946} * 365), ({phv00254011} == 7, {pht003099.phv00177936} * 365))'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005140
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00254089
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht005141
@@ -532,54 +532,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254596}) + ":FHS ORIGINAL EXAM 29")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht005141
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00226999} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005141
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00254610
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005141
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00226999} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005141
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00254611
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht005141
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00226999} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005141
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00254610
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005141
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00226999} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005141
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00254611
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht005142
@@ -590,54 +590,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00254989}) + ":FHS ORIGINAL EXAM 30")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht005142
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227002} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005142
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00255001
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005142
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227002} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005142
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00255003
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht005142
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227002} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005142
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00255001
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005142
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227002} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005142
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00255003
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006005
@@ -648,54 +648,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00273700}) + ":FHS NEW OFFSPRING SPOUSE EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006005
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006005
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00273914
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006005
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006005
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00273915
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006005
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006005
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00273914
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006005
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006005
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00273915
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006006
@@ -706,50 +706,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00274193}) + ":FHS OMNI 2 EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006006
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006006
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00566077
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006006
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006006
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00566078
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006006
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006006
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00566077
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006006
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006006
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00566078
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006007
@@ -760,54 +760,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00274708}) + ":FHS ORIGINAL EXAM 31")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006007
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227005} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006007
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00274721
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006007
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227005} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006007
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00274723
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006007
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227005} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006007
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00274721
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006007
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227005} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006007
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00274723
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006008
@@ -818,54 +818,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00275063}) + ":FHS ORIGINAL EXAM 32")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006008
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227008} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006008
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00275078
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006008
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227008} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006008
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00275080
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006008
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227008} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006008
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00275078
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006008
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227008} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006008
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00275080
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht010724
@@ -877,50 +877,50 @@
             ({phv00461745} == ''72'', ''FHS OMNI 2 EXAM 3''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht010724
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010724
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00461869
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht010724
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010724
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00461870
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht010724
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010724
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00461869
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht010724
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010724
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00461870
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht015104
@@ -932,50 +932,50 @@
             UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht015104
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: 'case(({phv00545189} == 1, {pht003099.phv00177948} * 365), ({phv00545189} == 7, {pht003099.phv00177938} * 365))'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht015104
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00545293
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht015104
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: 'case(({phv00545189} == 1, {pht003099.phv00177948} * 365), ({phv00545189} == 7, {pht003099.phv00177938} * 365))'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht015104
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00545294
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht015104
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: 'case(({phv00545189} == 1, {pht003099.phv00177948} * 365), ({phv00545189} == 7, {pht003099.phv00177938} * 365))'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht015104
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00545293
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht015104
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: 'case(({phv00545189} == 1, {pht003099.phv00177948} * 365), ({phv00545189} == 7, {pht003099.phv00177938} * 365))'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht015104
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00545294
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -986,54 +986,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370031
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369839
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370031
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369839
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1044,54 +1044,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370032
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369840
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370032
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369840
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1102,54 +1102,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370033
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369841
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370033
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369841
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1160,54 +1160,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177936} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370034
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177936} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369842
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177936} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370034
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177936} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369842
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1218,54 +1218,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370035
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369843
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370035
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369843
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1276,54 +1276,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370036
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369844
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370036
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369844
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1334,54 +1334,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 7")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370037
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369845
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370037
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369845
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1392,54 +1392,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 8")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370038
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369846
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370038
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369846
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1450,54 +1450,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 9")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177946} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370039
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177946} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369847
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177946} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370039
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177946} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369847
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1508,54 +1508,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 10")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177948} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370040
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177948} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369848
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177948} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370040
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177948} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369848
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1566,54 +1566,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 11")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177950} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370041
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177950} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369849
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177950} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370041
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177950} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369849
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1624,54 +1624,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 12")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177952} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370042
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177952} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369850
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177952} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370042
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177952} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369850
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1682,54 +1682,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 13")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177954} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370043
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177954} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369851
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177954} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370043
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177954} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369851
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1740,54 +1740,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 14")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177956} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370044
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177956} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369852
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177956} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370044
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177956} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369852
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1798,54 +1798,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 15")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177958} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370045
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177958} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369853
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177958} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370045
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177958} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369853
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1856,54 +1856,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 16")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177960} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370046
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177960} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369854
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177960} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370046
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177960} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369854
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1914,54 +1914,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 17")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177962} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370047
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177962} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369855
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177962} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370047
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177962} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369855
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -1972,54 +1972,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 18")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177964} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370048
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177964} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369856
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177964} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370048
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177964} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369856
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2030,54 +2030,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 19")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370049
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369857
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370049
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369857
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2088,54 +2088,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 20")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177968} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370050
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177968} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369858
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177968} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370050
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177968} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369858
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2146,54 +2146,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 21")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177970} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370051
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177970} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369859
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177970} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370051
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177970} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369859
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2204,54 +2204,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 22")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177972} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370052
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177972} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369860
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177972} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370052
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177972} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369860
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2262,54 +2262,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 23")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177974} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370053
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177974} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369861
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177974} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370053
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177974} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369861
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2320,54 +2320,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 24")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177976} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370054
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177976} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369862
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177976} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370054
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177976} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369862
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2378,54 +2378,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 25")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177978} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370055
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177978} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369863
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177978} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370055
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177978} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369863
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2436,54 +2436,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 26")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177980} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370056
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177980} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369864
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177980} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370056
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177980} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369864
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2494,54 +2494,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 27")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177982} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370057
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177982} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369865
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177982} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370057
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177982} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369865
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2552,54 +2552,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 28")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177984} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370058
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177984} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369866
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177984} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370058
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177984} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369866
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2610,54 +2610,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 29")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00226999} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370059
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00226999} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369867
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00226999} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370059
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00226999} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369867
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2668,54 +2668,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 30")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227002} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370060
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227002} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369868
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227002} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370060
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227002} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369868
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2726,54 +2726,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 31")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227005} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370061
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227005} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369869
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227005} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370061
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227005} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369869
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht007777
@@ -2784,54 +2784,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00369651}) + ":FHS ORIGINAL EXAM 32")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227008} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00370062
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht007777
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00227008} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht007777
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00369870
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227008} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00370062
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht007777
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00227008} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht007777
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00369870
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -2843,54 +2843,54 @@
             VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423925
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423902
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423925
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423902
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -2902,54 +2902,54 @@
             VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423926
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423903
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423926
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423903
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -2961,54 +2961,54 @@
             VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423927
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423904
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423927
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423904
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3020,54 +3020,54 @@
             VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177936} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423928
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177936} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00423905
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177936} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423928
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177936} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00423905
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3079,50 +3079,50 @@
             VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544844
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544784
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544844
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544784
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3133,50 +3133,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":FHS OFFSPRING EXAM 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544845
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544785
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544845
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544785
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3187,50 +3187,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":FHS OFFSPRING EXAM 7")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544846
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544786
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544846
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544786
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3241,50 +3241,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":FHS OFFSPRING EXAM 8")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544847
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544787
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544847
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544787
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3295,50 +3295,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":FHS OFFSPRING EXAM 9")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177946} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544848
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177946} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544788
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177946} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544848
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177946} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544788
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht009761
@@ -3349,50 +3349,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00423868}) + ":FHS OFFSPRING EXAM 10")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177948} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544849
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht009761
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177948} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht009761
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00544789
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177948} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544849
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht009761
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177948} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht009761
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00544789
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006026
@@ -3404,54 +3404,54 @@
             ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006026
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006026
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00277045
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006026
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006026
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00277034
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006026
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006026
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00277045
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006026
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006026
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00277034
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006026
@@ -3463,54 +3463,54 @@
             ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 2''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006026
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006026
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00277046
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006026
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              method_type:
-                value: 'auscultatory method'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006026
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00277035
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006026
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006026
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00277046
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006026
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                method_type:
+                  value: 'auscultatory method'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006026
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00277035
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006026
@@ -3522,47 +3522,47 @@
             ({phv00277016} == ''72'', ''FHS OMNI 2 EXAM 3''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006026
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4152194'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006026
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00520305
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht006026
-            slot_derivations:
-              observation_type:
-                value: 'OMOP:4154790'
-                range: string
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              body_position:
-                value: 'SITTING_POSITION'
-              body_site:
-                value: 'Right arm'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006026
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00520296
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht006026
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4152194'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006026
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00520305
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht006026
+              slot_derivations:
+                observation_type:
+                  value: 'OMOP:4154790'
+                  range: string
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                body_position:
+                  value: 'SITTING_POSITION'
+                body_site:
+                  value: 'Right arm'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006026
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00520296
+                        unit:
+                          value: mm[Hg]
+                          range: string

--- a/priority_variables_transform/FHS-ingest/bmi.yaml
+++ b/priority_variables_transform/FHS-ingest/bmi.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277024
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277024
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -36,14 +36,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277025
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277025
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -59,14 +59,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00520291
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00520291
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -82,14 +82,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369740
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369740
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -105,14 +105,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369741
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369741
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -128,14 +128,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369742
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369742
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -151,14 +151,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369743
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369743
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -174,14 +174,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369744
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369744
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -197,14 +197,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369745
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369745
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -220,14 +220,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369746
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369746
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -243,14 +243,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369747
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369747
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -266,14 +266,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369748
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369748
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -289,14 +289,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369749
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369749
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -312,14 +312,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369750
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369750
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -335,14 +335,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369751
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369751
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -358,14 +358,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369752
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369752
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -381,14 +381,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369753
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369753
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -404,14 +404,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369754
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369754
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -427,14 +427,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369755
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369755
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -450,14 +450,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369756
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369756
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -473,14 +473,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369757
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369757
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -496,14 +496,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369758
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369758
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -519,14 +519,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369759
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369759
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -542,14 +542,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369760
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369760
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -565,14 +565,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369761
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369761
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -588,14 +588,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369762
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369762
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -611,14 +611,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369763
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369763
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -634,14 +634,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369764
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369764
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -657,14 +657,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369765
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369765
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -680,14 +680,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423883
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423883
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -703,14 +703,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423884
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423884
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -726,14 +726,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423885
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423885
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -749,14 +749,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423886
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423886
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -772,14 +772,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544754
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544754
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -795,14 +795,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544755
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544755
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -818,14 +818,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544756
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544756
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -841,14 +841,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544757
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544757
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -864,14 +864,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544758
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544758
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -887,14 +887,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544759
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544759
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -912,14 +912,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00056588
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00056588
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000397
@@ -937,11 +937,11 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000397
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00056833
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht000397
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00056833
+                unit:
+                  value: kg/m2
+                  range: string

--- a/priority_variables_transform/FHS-ingest/bnp.yaml
+++ b/priority_variables_transform/FHS-ingest/bnp.yaml
@@ -15,25 +15,25 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000393
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055159
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht000393
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055159
+                unit:
+                  value: pg/mL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000393
-            slot_derivations:
-              value_decimal:
-                value: '4'
-                range: string
-              unit:
-                value: pg/mL
-                range: string                    
+          - Quantity:
+              populated_from: pht000393
+              slot_derivations:
+                value_decimal:
+                  value: '4'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007776
@@ -49,14 +49,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007776
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369624
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht007776
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369624
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007776
@@ -72,11 +72,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007776
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369625
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht007776
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369625
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/bun.yaml
+++ b/priority_variables_transform/FHS-ingest/bun.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007559
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007559
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008085
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008085
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081023
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081023
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -89,11 +89,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276861
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276861
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/cac_score.yaml
+++ b/priority_variables_transform/FHS-ingest/cac_score.yaml
@@ -15,14 +15,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000144
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023194
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000144
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023194
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000144
@@ -40,14 +40,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000144
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023195
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000144
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023195
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000144
@@ -65,14 +65,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000144
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023196
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000144
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023196
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000145
@@ -90,14 +90,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000145
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023200
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000145
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023200
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000145
@@ -115,14 +115,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000145
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023201
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000145
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023201
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000145
@@ -140,14 +140,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000145
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023202
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000145
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023202
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000147
@@ -163,14 +163,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000147
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023235
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000147
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023235
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005161
@@ -186,14 +186,14 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005161
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00257670
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht005161
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00257670
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000147
@@ -209,11 +209,11 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000147
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023230
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000147
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023230
+                unit:
+                  value: '{score}'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/cac_volume.yaml
+++ b/priority_variables_transform/FHS-ingest/cac_volume.yaml
@@ -13,11 +13,11 @@
           value: 'Computed Tomography-Thoracic'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005161
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00257671
-              unit:
-                value: mm3
-                range: string
+          - Quantity:
+              populated_from: pht005161
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00257671
+                unit:
+                  value: mm3
+                  range: string

--- a/priority_variables_transform/FHS-ingest/carotid_imt.yaml
+++ b/priority_variables_transform/FHS-ingest/carotid_imt.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000083
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021728
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht000083
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021728
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: MEAN OF MAX IMT FOR BOTH LEFT AND RIGHT COMMON CAROTID ARTERIES IN DIASTOLE
 - class_derivations:
@@ -38,14 +38,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000083
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021729
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht000083
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021729
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: MEAN OF MAX IMT FOR BOTH LEFT AND RIGHT COMMON CAROTID ARTERIES IN SYSTOLE
 - class_derivations:
@@ -63,14 +63,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000907
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00076366
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht000907
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00076366
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the mean common carotid IMT far wall of both sides
 - class_derivations:
@@ -88,13 +88,13 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000907
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00076367
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht000907
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00076367
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: Mean of the mean internal carotid IMT far wall both sides

--- a/priority_variables_transform/FHS-ingest/carotid_sten_left.yaml
+++ b/priority_variables_transform/FHS-ingest/carotid_sten_left.yaml
@@ -14,17 +14,17 @@
           value: 'Carotid Ultrasound'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000083
-            slot_derivations:
-              value_concept:
-                populated_from: phv00021702
-                value_mappings:
-                  '0': 0
-                  '1': 1-24
-                  '2': 25-49
-                  '3': 50-74
-                  '4': 75-99
-                  '5': 100
-              unit:
-                value: '%'
+          - Quantity:
+              populated_from: pht000083
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00021702
+                  value_mappings:
+                    '0': 0
+                    '1': 1-24
+                    '2': 25-49
+                    '3': 50-74
+                    '4': 75-99
+                    '5': 100
+                unit:
+                  value: '%'

--- a/priority_variables_transform/FHS-ingest/carotid_sten_right.yaml
+++ b/priority_variables_transform/FHS-ingest/carotid_sten_right.yaml
@@ -15,18 +15,18 @@
           value: 'Carotid Ultrasound'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000083
-            slot_derivations:
-              value_concept:
-                populated_from: phv00021700
-                value_mappings:
-                  '0': 0
-                  '1': 1-24
-                  '2': 25-49
-                  '3': 50-74
-                  '4': 75-99
-                  '5': 100
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000083
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00021700
+                  value_mappings:
+                    '0': 0
+                    '1': 1-24
+                    '2': 25-49
+                    '3': 50-74
+                    '4': 75-99
+                    '5': 100
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/cesd_score.yaml
+++ b/priority_variables_transform/FHS-ingest/cesd_score.yaml
@@ -11,14 +11,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000160
-            slot_derivations:
-              value_integer:
-                populated_from: phv00023792
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000160
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00023792
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000172
@@ -32,11 +32,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000172
-            slot_derivations:
-              value_integer:
-                populated_from: phv00023899
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht000172
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00023899
+                unit:
+                  value: '{score}'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/chloride_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/chloride_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008103
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008103
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -40,11 +40,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081017
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081017
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/FHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/creat_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000016
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00002416
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000016
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00002416
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000146
@@ -41,36 +41,36 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000146
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023207
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000146
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023207
+                unit:
+                  value: mg/dL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000146
-            slot_derivations:
-              value_decimal:
-                value: '0.2'
-                range: string
-              unit:
-                value: mg/dL
-                range: string        
+          - Quantity:
+              populated_from: pht000146
+              slot_derivations:
+                value_decimal:
+                  value: '0.2'
+                  range: string
+                unit:
+                  value: mg/dL
+                  range: string        
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000146
-            slot_derivations:
-              value_decimal:
-                value: '25'
-                range: string
-              unit:
-                value: mg/dL
-                range: string 
+          - Quantity:
+              populated_from: pht000146
+              slot_derivations:
+                value_decimal:
+                  value: '25'
+                  range: string
+                unit:
+                  value: mg/dL
+                  range: string 
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000017
@@ -88,14 +88,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000017
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00002654
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000017
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00002654
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000026
@@ -113,14 +113,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00006322
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00006322
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000027
@@ -138,14 +138,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000027
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00006662
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000027
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00006662
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000028
@@ -163,14 +163,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000028
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00006665
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000028
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00006665
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000029
@@ -188,14 +188,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000029
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007526
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000029
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007526
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -213,14 +213,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021396
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021396
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000692
@@ -238,14 +238,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000692
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00070734
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000692
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00070734
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000742
@@ -263,14 +263,14 @@
           value: 'Jaffe Reaction'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00071894
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00071894
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001039
@@ -288,14 +288,14 @@
           value: 'Jaffe Reaction'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001039
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080753
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001039
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080753
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -313,14 +313,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081024
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081024
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002234
@@ -338,14 +338,14 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002234
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00161767
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002234
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00161767
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002566
@@ -363,14 +363,14 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002566
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00166800
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002566
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00166800
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -388,14 +388,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172175
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172175
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002895
@@ -413,14 +413,14 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002895
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172326
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002895
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172326
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -438,14 +438,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227058
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227058
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005143
@@ -463,14 +463,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005143
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255344
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht005143
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255344
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006010
@@ -488,14 +488,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275408
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275408
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -513,14 +513,14 @@
           value: 'colorimetric'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275417
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275417
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -536,14 +536,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276860
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276860
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -561,14 +561,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277030
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277030
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -586,14 +586,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277031
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277031
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -607,14 +607,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544772
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544772
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -628,14 +628,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544773
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544773
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -649,14 +649,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544774
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544774
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -670,14 +670,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544775
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544775
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -691,14 +691,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544776
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544776
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -716,14 +716,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369801
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369801
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -741,14 +741,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369802
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369802
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -766,14 +766,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369803
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369803
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -791,14 +791,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369804
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369804
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -816,14 +816,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369805
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369805
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -841,14 +841,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369806
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369806
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -866,14 +866,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369807
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369807
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -891,14 +891,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369808
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369808
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -916,14 +916,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423895
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423895
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -941,14 +941,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423896
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423896
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -966,11 +966,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423897
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423897
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/creat_urin.yaml
+++ b/priority_variables_transform/FHS-ingest/creat_urin.yaml
@@ -15,14 +15,14 @@
           value: colorimetric, modified Jaffee (rate blanked)
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000313
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00036494
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000313
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00036494
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -40,14 +40,14 @@
           value: 'colorimetric'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275419
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275419
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000685
@@ -65,14 +65,14 @@
           value: 'urine assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000685
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00070900} * 11.312'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000685
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00070900} * 11.312'
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000742
@@ -90,14 +90,14 @@
           value: 'Jaffe Reaction'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00071896
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00071896
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -115,14 +115,14 @@
           value: 'urine assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172162
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172162
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004363
@@ -140,14 +140,14 @@
           value: 'colorimetric'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004363
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219548
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004363
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219548
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -165,14 +165,14 @@
           value: 'urine assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227046
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227046
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004809
@@ -190,11 +190,11 @@
           value: 'photometric assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004809
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00227286} * 100) / {phv00227269}'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004809
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00227286} * 100) / {phv00227269}'
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/crp.yaml
+++ b/priority_variables_transform/FHS-ingest/crp.yaml
@@ -16,36 +16,36 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000080
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021690
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000080
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021690
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000080
-            slot_derivations:
-              value_decimal:
-                value: '0.16'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000080
+              slot_derivations:
+                value_decimal:
+                  value: '0.16'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000080
-            slot_derivations:
-              value_decimal:
-                value: '550'
-                range: string
-              unit:
-                value: mg/L
-                range: string                     
+          - Quantity:
+              populated_from: pht000080
+              slot_derivations:
+                value_decimal:
+                  value: '550'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string                     
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000081
@@ -64,36 +64,36 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000081
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021693
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000081
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021693
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000080
-            slot_derivations:
-              value_decimal:
-                value: '0.16'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000080
+              slot_derivations:
+                value_decimal:
+                  value: '0.16'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000080
-            slot_derivations:
-              value_decimal:
-                value: '550'
-                range: string
-              unit:
-                value: mg/L
-                range: string                     
+          - Quantity:
+              populated_from: pht000080
+              slot_derivations:
+                value_decimal:
+                  value: '550'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string                     
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -111,27 +111,27 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00172177} > 0.15, {phv00172177}), ({phv00462201} == 1, 0.15), (True, {phv00172177}))
-              operator:
-                expr: 'case(({phv00462201} == 1, "LESS_THAN"))'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00172177} > 0.15, {phv00172177}), ({phv00462201} == 1, 0.15), (True, {phv00172177}))
+                operator:
+                  expr: 'case(({phv00462201} == 1, "LESS_THAN"))'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                value: '0.15'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  value: '0.15'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -149,27 +149,27 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00227060} > 0.15, {phv00227060}), ({phv00227067} == 1, 0.15), (True, {phv00227060}))
-              operator:
-                expr: 'case(({phv00227067} == 1, "LESS_THAN"))'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00227060} > 0.15, {phv00227060}), ({phv00227067} == 1, 0.15), (True, {phv00227060}))
+                operator:
+                  expr: 'case(({phv00227067} == 1, "LESS_THAN"))'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                value: '0.15'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  value: '0.15'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012880
@@ -185,25 +185,25 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012880
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00520365
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht012880
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00520365
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012880
-            slot_derivations:
-              value_decimal:
-                value: '0.15'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht012880
+              slot_derivations:
+                value_decimal:
+                  value: '0.15'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht010726
@@ -219,27 +219,27 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010726
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00462196} > 0.15, {phv00462196}), ({phv00462201} == 1, 0.15), (True, {phv00462196}))
-              operator:
-                expr: 'case(({phv00462201} == 1, "LESS_THAN"))'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht010726
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00462196} > 0.15, {phv00462196}), ({phv00462201} == 1, 0.15), (True, {phv00462196}))
+                operator:
+                  expr: 'case(({phv00462201} == 1, "LESS_THAN"))'
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010726
-            slot_derivations:
-              value_decimal:
-                value: '0.15'
-                range: string
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht010726
+              slot_derivations:
+                value_decimal:
+                  value: '0.15'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012881
@@ -255,14 +255,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012881
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00520381
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht012881
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00520381
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht012882
@@ -278,13 +278,13 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012882
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00520398} == 0.14, 0.15), (True, {phv00520398}))'
-              operator:
-                expr: 'case(({phv00520398} == 0.14, "LESS_THAN"))'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht012882
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00520398} == 0.14, 0.15), (True, {phv00520398}))'
+                operator:
+                  expr: 'case(({phv00520398} == 0.14, "LESS_THAN"))'
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/FHS-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/cysc_bld.yaml
@@ -16,33 +16,33 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000146
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023208
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht000146
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023208
+                unit:
+                  value: mg/L
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000146
-            slot_derivations:
-              value_decimal:
-                value: '0.29'
-                range: string
-              unit:
-                value: mg/L
-                range: string 
+          - Quantity:
+              populated_from: pht000146
+              slot_derivations:
+                value_decimal:
+                  value: '0.29'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string 
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000146
-            slot_derivations:
-              value_decimal:
-                value: '7.22'
-                range: string
-              unit:
-                value: mg/L
-                range: string                          
+          - Quantity:
+              populated_from: pht000146
+              slot_derivations:
+                value_decimal:
+                  value: '7.22'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string                          

--- a/priority_variables_transform/FHS-ingest/d_dimer.yaml
+++ b/priority_variables_transform/FHS-ingest/d_dimer.yaml
@@ -15,11 +15,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000085
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00021744} * 0.001'
-              unit:
-                value: ug/mL
-                range: string
+          - Quantity:
+              populated_from: pht000085
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00021744} * 0.001'
+                unit:
+                  value: ug/mL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/eosinophil_ncnc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/eosinophil_ncnc_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172196
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172196
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -40,11 +40,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227043
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227043
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/eselectin.yaml
+++ b/priority_variables_transform/FHS-ingest/eselectin.yaml
@@ -15,11 +15,11 @@
           value: 'flow cytometry'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002425
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00163434
-              unit:
-                value: /uL
-                range: string
+          - Quantity:
+              populated_from: pht002425
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00163434
+                unit:
+                  value: /uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/factor_7.yaml
+++ b/priority_variables_transform/FHS-ingest/factor_7.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000198
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024570
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht000198
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024570
+                unit:
+                  value: '%{Normal}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004806
@@ -41,11 +41,11 @@
           value: 'platelet aggregation'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004806
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227096
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht004806
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227096
+                unit:
+                  value: '%{Normal}'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/fam_income.yaml
+++ b/priority_variables_transform/FHS-ingest/fam_income.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003094
-            slot_derivations:
-              value_concept:
-                expr: 'case((str({phv00177608}) == "1", "< $20,000"), (str({phv00177608}) == "2", "$20,000 - $34,999"), (str({phv00177608}) == "3", "$35,000 - $54,999"), (str({phv00177608}) == "4", "$55,000 - $74,999"), (str({phv00177608}) == "5", "$75,000 - $100,000"), (str({phv00177608}) == "6", "> $100,000"), (True, None))'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht003094
+              slot_derivations:
+                value_concept:
+                  expr: 'case((str({phv00177608}) == "1", "< $20,000"), (str({phv00177608}) == "2", "$20,000 - $34,999"), (str({phv00177608}) == "3", "$35,000 - $54,999"), (str({phv00177608}) == "4", "$55,000 - $74,999"), (str({phv00177608}) == "5", "$75,000 - $100,000"), (str({phv00177608}) == "6", "> $100,000"), (True, None))'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     Observation:
       populated_from: pht006005
@@ -36,14 +36,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006005
-            slot_derivations:
-              value_concept:
-                expr: 'case((str({phv00274078}) == "1", "< $12,000"), (str({phv00274078}) == "2", "$12,000 - $24,999"), (str({phv00274078}) == "3", "$25,000 - $49,999"), (str({phv00274078}) == "4", "$50,000 - $74,999"), (str({phv00274078}) == "5", "$75,000 - $100,000"), (str({phv00274078}) == "6", "> $100,000"), (True, None))'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht006005
+              slot_derivations:
+                value_concept:
+                  expr: 'case((str({phv00274078}) == "1", "< $12,000"), (str({phv00274078}) == "2", "$12,000 - $24,999"), (str({phv00274078}) == "3", "$25,000 - $49,999"), (str({phv00274078}) == "4", "$50,000 - $74,999"), (str({phv00274078}) == "5", "$75,000 - $100,000"), (str({phv00274078}) == "6", "> $100,000"), (True, None))'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     Observation:
       populated_from: pht000074
@@ -59,14 +59,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_concept:
-                expr: 'case((str({phv00021256}) == "1", "< $12,000"), (str({phv00021256}) == "2", "$12,000 - $24,999"), (str({phv00021256}) == "3", "$25,000 - $49,999"), (str({phv00021256}) == "4", "$50,000 - $74,999"), (str({phv00021256}) == "5", "$75,000 - $100,000"), (str({phv00021256}) == "6", "> $100,000"), (True, None))'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_concept:
+                  expr: 'case((str({phv00021256}) == "1", "< $12,000"), (str({phv00021256}) == "2", "$12,000 - $24,999"), (str({phv00021256}) == "3", "$25,000 - $49,999"), (str({phv00021256}) == "4", "$50,000 - $74,999"), (str({phv00021256}) == "5", "$75,000 - $100,000"), (str({phv00021256}) == "6", "> $100,000"), (True, None))'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     Observation:
       populated_from: pht000100
@@ -82,11 +82,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000100
-            slot_derivations:
-              value_concept:
-                expr: 'case((str({phv00022428}) == "1", "< $20,000"), (str({phv00022428}) == "2", "$20,000 - $34,999"), (str({phv00022428}) == "3", "$35,000 - $54,999"), (str({phv00022428}) == "4", "$55,000 - $74,999"), (str({phv00022428}) == "5", "$75,000 - $100,000"), (str({phv00022428}) == "6", "> $100,000"), (True, None))'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht000100
+              slot_derivations:
+                value_concept:
+                  expr: 'case((str({phv00022428}) == "1", "< $20,000"), (str({phv00022428}) == "2", "$20,000 - $34,999"), (str({phv00022428}) == "3", "$35,000 - $54,999"), (str({phv00022428}) == "4", "$55,000 - $74,999"), (str({phv00022428}) == "5", "$75,000 - $100,000"), (str({phv00022428}) == "6", "> $100,000"), (True, None))'
+                unit:
+                  value: USD
+                  range: string

--- a/priority_variables_transform/FHS-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/fast_gluc_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172173
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172173
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277038
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277038
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277039
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277039
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -89,14 +89,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544804
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544804
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -113,14 +113,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544805
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544805
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -137,14 +137,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544806
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544806
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -161,14 +161,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544807
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544807
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -185,14 +185,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544808
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544808
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -210,14 +210,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423910
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423910
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -235,14 +235,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423911
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423911
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -260,14 +260,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423912
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423912
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -285,11 +285,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423913
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423913
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/fibrin.yaml
+++ b/priority_variables_transform/FHS-ingest/fibrin.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000012
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001384
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000012
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001384
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000024
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000024
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00005553
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000024
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00005553
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000025
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000025
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00006029
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000025
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00006029
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021397
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021397
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000084
@@ -115,14 +115,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000084
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021740
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000084
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021740
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000085
@@ -140,14 +140,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000085
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021745
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000085
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021745
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000086
@@ -166,14 +166,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021747
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021747
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004806
@@ -191,11 +191,11 @@
           value: 'platelet aggregation'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004806
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227093
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004806
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227093
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/FHS-ingest/fruit_serving.yaml
@@ -15,17 +15,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000680
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00070066} + {phv00070067} + {phv00070068} + {phv00070069}
-                  + {phv00070070} + {phv00070071} +{phv00070072} + {phv00070073}
-                  + {phv00070074} + {phv00070075} + {phv00070076} + {phv00070077}
-                  +{phv00070078} + {phv00070079} + {phv00070080}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht000680
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00070066} + {phv00070067} + {phv00070068} + {phv00070069}
+                    + {phv00070070} + {phv00070071} +{phv00070072} + {phv00070073}
+                    + {phv00070074} + {phv00070075} + {phv00070076} + {phv00070077}
+                    +{phv00070078} + {phv00070079} + {phv00070080}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000681
@@ -43,17 +43,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000681
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00068474} + {phv00068475} + {phv00068476} + {phv00068477}
-                  + {phv00068473} + {phv00068478} +{phv00068479} + {phv00068480}
-                  + {phv00068481} + {phv00068482} + {phv00068483} + {phv00068484}
-                  +{phv00068485} + {phv00068486} + {phv00068487}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht000681
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00068474} + {phv00068475} + {phv00068476} + {phv00068477}
+                    + {phv00068473} + {phv00068478} +{phv00068479} + {phv00068480}
+                    + {phv00068481} + {phv00068482} + {phv00068483} + {phv00068484}
+                    +{phv00068485} + {phv00068486} + {phv00068487}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000682
@@ -71,17 +71,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000682
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00069042} + {phv00069043} + {phv00069044} + {phv00069045}
-                  + {phv00069046} + {phv00069047} +{phv00069048} + {phv00069049}
-                  + {phv00069050} + {phv00069051} + {phv00069052} + {phv00069053}
-                  +{phv00069054} + {phv00069055} + {phv00069056}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht000682
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00069042} + {phv00069043} + {phv00069044} + {phv00069045}
+                    + {phv00069046} + {phv00069047} +{phv00069048} + {phv00069049}
+                    + {phv00069050} + {phv00069051} + {phv00069052} + {phv00069053}
+                    +{phv00069054} + {phv00069055} + {phv00069056}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002150
@@ -99,17 +99,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002150
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00157176} + {phv00157177} + {phv00157178} + {phv00157179}
-                  + {phv00157180} + {phv00157181} +{phv00157182} + {phv00157183}
-                  + {phv00157184} + {phv00157185} + {phv00157186} + {phv00157187}
-                  +{phv00157188} + {phv00157189} + {phv00157190}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002150
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00157176} + {phv00157177} + {phv00157178} + {phv00157179}
+                    + {phv00157180} + {phv00157181} +{phv00157182} + {phv00157183}
+                    + {phv00157184} + {phv00157185} + {phv00157186} + {phv00157187}
+                    +{phv00157188} + {phv00157189} + {phv00157190}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002151
@@ -127,17 +127,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002151
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00157617} + {phv00157618} + {phv00157619} + {phv00157620}
-                  + {phv00157621} + {phv00157622} +{phv00157623} + {phv00157624}
-                  + {phv00157625} + {phv00157626} + {phv00157627} + {phv00157628}
-                  +{phv00157629} + {phv00157630} + {phv00157631}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002151
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00157617} + {phv00157618} + {phv00157619} + {phv00157620}
+                    + {phv00157621} + {phv00157622} +{phv00157623} + {phv00157624}
+                    + {phv00157625} + {phv00157626} + {phv00157627} + {phv00157628}
+                    +{phv00157629} + {phv00157630} + {phv00157631}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002153
@@ -155,17 +155,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002153
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00158420} + {phv00158421} + {phv00158422} + {phv00158423}
-                  + {phv00158424} + {phv00158425} +{phv00158426} + {phv00158427}
-                  + {phv00158428} + {phv00158429} + {phv00158430} + {phv00158431}
-                  +{phv00158432} + {phv00158433} + {phv00158434}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002153
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00158420} + {phv00158421} + {phv00158422} + {phv00158423}
+                    + {phv00158424} + {phv00158425} +{phv00158426} + {phv00158427}
+                    + {phv00158428} + {phv00158429} + {phv00158430} + {phv00158431}
+                    +{phv00158432} + {phv00158433} + {phv00158434}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002350
@@ -183,17 +183,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002350
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00162554} + {phv00162555} + {phv00162556} + {phv00162557}
-                  + {phv00162558} + {phv00162559} +{phv00162560} + {phv00162561}
-                  + {phv00162562} + {phv00162563} + {phv00162564} + {phv00162565}
-                  +{phv00162566} + {phv00162567} + {phv00162568}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002350
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00162554} + {phv00162555} + {phv00162556} + {phv00162557}
+                    + {phv00162558} + {phv00162559} +{phv00162560} + {phv00162561}
+                    + {phv00162562} + {phv00162563} + {phv00162564} + {phv00162565}
+                    +{phv00162566} + {phv00162567} + {phv00162568}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002900
@@ -211,15 +211,15 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002900
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00172953} + {phv00172954} + {phv00172955} + {phv00172956}
-                  + {phv00172957} + {phv00172958} +{phv00172959} + {phv00172960}
-                  + {phv00172961} + {phv00172962} + {phv00172963} + {phv00172964}
-                  +{phv00172965} + {phv00172966} + {phv00172967} + {phv00172968}
-                  + {phv00172969}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002900
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00172953} + {phv00172954} + {phv00172955} + {phv00172956}
+                    + {phv00172957} + {phv00172958} +{phv00172959} + {phv00172960}
+                    + {phv00172961} + {phv00172962} + {phv00172963} + {phv00172964}
+                    +{phv00172965} + {phv00172966} + {phv00172967} + {phv00172968}
+                    + {phv00172969}'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/glucose_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000021
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004081
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000021
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004081
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004517
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004517
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000023
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000023
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004937
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000023
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004937
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000024
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000024
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00005550
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000024
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00005550
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000025
@@ -115,14 +115,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000025
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00006026
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000025
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00006026
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000028
@@ -140,14 +140,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000028
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00006666
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000028
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00006666
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000029
@@ -165,14 +165,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000029
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007527
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000029
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007527
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000030
@@ -190,14 +190,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007558
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007558
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -215,14 +215,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008084
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008084
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000032
@@ -240,14 +240,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000032
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008731
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000032
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008731
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000033
@@ -265,14 +265,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000033
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00009125
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000033
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00009125
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000034
@@ -290,14 +290,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000034
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00009577
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000034
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00009577
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000035
@@ -315,14 +315,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010133
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010133
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -340,14 +340,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010143
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010143
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -365,14 +365,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080781
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080781
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -390,14 +390,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080782
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080782
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -415,14 +415,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080783
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080783
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -440,14 +440,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080784
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080784
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -465,14 +465,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080785
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080785
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -490,14 +490,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080786
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080786
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -515,14 +515,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080787
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080787
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -540,14 +540,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080788
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080788
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -565,14 +565,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080789
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080789
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -590,14 +590,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080790
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080790
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -615,14 +615,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080791
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080791
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -640,14 +640,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080792
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080792
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -665,14 +665,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080793
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080793
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -690,14 +690,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080794
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080794
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -715,14 +715,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080795
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080795
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -740,14 +740,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080796
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080796
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -765,14 +765,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080797
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080797
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -790,14 +790,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080798
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080798
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -815,14 +815,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080799
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080799
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -840,14 +840,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080800
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080800
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -865,14 +865,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00080801
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00080801
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000040
@@ -890,14 +890,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000040
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369401
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000040
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369401
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -915,14 +915,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021394
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021394
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000692
@@ -940,14 +940,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000692
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00070730
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000692
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00070730
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000742
@@ -965,14 +965,14 @@
           value: 'hexokinase'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00071893
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00071893
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004801
@@ -990,14 +990,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004801
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227016
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004801
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227016
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -1015,14 +1015,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227057
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227057
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005143
@@ -1040,14 +1040,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005143
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255343
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht005143
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255343
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005144
@@ -1065,14 +1065,14 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005144
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255372
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht005144
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255372
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006010
@@ -1090,14 +1090,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275404
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275404
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -1115,14 +1115,14 @@
           value: 'hexokinase'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275416
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275416
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -1138,14 +1138,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276862
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276862
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -1163,14 +1163,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277022
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277022
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -1188,14 +1188,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277023
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277023
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1209,14 +1209,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544748
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544748
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1230,14 +1230,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544749
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544749
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1251,14 +1251,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544750
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544750
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1272,14 +1272,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544751
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544751
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1293,14 +1293,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544752
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544752
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1318,14 +1318,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369718
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369718
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1343,14 +1343,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369719
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369719
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1368,14 +1368,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369720
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369720
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1393,14 +1393,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369721
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369721
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1418,14 +1418,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369722
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369722
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1443,14 +1443,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369723
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369723
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1468,14 +1468,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369724
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369724
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1493,14 +1493,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369725
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369725
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1518,14 +1518,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369726
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369726
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1543,14 +1543,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369727
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369727
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1568,14 +1568,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369728
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369728
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1593,14 +1593,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369729
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369729
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1618,14 +1618,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369730
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369730
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1643,14 +1643,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369731
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369731
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1668,14 +1668,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369732
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369732
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1693,14 +1693,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369733
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369733
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1718,14 +1718,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369734
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369734
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1743,14 +1743,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369735
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369735
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1768,14 +1768,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369736
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369736
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1793,14 +1793,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369737
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369737
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1818,14 +1818,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369738
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369738
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -1843,14 +1843,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369739
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369739
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1868,14 +1868,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423879
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423879
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1893,14 +1893,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423880
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423880
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1918,14 +1918,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423881
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423881
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -1943,11 +1943,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423882
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423882
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/hdl.yaml
+++ b/priority_variables_transform/FHS-ingest/hdl.yaml
@@ -16,14 +16,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055263
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055263
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -42,17 +42,17 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                         ({phv00172176} > 16.0, {phv00172176}),
-                         ({phv00172201} == 1, None)
-                      )'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                           ({phv00172176} > 16.0, {phv00172176}),
+                           ({phv00172201} == 1, None)
+                        )'
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004801
@@ -71,14 +71,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004801
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227018
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004801
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227018
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -97,26 +97,26 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00227059} > 16.0, {phv00227059}),({phv00227068}
-                  == 1, None))
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00227059} > 16.0, {phv00227059}),({phv00227068}
+                    == 1, None))
+                unit:
+                  value: mg/dL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                value: '16'
-                range: string
-              unit:
-                value: mg/dL
-                range: string                    
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  value: '16'
+                  range: string
+                unit:
+                  value: mg/dL
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005143
@@ -135,14 +135,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005143
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255345
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht005143
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255345
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006010
@@ -161,14 +161,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275405
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275405
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -187,14 +187,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275414
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275414
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -213,14 +213,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277040
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277040
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -239,14 +239,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277041
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277041
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -263,14 +263,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544810
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544810
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -287,14 +287,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544811
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544811
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -311,14 +311,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544812
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544812
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -335,14 +335,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544813
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544813
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -359,14 +359,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544814
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544814
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -385,14 +385,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369935
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369935
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -411,14 +411,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369936
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369936
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -437,14 +437,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369937
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369937
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -463,14 +463,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369938
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369938
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -489,14 +489,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369939
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369939
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -515,14 +515,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369940
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369940
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -541,14 +541,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369941
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369941
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -567,14 +567,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369942
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369942
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -593,14 +593,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369943
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369943
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009755
@@ -619,14 +619,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009755
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423781
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009755
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423781
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -645,14 +645,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423914
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423914
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -671,14 +671,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423915
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423915
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -697,14 +697,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423916
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423916
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -723,14 +723,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423917
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423917
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -749,14 +749,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007973
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007973
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -778,14 +778,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001582
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001582
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -803,11 +803,11 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001589
-              unit:
-                value: mg/dL
-                range: string                    
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001589
+                unit:
+                  value: mg/dL
+                  range: string                    

--- a/priority_variables_transform/FHS-ingest/hemat.yaml
+++ b/priority_variables_transform/FHS-ingest/hemat.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00000677
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00000677
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00000765
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00000765
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00000842
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00000842
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00000929
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00000929
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000010
@@ -115,14 +115,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001047
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001047
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000011
@@ -140,14 +140,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001202
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001202
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000012
@@ -165,14 +165,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000012
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001376
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000012
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001376
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -190,14 +190,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001579
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001579
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000014
@@ -215,14 +215,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000014
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001815
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000014
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001815
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000015
@@ -240,14 +240,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000015
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00002030
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000015
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00002030
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000016
@@ -265,14 +265,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000016
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00002414
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000016
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00002414
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000017
@@ -290,14 +290,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000017
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00002652
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000017
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00002652
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000019
@@ -315,14 +315,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00003258
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00003258
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000020
@@ -340,14 +340,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000020
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00003664
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000020
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00003664
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000021
@@ -365,14 +365,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000021
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004080
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000021
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004080
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -390,14 +390,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004516
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004516
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000023
@@ -415,14 +415,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000023
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004936
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000023
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004936
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000030
@@ -440,14 +440,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007555
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007555
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -463,14 +463,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008111
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008111
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -488,14 +488,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081031
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081031
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -513,14 +513,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172181
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172181
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -538,11 +538,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227028
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227028
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/hemo.yaml
+++ b/priority_variables_transform/FHS-ingest/hemo.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000535} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000535} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000627} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000627} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000634} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000634} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000673} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000673} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -115,14 +115,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000764} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000764} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -140,14 +140,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00000841} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00000841} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -165,14 +165,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081032
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081032
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -190,14 +190,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172180
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172180
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -215,11 +215,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227027
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227027
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/FHS-ingest/hemo_a1c.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00071897
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00071897
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172163
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172163
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227047
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227047
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -90,11 +90,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275420
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275420
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/hip_circ.yaml
+++ b/priority_variables_transform/FHS-ingest/hip_circ.yaml
@@ -17,14 +17,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000021
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003673} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000021
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003673} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -44,14 +44,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004089} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004089} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000023
@@ -71,14 +71,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000023
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004531} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000023
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004531} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000024
@@ -98,14 +98,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000024
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005545} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000024
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005545} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000025
@@ -125,14 +125,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000025
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005925} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000025
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005925} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000033
@@ -152,14 +152,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000033
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008768} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000033
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008768} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000034
@@ -179,14 +179,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000034
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00009556} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000034
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00009556} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000035
@@ -206,14 +206,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010113} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010113} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -233,14 +233,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010503} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010503} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003094
@@ -260,14 +260,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003094
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00177545} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003094
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00177545} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004814
@@ -287,14 +287,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004814
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251066} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004814
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251066} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -314,14 +314,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254293} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254293} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -341,14 +341,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254294} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254294} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -368,14 +368,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277044} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277044} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -393,14 +393,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00520302} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00520302} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -420,14 +420,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369970} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369970} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -447,14 +447,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369971} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369971} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -474,14 +474,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369972} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369972} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -501,14 +501,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369973} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369973} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -528,14 +528,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00369974} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00369974} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -555,14 +555,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423922} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423922} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -582,14 +582,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423923} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423923} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -609,11 +609,11 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423924} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423924} * 2.54'
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/FHS-ingest/hrtrt.yaml
+++ b/priority_variables_transform/FHS-ingest/hrtrt.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000028
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006839} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000028
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006839} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000029
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000029
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007263} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000029
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007263} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008162
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008162
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008174
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008174
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -119,14 +119,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008186
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008186
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -145,14 +145,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008198
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008198
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -170,14 +170,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008210
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008210
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -195,14 +195,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008222
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008222
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -220,14 +220,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008234
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008234
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -245,14 +245,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008246
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008246
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -270,14 +270,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008258
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008258
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -295,14 +295,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008271
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008271
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -320,14 +320,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008283
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008283
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -345,14 +345,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008295
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008295
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -370,14 +370,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008307
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008307
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -395,14 +395,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008319
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008319
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -420,14 +420,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008331
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008331
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000194
@@ -445,14 +445,14 @@
           value: 'Brachial Vascular Reactivity Test'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000194
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024408
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000194
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024408
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000194
@@ -471,14 +471,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000194
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024409
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000194
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024409
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000194
@@ -496,14 +496,14 @@
           value: 'Brachial Vascular Reactivity Test'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000194
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024410
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000194
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024410
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000194
@@ -521,14 +521,14 @@
           value: 'Brachial Vascular Reactivity Test'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000194
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024411
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000194
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024411
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000195
@@ -547,14 +547,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000195
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024477
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000195
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024477
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000195
@@ -573,14 +573,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000195
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024478
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000195
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024478
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000195
@@ -598,14 +598,14 @@
           value: 'Brachial Vascular Reactivity Test'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000195
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024486
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000195
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024486
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000195
@@ -624,14 +624,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000195
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024494
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000195
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024494
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000196
@@ -647,14 +647,14 @@
           value: 'Cardiac Magnetic Resonance Imaging'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000196
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024534
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000196
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024534
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000197
@@ -673,14 +673,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000197
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024549
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000197
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024549
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000209
@@ -699,14 +699,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000209
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024764
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000209
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024764
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000209
@@ -725,14 +725,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000209
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024765
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000209
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024765
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000209
@@ -750,14 +750,14 @@
           value: 'Arterial Tonometry'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000209
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024796
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000209
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024796
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000209
@@ -776,14 +776,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000209
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024797
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000209
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024797
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000210
@@ -801,14 +801,14 @@
           value: 'Arterial Tonometry'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000210
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024804
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000210
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024804
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000210
@@ -827,14 +827,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000210
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024805
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000210
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024805
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000210
@@ -853,14 +853,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000210
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024810
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000210
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024810
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000210
@@ -879,14 +879,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000210
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024811
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000210
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024811
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000211
@@ -905,14 +905,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000211
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024852
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000211
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024852
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -931,14 +931,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055184
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055184
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -957,14 +957,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055191
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055191
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -983,14 +983,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055203
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055203
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -1009,14 +1009,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055210
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055210
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -1035,14 +1035,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055222
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055222
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -1061,14 +1061,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055229
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055229
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000394
@@ -1087,14 +1087,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000394
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055236
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000394
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055236
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000673
@@ -1112,14 +1112,14 @@
           value: 'Peripheral Arterial Tone'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000673
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00066705
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000673
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00066705
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000692
@@ -1138,14 +1138,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000692
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00070718} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000692
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00070718} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000748
@@ -1163,14 +1163,14 @@
           value: 'Peripheral Arterial Tone'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000748
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00072652
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000748
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00072652
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000830
@@ -1189,14 +1189,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000830
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00073814
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht000830
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00073814
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002572
@@ -1215,14 +1215,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002572
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00167051
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht002572
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00167051
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002573
@@ -1241,14 +1241,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002573
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00167182
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht002573
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00167182
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005141
@@ -1267,14 +1267,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005141
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254794} * 2'
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht005141
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254794} * 2'
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -1288,11 +1288,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276850
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276850
+                unit:
+                  value: '{beats}/min'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/il18.yaml
+++ b/priority_variables_transform/FHS-ingest/il18.yaml
@@ -17,11 +17,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht012881
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00520385
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht012881
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00520385
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/insulin_in_blood.yaml
+++ b/priority_variables_transform/FHS-ingest/insulin_in_blood.yaml
@@ -15,14 +15,14 @@
           value: 'ELISA'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000688
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00070362
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht000688
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00070362
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003901
@@ -40,17 +40,17 @@
           value: 'immunoassay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003901
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                      ({phv00201991} > 1.39, {phv00201991}),
-                      (True, None)
-                     )'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003901
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                        ({phv00201991} > 1.39, {phv00201991}),
+                        (True, None)
+                       )'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003902
@@ -68,17 +68,17 @@
           value: 'immunoassay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003902
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                      ({phv00201995} > 1.39, {phv00201995}),
-                      (True, None)
-                     )'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003902
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                        ({phv00201995} > 1.39, {phv00201995}),
+                        (True, None)
+                       )'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004804
@@ -96,14 +96,14 @@
           value: 'immunoassay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004804
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227080
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht004804
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227080
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004805
@@ -121,14 +121,14 @@
           value: 'immunoassay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004805
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                      ({phv00227085} > 1.39, {phv00227085}),
-                      (True, None)
-                     )'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht004805
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                        ({phv00227085} > 1.39, {phv00227085}),
+                        (True, None)
+                       )'
+                unit:
+                  value: pmol/L
+                  range: string

--- a/priority_variables_transform/FHS-ingest/lactate.yaml
+++ b/priority_variables_transform/FHS-ingest/lactate.yaml
@@ -15,14 +15,14 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002565
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00166732
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht002565
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00166732
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002894
@@ -40,14 +40,14 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002894
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172259
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht002894
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172259
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005144
@@ -65,11 +65,11 @@
           value: 'metabolite profiling'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005144
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255391
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht005144
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255391
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/FHS-ingest/lactate_dehyd.yaml
+++ b/priority_variables_transform/FHS-ingest/lactate_dehyd.yaml
@@ -15,11 +15,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081018
-              unit:
-                value: '[IU]/L'
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081018
+                unit:
+                  value: '[IU]/L'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/ldl.yaml
+++ b/priority_variables_transform/FHS-ingest/ldl.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007539
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007539
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -42,14 +42,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007975
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007975
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000032
@@ -68,14 +68,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000032
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008733
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000032
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008733
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009755
@@ -94,14 +94,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009755
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423782
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009755
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423782
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -120,14 +120,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277026
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277026
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -146,14 +146,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277027
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277027
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -172,14 +172,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423887
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423887
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -198,14 +198,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423888
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423888
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -224,14 +224,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423889
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423889
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -250,14 +250,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423890
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423890
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -274,14 +274,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544760
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544760
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -298,14 +298,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544761
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544761
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -322,14 +322,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544762
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544762
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -346,14 +346,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544763
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544763
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -370,14 +370,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544764
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544764
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -396,14 +396,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369766
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369766
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -422,14 +422,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369767
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369767
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -448,14 +448,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369768
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369768
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -474,14 +474,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369769
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369769
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -500,14 +500,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00369770
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00369770
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -529,14 +529,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001584
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001584
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -558,11 +558,11 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001591
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001591
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/lympho_pct.yaml
+++ b/priority_variables_transform/FHS-ingest/lympho_pct.yaml
@@ -15,11 +15,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008117
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008117
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/mch.yaml
+++ b/priority_variables_transform/FHS-ingest/mch.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008113
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008113
+                unit:
+                  value: pg/{cell}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -38,14 +38,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172183
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172183
+                unit:
+                  value: pg/{cell}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -63,14 +63,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227030
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227030
+                unit:
+                  value: pg/{cell}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -88,14 +88,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081035
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081035
+                unit:
+                  value: pg/{cell}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht015118
@@ -111,11 +111,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht015118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00546089
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht015118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00546089
+                unit:
+                  value: pg/{cell}
+                  range: string

--- a/priority_variables_transform/FHS-ingest/mchc.yaml
+++ b/priority_variables_transform/FHS-ingest/mchc.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008114} / 10'
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008114} / 10'
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172184
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172184
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227031
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227031
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -90,11 +90,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081036
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081036
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/mcv.yaml
+++ b/priority_variables_transform/FHS-ingest/mcv.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008112
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008112
+                unit:
+                  value: fL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172182
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172182
+                unit:
+                  value: fL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081033
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081033
+                unit:
+                  value: fL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -90,11 +90,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227029
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227029
+                unit:
+                  value: fL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/mean_art_press.yaml
+++ b/priority_variables_transform/FHS-ingest/mean_art_press.yaml
@@ -15,14 +15,14 @@
           value: 'Brachial Vascular Reactivity Test'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000195
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024481
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht000195
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024481
+                unit:
+                  value: mm[Hg]
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000194
@@ -40,14 +40,14 @@
           value: 'Brachial Vascular Reactivity Test'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000194
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024414
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht000194
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024414
+                unit:
+                  value: mm[Hg]
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000211
@@ -65,14 +65,14 @@
           value: 'Arterial Tonometry'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000211
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024867
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht000211
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024867
+                unit:
+                  value: mm[Hg]
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000209
@@ -90,14 +90,14 @@
           value: 'Arterial Tonometry'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000209
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024780
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht000209
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024780
+                unit:
+                  value: mm[Hg]
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000210
@@ -115,11 +115,11 @@
           value: 'Arterial Tonometry'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000210
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024826
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht000210
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024826
+                unit:
+                  value: mm[Hg]
+                  range: string

--- a/priority_variables_transform/FHS-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/monocyte_ncnc_bld.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172195
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172195
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -40,11 +40,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227042
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227042
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/nt_bnp.yaml
+++ b/priority_variables_transform/FHS-ingest/nt_bnp.yaml
@@ -16,33 +16,33 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000823
-            slot_derivations:
-              value_decimal:
-                expr: case(({phv00073727} > 4, {phv00073727}), (True, None))
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht000823
+              slot_derivations:
+                value_decimal:
+                  expr: case(({phv00073727} > 4, {phv00073727}), (True, None))
+                unit:
+                  value: pg/mL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000823
-            slot_derivations:
-              value_decimal:
-                value: '5'
-                range: string
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht000823
+              slot_derivations:
+                value_decimal:
+                  value: '5'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000823
-            slot_derivations:
-              value_decimal:
-                value: '35000'
-                range: string
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht000823
+              slot_derivations:
+                value_decimal:
+                  value: '35000'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/person.yaml
+++ b/priority_variables_transform/FHS-ingest/person.yaml
@@ -21,40 +21,40 @@
           expr: 'case(({pht002075.phv00146741} is not None, {pht002075.phv00146741} * 365))'
         cause_of_death:
           class_derivations:
-          - name: CauseOfDeath
-            populated_from: pht003099
-            joins:
-              pht000094:
-                source_key: phv00177926
-                lookup_key: phv00030516
-            slot_derivations:
-              cause:
-                # pht000094.phv00030515 = icd_sys (ICD version: 8 or 9)
-                # pht000094.phv00030512 = icdecod1 (main/underlying cause of death)
-                expr: 'case(({pht000094.phv00030515} == 9 and {pht000094.phv00030512} is not None, "ICD9CM:" + str({pht000094.phv00030512})), ({pht000094.phv00030515} == 8 and {pht000094.phv00030512} is not None, "ICD8CM:" + str({pht000094.phv00030512})))'
-              order:
-                value: 1
-          - name: CauseOfDeath
-            populated_from: pht003099
-            joins:
-              pht000094:
-                source_key: phv00177926
-                lookup_key: phv00030516
-            slot_derivations:
-              cause:
-                # pht000094.phv00030513 = icdecod2 (secondary cause of death)
-                expr: 'case(({pht000094.phv00030515} == 9 and {pht000094.phv00030513} is not None, "ICD9CM:" + str({pht000094.phv00030513})), ({pht000094.phv00030515} == 8 and {pht000094.phv00030513} is not None, "ICD8CM:" + str({pht000094.phv00030513})))'
-              order:
-                value: 2
-          - name: CauseOfDeath
-            populated_from: pht003099
-            joins:
-              pht000094:
-                source_key: phv00177926
-                lookup_key: phv00030516
-            slot_derivations:
-              cause:
-                # pht000094.phv00030514 = icdecod3 (tertiary cause of death)
-                expr: 'case(({pht000094.phv00030515} == 9 and {pht000094.phv00030514} is not None, "ICD9CM:" + str({pht000094.phv00030514})), ({pht000094.phv00030515} == 8 and {pht000094.phv00030514} is not None, "ICD8CM:" + str({pht000094.phv00030514})))'
-              order:
-                value: 3
+          - CauseOfDeath:
+              populated_from: pht003099
+              joins:
+                pht000094:
+                  source_key: phv00177926
+                  lookup_key: phv00030516
+              slot_derivations:
+                cause:
+                  # pht000094.phv00030515 = icd_sys (ICD version: 8 or 9)
+                  # pht000094.phv00030512 = icdecod1 (main/underlying cause of death)
+                  expr: 'case(({pht000094.phv00030515} == 9 and {pht000094.phv00030512} is not None, "ICD9CM:" + str({pht000094.phv00030512})), ({pht000094.phv00030515} == 8 and {pht000094.phv00030512} is not None, "ICD8CM:" + str({pht000094.phv00030512})))'
+                order:
+                  value: 1
+          - CauseOfDeath:
+              populated_from: pht003099
+              joins:
+                pht000094:
+                  source_key: phv00177926
+                  lookup_key: phv00030516
+              slot_derivations:
+                cause:
+                  # pht000094.phv00030513 = icdecod2 (secondary cause of death)
+                  expr: 'case(({pht000094.phv00030515} == 9 and {pht000094.phv00030513} is not None, "ICD9CM:" + str({pht000094.phv00030513})), ({pht000094.phv00030515} == 8 and {pht000094.phv00030513} is not None, "ICD8CM:" + str({pht000094.phv00030513})))'
+                order:
+                  value: 2
+          - CauseOfDeath:
+              populated_from: pht003099
+              joins:
+                pht000094:
+                  source_key: phv00177926
+                  lookup_key: phv00030516
+              slot_derivations:
+                cause:
+                  # pht000094.phv00030514 = icdecod3 (tertiary cause of death)
+                  expr: 'case(({pht000094.phv00030515} == 9 and {pht000094.phv00030514} is not None, "ICD9CM:" + str({pht000094.phv00030514})), ({pht000094.phv00030515} == 8 and {pht000094.phv00030514} is not None, "ICD8CM:" + str({pht000094.phv00030514})))'
+                order:
+                  value: 3

--- a/priority_variables_transform/FHS-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/FHS-ingest/platelet_ct.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172186
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172186
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227033
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227033
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -65,11 +65,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081034
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081034
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/pmv.yaml
+++ b/priority_variables_transform/FHS-ingest/pmv.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172187
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172187
+                unit:
+                  value: fL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -40,11 +40,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227034
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227034
+                unit:
+                  value: fL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/pr_qrs_qt.yaml
+++ b/priority_variables_transform/FHS-ingest/pr_qrs_qt.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000299
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00036353
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000299
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00036353
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000299
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000299
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00036354
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000299
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00036354
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000299
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000299
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00036363
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000299
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00036363
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000299
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000299
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00036355
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000299
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00036355
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000299
@@ -120,11 +120,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000299
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00036356
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000299
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00036356
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/FHS-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/FHS-ingest/qrs_ekg.yaml
@@ -15,14 +15,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003094
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177464
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003094
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177464
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006005
@@ -40,14 +40,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006005
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00273976} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht006005
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00273976} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004814
@@ -65,14 +65,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004814
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00250999} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht004814
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00250999} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004815
@@ -90,14 +90,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004815
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251459} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht004815
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251459} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -115,14 +115,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00254208
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00254208
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005141
@@ -140,14 +140,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005141
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254716} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht005141
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254716} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005142
@@ -165,14 +165,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005142
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255106
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht005142
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255106
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006007
@@ -190,14 +190,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006007
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00274831
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht006007
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00274831
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006008
@@ -215,14 +215,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006008
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275189
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht006008
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275189
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000149
@@ -240,14 +240,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000149
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023257
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000149
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023257
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000012
@@ -265,14 +265,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000012
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00001526} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000012
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00001526} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -290,14 +290,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00001717} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00001717} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000014
@@ -315,14 +315,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000014
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00001978} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000014
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00001978} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000015
@@ -340,14 +340,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000015
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002158} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000015
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002158} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000016
@@ -365,14 +365,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000016
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002353} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000016
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002353} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000017
@@ -390,14 +390,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000017
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002593} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000017
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002593} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000018
@@ -415,14 +415,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000018
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002801} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000018
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002801} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000019
@@ -440,14 +440,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000019
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003180} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000019
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003180} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000020
@@ -465,14 +465,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000020
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003595} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000020
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003595} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000021
@@ -490,14 +490,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000021
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004003} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000021
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004003} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -515,14 +515,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004427} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004427} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000023
@@ -540,14 +540,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000023
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004869} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000023
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004869} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000024
@@ -565,14 +565,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000024
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005233} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000024
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005233} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000025
@@ -590,14 +590,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000025
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005860} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000025
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005860} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000026
@@ -615,14 +615,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006217} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006217} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000026
@@ -640,14 +640,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006219} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006219} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000027
@@ -665,14 +665,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000027
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00006612} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000027
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00006612} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000028
@@ -690,14 +690,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000028
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007046} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000028
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007046} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000029
@@ -715,14 +715,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000029
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007481} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000029
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007481} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000692
@@ -740,14 +740,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000692
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00070507} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000692
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00070507} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000010
@@ -765,14 +765,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000010
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00001174} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000010
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00001174} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000030
@@ -790,14 +790,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007649} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007649} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -815,14 +815,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007889} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007889} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000032
@@ -840,14 +840,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000032
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008635} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000032
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008635} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000033
@@ -865,14 +865,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000033
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00009031} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000033
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00009031} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000034
@@ -890,14 +890,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000034
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00009491} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000034
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00009491} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000035
@@ -915,14 +915,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010005} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010005} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -940,14 +940,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010438} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010438} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000747
@@ -965,14 +965,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000747
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00072263} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000747
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00072263} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -990,14 +990,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00021154} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00021154} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -1013,14 +1013,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276825
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276825
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -1036,14 +1036,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276826
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276826
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -1059,11 +1059,11 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276827
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276827
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/FHS-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/FHS-ingest/qt_ekg.yaml
@@ -15,14 +15,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000149
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00023258
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000149
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00023258
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000014
@@ -40,14 +40,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000014
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00001979} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000014
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00001979} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000015
@@ -65,14 +65,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000015
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002159} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000015
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002159} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000016
@@ -90,14 +90,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000016
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002354} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000016
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002354} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000017
@@ -115,14 +115,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000017
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00002594} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000017
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00002594} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000019
@@ -140,14 +140,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000019
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003181} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000019
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003181} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000020
@@ -165,14 +165,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000020
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003596} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000020
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003596} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000030
@@ -190,14 +190,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007650} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007650} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -215,14 +215,14 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007890} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007890} * 10'
+                unit:
+                  value: ms
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000032
@@ -240,11 +240,11 @@
           value: 'Electrocardiogram'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000032
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008636} * 10'
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht000032
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008636} * 10'
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/FHS-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/FHS-ingest/rdbld_ct.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008109} / 100'
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008109} / 100'
+                unit:
+                  value: 10*6/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -38,14 +38,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172179
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172179
+                unit:
+                  value: 10*6/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -63,14 +63,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227026
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227026
+                unit:
+                  value: 10*6/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -88,14 +88,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081029
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081029
+                unit:
+                  value: 10*6/uL
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -112,11 +112,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00007641} / 100'
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00007641} / 100'
+                unit:
+                  value: 10*6/uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/rdw.yaml
+++ b/priority_variables_transform/FHS-ingest/rdw.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172185
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172185
+                unit:
+                  value: '%'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -39,11 +39,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227032
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227032
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/FHS-ingest/sleep_duration_daily.yaml
@@ -15,14 +15,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000098
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00022090
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000098
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00022090
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003094
@@ -40,14 +40,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003094
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177686
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht003094
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177686
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006005
@@ -65,14 +65,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006005
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00274175
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht006005
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00274175
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004814
@@ -90,14 +90,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004814
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00251253
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht004814
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00251253
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004815
@@ -115,14 +115,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00251570
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht004815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00251570
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004815
@@ -140,14 +140,14 @@
           value: 'Sleep Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004815
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00251771
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht004815
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00251771
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -165,14 +165,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00254343
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00254343
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -190,14 +190,14 @@
           value: 'Sleep Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00254569
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00254569
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000014
@@ -215,14 +215,14 @@
           value: 'Medical History'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000014
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001902
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000014
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001902
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -240,14 +240,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00004158
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00004158
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000031
@@ -265,14 +265,14 @@
           value: 'Medical History'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007754
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007754
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000033
@@ -290,14 +290,14 @@
           value: 'Medical History'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000033
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00009109
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000033
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00009109
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -315,14 +315,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010680
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010680
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000747
@@ -340,14 +340,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00072369
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00072369
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000747
@@ -365,14 +365,14 @@
           value: 'Sleep Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00072556
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00072556
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -390,14 +390,14 @@
           value: 'Physical Activity Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021348
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021348
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -415,14 +415,14 @@
           value: 'health interview'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055390
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055390
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -440,14 +440,14 @@
           value: 'Sleep Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055471
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055471
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -465,14 +465,14 @@
           value: 'Sleep Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055472
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055472
+                unit:
+                  value: h
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -488,12 +488,12 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00056652
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00056652
+                unit:
+                  value: h
+                  range: string
                 

--- a/priority_variables_transform/FHS-ingest/sodium_blood.yaml
+++ b/priority_variables_transform/FHS-ingest/sodium_blood.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008101
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008101
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -38,11 +38,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276858
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276858
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/FHS-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/FHS-ingest/sodium_intak.yaml
@@ -15,14 +15,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002151
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00157335
-              unit:
-                value: mg/d
-                range: string
+          - Quantity:
+              populated_from: pht002151
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00157335
+                unit:
+                  value: mg/d
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002152
@@ -40,14 +40,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002152
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00157809
-              unit:
-                value: mg/d
-                range: string                    
+          - Quantity:
+              populated_from: pht002152
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00157809
+                unit:
+                  value: mg/d
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002153
@@ -65,14 +65,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002153
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00158129
-              unit:
-                value: mg/d
-                range: string                    
+          - Quantity:
+              populated_from: pht002153
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00158129
+                unit:
+                  value: mg/d
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000680
@@ -90,14 +90,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000680
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00070229
-              unit:
-                value: mg/d
-                range: string                   
+          - Quantity:
+              populated_from: pht000680
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00070229
+                unit:
+                  value: mg/d
+                  range: string                   
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000681
@@ -115,14 +115,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000681
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00068636
-              unit:
-                value: mg/d
-                range: string                     
+          - Quantity:
+              populated_from: pht000681
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00068636
+                unit:
+                  value: mg/d
+                  range: string                     
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000682
@@ -140,14 +140,14 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000682
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00068753
-              unit:
-                value: mg/d
-                range: string                     
+          - Quantity:
+              populated_from: pht000682
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00068753
+                unit:
+                  value: mg/d
+                  range: string                     
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002150
@@ -163,14 +163,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002150
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00157001
-              unit:
-                value: mg/d
-                range: string                      
+          - Quantity:
+              populated_from: pht002150
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00157001
+                unit:
+                  value: mg/d
+                  range: string                      
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002900
@@ -188,14 +188,14 @@
           value: 'Food Frequency Questionnaire'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002900
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172710
-              unit:
-                value: mg/d
-                range: string                    
+          - Quantity:
+              populated_from: pht002900
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172710
+                unit:
+                  value: mg/d
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002350
@@ -213,11 +213,11 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002350
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00162361
-              unit:
-                value: mg/d
-                range: string                     
+          - Quantity:
+              populated_from: pht002350
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00162361
+                unit:
+                  value: mg/d
+                  range: string                     

--- a/priority_variables_transform/FHS-ingest/spirometry.yaml
+++ b/priority_variables_transform/FHS-ingest/spirometry.yaml
@@ -8,46 +8,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00002946}) + ":FHS ORIGINAL EXAM 16")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000018
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177960} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000018
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00002682} / 100'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000018
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177960} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000018
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00002684} / 100'
-                    unit:
-                      value: L
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000018
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177960} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000018
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00002682} / 100'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000018
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177960} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000018
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00002684} / 100'
+                        unit:
+                          value: L
+                          range: string
 
 - class_derivations:
     MeasurementObservationSet:
@@ -59,46 +59,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00003261}) + ":FHS ORIGINAL EXAM 17")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000019
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177962} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000019
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00003249} / 100'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000019
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177962} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000019
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00003251} / 100'
-                    unit:
-                      value: L
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000019
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177962} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000019
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00003249} / 100'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000019
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177962} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000019
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00003251} / 100'
+                        unit:
+                          value: L
+                          range: string
 
 - class_derivations:
     MeasurementObservationSet:
@@ -110,66 +110,66 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022662}) + ":FHS ORIGINAL EXAM 19")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022584
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022586
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022585
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022584
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022586
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022585
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000103
@@ -180,66 +180,66 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022662}) + ":FHS ORIGINAL EXAM 19")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022597
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022598
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022600
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022597
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022598
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022600
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000103
@@ -250,66 +250,66 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022662}) + ":FHS ORIGINAL EXAM 19")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022610
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022611
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022613
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022610
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022611
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022613
+                        unit:
+                          value: '%'
+                          range: string
 
 - class_derivations:
     MeasurementObservationSet:
@@ -321,66 +321,66 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022662}) + ":FHS ORIGINAL EXAM 19")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022623
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022624
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022626
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022623
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022624
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022626
+                        unit:
+                          value: '%'
+                          range: string
 
 - class_derivations:
     MeasurementObservationSet:
@@ -392,66 +392,66 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022662}) + ":FHS ORIGINAL EXAM 19")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022636
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022637
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022639
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022636
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022637
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022639
+                        unit:
+                          value: '%'
+                          range: string
 
 - class_derivations:
     MeasurementObservationSet:
@@ -463,66 +463,66 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022662}) + ":FHS ORIGINAL EXAM 19 SUMMARY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022651
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022652
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000103
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              age_at_observation:
-                expr: '{pht003099.phv00177966} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000103
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022654
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022651
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022652
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000103
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                age_at_observation:
+                  expr: '{pht003099.phv00177966} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000103
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022654
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000105
@@ -533,72 +533,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022687}) + ":FHS OFFSPRING EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000105
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000105
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022678
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000105
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000105
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022679
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000105
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177934} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000105
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00022681} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000105
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000105
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022678
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000105
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000105
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022679
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000105
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177934} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000105
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00022681} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000101
@@ -609,72 +609,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022566}) + ":FHS OFFSPRING EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000101
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000101
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022555
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000101
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000101
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022556
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000101
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177938} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000101
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00022565} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000101
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000101
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022555
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000101
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000101
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022556
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000101
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177938} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000101
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00022565} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000104
@@ -685,72 +685,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022675}) + ":FHS OFFSPRING EXAM 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000104
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000104
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022664
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000104
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000104
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022665
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000104
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177940} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000104
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00022674} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000104
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000104
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022664
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000104
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000104
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022665
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000104
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177940} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000104
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00022674} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000106
@@ -761,72 +761,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022700}) + ":FHS OFFSPRING EXAM 7")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000106
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000106
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022689
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000106
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000106
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022690
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000106
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177942} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000106
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00022699} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000106
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000106
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022689
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000106
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000106
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022690
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000106
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177942} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000106
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00022699} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000395
@@ -837,46 +837,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00056635}) + ":" + case(({phv00056607} == ''1'', ''FHS OFFSPRING SHHS EXAM 1''), ({phv00056607} == ''7'', ''FHS OMNI 1 SHHS EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000395
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000395
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00055266
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000395
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{phv00056587} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000395
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00055265
-                    unit:
-                      value: L
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000395
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000395
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00055266
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000395
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{phv00056587} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000395
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00055265
+                        unit:
+                          value: L
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000832
@@ -887,72 +887,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00073843}) + ":FHS OFFSPRING EXAM 8")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000832
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000832
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00073832
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000832
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000832
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00073829
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000832
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177944} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000832
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00073837} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000832
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000832
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00073832
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000832
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000832
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00073829
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000832
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177944} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000832
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00073837} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht000102
@@ -963,50 +963,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00022579}) + ":FHS GENERATION 3 EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht000102
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000102
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022571
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht000102
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht000102
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00022569
-                    unit:
-                      value: L
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht000102
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000102
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022571
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht000102
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht000102
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00022569
+                        unit:
+                          value: L
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht005170
@@ -1017,72 +1017,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00257846}) + ":" + case(({phv00257848} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 1''), ({phv00257848} == ''72'', ''FHS OMNI 2 EXAM 1''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht005170
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005170
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00257853
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005170
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005170
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00257850
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005170
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177930} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005170
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00257858} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht005170
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005170
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00257853
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005170
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005170
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00257850
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005170
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177930} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005170
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00257858} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003632
@@ -1093,72 +1093,72 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00196546}) + ":" + case(({phv00196547} == ''2'', ''FHS NEW OFFSPRING SPOUSE EXAM 2''), ({phv00196547} == ''3'', ''FHS GENERATION 3 EXAM 2''), ({phv00196547} == ''72'', ''FHS OMNI 2 EXAM 2''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003632
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003632
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00196552
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003632
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003632
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00196549
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003632
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: '{pht003099.phv00177932} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003632
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00196557} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003632
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003632
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00196552
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003632
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003632
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00196549
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003632
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: '{pht003099.phv00177932} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003632
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00196557} * 100'
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht005169
@@ -1169,69 +1169,69 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00257829}) + ":" + case(({phv00257830} == ''1'', ''FHS OFFSPRING EXAM 9''), ({phv00257830} == ''7'', ''FHS OMNI 1 EXAM 4''), (True, ''FHS UNKNOWN VISIT'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht005169
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: 'case(({phv00257830} == 1, {pht003099.phv00177946} * 365), ({phv00257830} == 7, {pht003099.phv00177936} * 365))'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005169
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00257838
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005169
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              method_type:
-                value: 'spirometry'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: 'case(({phv00257830} == 1, {pht003099.phv00177946} * 365), ({phv00257830} == 7, {pht003099.phv00177936} * 365))'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005169
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00257835
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht005169
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              method_type:
-                value: 'calculated'
-              qualifier:
-                value: MAXIMUM
-              age_at_observation:
-                expr: 'case(({phv00257830} == 1, {pht003099.phv00177946} * 365), ({phv00257830} == 7, {pht003099.phv00177936} * 365))'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht005169
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00257841} * 100'
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht005169
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: 'case(({phv00257830} == 1, {pht003099.phv00177946} * 365), ({phv00257830} == 7, {pht003099.phv00177936} * 365))'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005169
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00257838
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005169
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                method_type:
+                  value: 'spirometry'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: 'case(({phv00257830} == 1, {pht003099.phv00177946} * 365), ({phv00257830} == 7, {pht003099.phv00177936} * 365))'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005169
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00257835
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht005169
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                method_type:
+                  value: 'calculated'
+                qualifier:
+                  value: MAXIMUM
+                age_at_observation:
+                  expr: 'case(({phv00257830} == 1, {pht003099.phv00177946} * 365), ({phv00257830} == 7, {pht003099.phv00177936} * 365))'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht005169
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00257841} * 100'
+                        unit:
+                          value: '%'
+                          range: string

--- a/priority_variables_transform/FHS-ingest/spo2.yaml
+++ b/priority_variables_transform/FHS-ingest/spo2.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276851
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276851
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/tot_chol_bld.yaml
@@ -16,14 +16,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00010138}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010135
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010135
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -41,14 +41,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423929
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423929
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000013
@@ -66,14 +66,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000013
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00001581
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht000013
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00001581
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -92,14 +92,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00010139}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010142
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010142
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -118,14 +118,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00021427}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021391
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021391
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000742
@@ -144,14 +144,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00071888}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00071890
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00071890
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004801
@@ -170,14 +170,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00227012}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004801
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227014
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht004801
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227014
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006010
@@ -196,14 +196,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00275400}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275402
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht006010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275402
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -222,14 +222,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00275410}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275413
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275413
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -248,14 +248,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00277015}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277047
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277047
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -274,14 +274,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00277015}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277048
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277048
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -300,14 +300,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00423868}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544854
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544854
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -324,14 +324,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00423868}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00544850
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00544850
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -350,14 +350,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370081
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370081
+                unit:
+                  value: mg/dl
+                  range: string
 # REMOVED: Original Exam 4 (1954-56) total cholesterol — Abell-Kendall assay
 # reads systematically +10-15 mg/dL higher than enzymatic methods used by all
 # other cohorts. Not comparable cross-cohort without calibration adjustment.
@@ -411,14 +411,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370078
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370078
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -437,14 +437,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370065
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370065
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -463,14 +463,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370069
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370069
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -488,14 +488,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370072
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370072
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -514,14 +514,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370070
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370070
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -540,14 +540,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370068
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370068
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -566,14 +566,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370074
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370074
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -592,14 +592,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370077
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370077
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -618,14 +618,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370073
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370073
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -644,14 +644,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370064
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370064
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -669,14 +669,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370071
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370071
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -695,14 +695,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370076
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370076
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -721,14 +721,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370075
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370075
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -747,14 +747,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370063
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370063
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -773,14 +773,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370067
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370067
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -799,14 +799,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370079
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370079
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -825,14 +825,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00369651}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370080
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370080
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009755
@@ -850,14 +850,14 @@
           value: 'Abell-Kendall technique'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009755
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423784
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009755
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423784
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -876,14 +876,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00423868}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423932
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423932
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -902,14 +902,14 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00423868}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423931
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423931
+                unit:
+                  value: mg/dl
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -928,11 +928,11 @@
           expr: 'uuid5("https://w3id.org/bdchm/Participant", str({phv00423868}) + ":FHS")'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423930
-              unit:
-                value: mg/dl
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423930
+                unit:
+                  value: mg/dl
+                  range: string

--- a/priority_variables_transform/FHS-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/FHS-ingest/triglyc_bld.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009755
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423783} * 0.295'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009755
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423783} * 0.295'
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000009
@@ -42,14 +42,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000009
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00000931} < 9000, {phv00000931}), (True, None))'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000009
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00000931} < 9000, {phv00000931}), (True, None))'
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000010
@@ -68,14 +68,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000010
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00001054} < 9000, {phv00001054}), (True, None))'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000010
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00001054} < 9000, {phv00001054}), (True, None))'
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000011
@@ -94,14 +94,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000011
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00001209} < 9000, {phv00001209}), (True, None))'
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000011
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00001209} < 9000, {phv00001209}), (True, None))'
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000034
@@ -120,14 +120,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000034
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00009576
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000034
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00009576
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000035
@@ -146,14 +146,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010136
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010136
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -172,14 +172,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00010144
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00010144
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -198,14 +198,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00021393
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00021393
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000742
@@ -224,14 +224,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00071892
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00071892
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -250,14 +250,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172172
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172172
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005143
@@ -276,14 +276,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005143
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00255342
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht005143
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00255342
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004801
@@ -302,14 +302,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004801
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227015
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004801
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227015
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006010
@@ -328,14 +328,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275403
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275403
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006011
@@ -354,14 +354,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006011
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00275415
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006011
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00275415
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -380,14 +380,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227056
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227056
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -406,14 +406,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081038
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081038
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000395
@@ -432,14 +432,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000395
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00055264
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht000395
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00055264
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -458,14 +458,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277049
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277049
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -484,14 +484,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00277050
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00277050
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -510,14 +510,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423933
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423933
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -536,14 +536,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423934
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423934
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -562,14 +562,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423935
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423935
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -588,14 +588,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00423936
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00423936
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -614,14 +614,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370082
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370082
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -640,14 +640,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370083
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370083
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -666,14 +666,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370084
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370084
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -692,14 +692,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370085
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370085
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -718,14 +718,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370086
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370086
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -744,14 +744,14 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370087
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370087
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -770,11 +770,11 @@
           range: string          
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00370088
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00370088
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/troponin.yaml
+++ b/priority_variables_transform/FHS-ingest/troponin.yaml
@@ -15,29 +15,29 @@
           value: 'immunoassay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002072
-            slot_derivations:
-              value_decimal:
-                expr: 'case(
-                         ({phv00141866} >= 0.79, ({phv00141866} / 1000)),
-                         ({phv00141868} == 1, None), 
-                         (True, {phv00141866} / 1000)
-                      )'
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht002072
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(
+                           ({phv00141866} >= 0.79, ({phv00141866} / 1000)),
+                           ({phv00141868} == 1, None), 
+                           (True, {phv00141866} / 1000)
+                        )'
+                unit:
+                  value: ng/mL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002072
-            slot_derivations:
-              value_decimal:
-                value: '0.00078'
-                range: string
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht002072
+              slot_derivations:
+                value_decimal:
+                  value: '0.00078'
+                  range: string
+                unit:
+                  value: ng/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -53,11 +53,11 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00276804}'
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00276804}'
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/vege_serving.yaml
+++ b/priority_variables_transform/FHS-ingest/vege_serving.yaml
@@ -15,20 +15,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002151
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00157632} + {phv00157633} + {phv00157634} + {phv00157635}
-                  + {phv00157636} + {phv00157637} +{phv00157638} + {phv00157639}
-                  + {phv00157640} + {phv00157641} + {phv00157642} + {phv00157643}
-                  +{phv00157644} + {phv00157645} + {phv00157646} + {phv00157647}
-                  + {phv00157648} + {phv00157649} + {phv00157650} +{phv00157651}
-                  + {phv00157652} + {phv00157653} + {phv00157654} + {phv00157655}
-                  + {phv00157656} + {phv00157657} +{phv00157658} + {phv00157659})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002151
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00157632} + {phv00157633} + {phv00157634} + {phv00157635}
+                    + {phv00157636} + {phv00157637} +{phv00157638} + {phv00157639}
+                    + {phv00157640} + {phv00157641} + {phv00157642} + {phv00157643}
+                    +{phv00157644} + {phv00157645} + {phv00157646} + {phv00157647}
+                    + {phv00157648} + {phv00157649} + {phv00157650} +{phv00157651}
+                    + {phv00157652} + {phv00157653} + {phv00157654} + {phv00157655}
+                    + {phv00157656} + {phv00157657} +{phv00157658} + {phv00157659})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002153
@@ -46,20 +46,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002153
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00158435} + {phv00158436} + {phv00158437} + {phv00158438}
-                  + {phv00158439} + {phv00158440} +{phv00158441} + {phv00158442}
-                  + {phv00158443} + {phv00158444} + {phv00158445} + {phv00158446}
-                  +{phv00158447} + {phv00158448} + {phv00158449} + {phv00158450}
-                  + {phv00158451} + {phv00158452} + {phv00158453} +{phv00158454}
-                  + {phv00158455} + {phv00158456} + {phv00158457} + {phv00158458}
-                  + {phv00158459} + {phv00158460} +{phv00158461} + {phv00158462})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002153
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00158435} + {phv00158436} + {phv00158437} + {phv00158438}
+                    + {phv00158439} + {phv00158440} +{phv00158441} + {phv00158442}
+                    + {phv00158443} + {phv00158444} + {phv00158445} + {phv00158446}
+                    +{phv00158447} + {phv00158448} + {phv00158449} + {phv00158450}
+                    + {phv00158451} + {phv00158452} + {phv00158453} +{phv00158454}
+                    + {phv00158455} + {phv00158456} + {phv00158457} + {phv00158458}
+                    + {phv00158459} + {phv00158460} +{phv00158461} + {phv00158462})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000680
@@ -77,20 +77,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000680
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00070081} + {phv00070082} + {phv00070083} + {phv00070084}
-                  + {phv00070085} + {phv00070086} +{phv00070087} + {phv00070088}
-                  + {phv00070089} + {phv00070090} + {phv00070091} + {phv00070092}
-                  +{phv00070093} + {phv00070094} + {phv00070095} + {phv00070096}
-                  + {phv00070097} + {phv00070098} + {phv00070099} +{phv00070100}
-                  + {phv00070101} + {phv00070102} + {phv00070103} + {phv00070104}
-                  + {phv00070105} + {phv00070106} +{phv00070107} + {phv00070108})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht000680
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00070081} + {phv00070082} + {phv00070083} + {phv00070084}
+                    + {phv00070085} + {phv00070086} +{phv00070087} + {phv00070088}
+                    + {phv00070089} + {phv00070090} + {phv00070091} + {phv00070092}
+                    +{phv00070093} + {phv00070094} + {phv00070095} + {phv00070096}
+                    + {phv00070097} + {phv00070098} + {phv00070099} +{phv00070100}
+                    + {phv00070101} + {phv00070102} + {phv00070103} + {phv00070104}
+                    + {phv00070105} + {phv00070106} +{phv00070107} + {phv00070108})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000681
@@ -108,20 +108,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000681
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00068488} + {phv00068489} + {phv00068490} + {phv00068491}
-                  + {phv00068492} + {phv00068493} +{phv00068494} + {phv00068495}
-                  + {phv00068496} + {phv00068497} + {phv00068498} + {phv00068499}
-                  +{phv00068500} + {phv00068501} + {phv00068502} + {phv00068503}
-                  + {phv00068504} + {phv00068505} + {phv00068506} +{phv00068507}
-                  + {phv00068508} + {phv00068509} + {phv00068510} + {phv00068511}
-                  + {phv00068512} + {phv00068513} +{phv00068514} + {phv00068515})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht000681
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00068488} + {phv00068489} + {phv00068490} + {phv00068491}
+                    + {phv00068492} + {phv00068493} +{phv00068494} + {phv00068495}
+                    + {phv00068496} + {phv00068497} + {phv00068498} + {phv00068499}
+                    +{phv00068500} + {phv00068501} + {phv00068502} + {phv00068503}
+                    + {phv00068504} + {phv00068505} + {phv00068506} +{phv00068507}
+                    + {phv00068508} + {phv00068509} + {phv00068510} + {phv00068511}
+                    + {phv00068512} + {phv00068513} +{phv00068514} + {phv00068515})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000682
@@ -139,20 +139,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000682
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00069057} + {phv00069058} + {phv00069059} + {phv00069060}
-                  + {phv00069061} + {phv00069062} +{phv00069063} + {phv00069064}
-                  + {phv00069065} + {phv00069066} + {phv00069067} + {phv00069068}
-                  +{phv00069069} + {phv00069070} + {phv00069071} + {phv00069072}
-                  + {phv00069073} + {phv00069074} + {phv00069075} +{phv00069076}
-                  + {phv00069077} + {phv00069078} + {phv00069079} + {phv00069080}
-                  + {phv00069081} + {phv00069082} +{phv00069083} + {phv00069084})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht000682
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00069057} + {phv00069058} + {phv00069059} + {phv00069060}
+                    + {phv00069061} + {phv00069062} +{phv00069063} + {phv00069064}
+                    + {phv00069065} + {phv00069066} + {phv00069067} + {phv00069068}
+                    +{phv00069069} + {phv00069070} + {phv00069071} + {phv00069072}
+                    + {phv00069073} + {phv00069074} + {phv00069075} +{phv00069076}
+                    + {phv00069077} + {phv00069078} + {phv00069079} + {phv00069080}
+                    + {phv00069081} + {phv00069082} +{phv00069083} + {phv00069084})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002150
@@ -170,20 +170,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002150
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00157191} + {phv00157192} + {phv00157193} + {phv00157194}
-                  + {phv00157195} + {phv00157196} +{phv00157197} + {phv00157198}
-                  + {phv00157199} + {phv00157200} + {phv00157201} + {phv00157202}
-                  +{phv00157203} + {phv00157204} + {phv00157205} + {phv00157206}
-                  + {phv00157207} + {phv00157208} + {phv00157209} +{phv00157210}
-                  + {phv00157211} + {phv00157212} + {phv00157213} + {phv00157214}
-                  + {phv00157215} + {phv00157216} +{phv00157217} + {phv00157218})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002150
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00157191} + {phv00157192} + {phv00157193} + {phv00157194}
+                    + {phv00157195} + {phv00157196} +{phv00157197} + {phv00157198}
+                    + {phv00157199} + {phv00157200} + {phv00157201} + {phv00157202}
+                    +{phv00157203} + {phv00157204} + {phv00157205} + {phv00157206}
+                    + {phv00157207} + {phv00157208} + {phv00157209} +{phv00157210}
+                    + {phv00157211} + {phv00157212} + {phv00157213} + {phv00157214}
+                    + {phv00157215} + {phv00157216} +{phv00157217} + {phv00157218})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002900
@@ -201,20 +201,20 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002900
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00172970} + {phv00172971} + {phv00172972} + {phv00172973}
-                  + {phv00172974} + {phv00172975} +{phv00172976} + {phv00172977}
-                  + {phv00172978} + {phv00172979} + {phv00172980} + {phv00172981}
-                  +{phv00172982} + {phv00172983} + {phv00172984} + {phv00172985}
-                  + {phv00172986} + {phv00172987} + {phv00172988} +{phv00172989}
-                  + {phv00172990} + {phv00172991} + {phv00172992} + {phv00172993}
-                  + {phv00172994} + {phv00172995} +{phv00172996} + {phv00172997})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002900
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00172970} + {phv00172971} + {phv00172972} + {phv00172973}
+                    + {phv00172974} + {phv00172975} +{phv00172976} + {phv00172977}
+                    + {phv00172978} + {phv00172979} + {phv00172980} + {phv00172981}
+                    +{phv00172982} + {phv00172983} + {phv00172984} + {phv00172985}
+                    + {phv00172986} + {phv00172987} + {phv00172988} +{phv00172989}
+                    + {phv00172990} + {phv00172991} + {phv00172992} + {phv00172993}
+                    + {phv00172994} + {phv00172995} +{phv00172996} + {phv00172997})
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002350
@@ -232,17 +232,17 @@
           value: 'calculated'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002350
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00162569} + {phv00162570} + {phv00162571} + {phv00162572}
-                  + {phv00162573} + {phv00162574} +{phv00162575} + {phv00162576}
-                  + {phv00162577} + {phv00162578} + {phv00162579} + {phv00162580}
-                  +{phv00162581} + {phv00162582} + {phv00162583} + {phv00162584}
-                  + {phv00162585} + {phv00162586} + {phv00162587} +{phv00162588}
-                  + {phv00162589} + {phv00162590} + {phv00162591} + {phv00162592}
-                  + {phv00162593} + {phv00162594} +{phv00162595} + {phv00162596})
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002350
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00162569} + {phv00162570} + {phv00162571} + {phv00162572}
+                    + {phv00162573} + {phv00162574} +{phv00162575} + {phv00162576}
+                    + {phv00162577} + {phv00162578} + {phv00162579} + {phv00162580}
+                    +{phv00162581} + {phv00162582} + {phv00162583} + {phv00162584}
+                    + {phv00162585} + {phv00162586} + {phv00162587} +{phv00162588}
+                    + {phv00162589} + {phv00162590} + {phv00162591} + {phv00162592}
+                    + {phv00162593} + {phv00162594} +{phv00162595} + {phv00162596})
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/FHS-ingest/waist_circ.yaml
+++ b/priority_variables_transform/FHS-ingest/waist_circ.yaml
@@ -17,14 +17,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000139
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00023150} / 10'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000139
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00023150} / 10'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000140
@@ -44,14 +44,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000140
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00023159} / 10'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000140
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00023159} / 10'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003094
@@ -71,14 +71,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003094
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00177543} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003094
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00177543} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006005
@@ -98,14 +98,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006005
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00274057} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006005
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00274057} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004814
@@ -125,14 +125,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004814
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251065} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004814
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251065} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004815
@@ -152,14 +152,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004815
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251538} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004815
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251538} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004815
@@ -179,14 +179,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004815
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00251540} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004815
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00251540} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht005140
@@ -206,14 +206,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht005140
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00254291} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht005140
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00254291} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000021
@@ -233,14 +233,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000021
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00003672} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000021
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00003672} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000022
@@ -260,14 +260,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000022
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004088} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000022
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004088} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000023
@@ -287,14 +287,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000023
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00004530} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000023
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00004530} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000024
@@ -314,14 +314,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000024
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005544} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000024
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005544} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000025
@@ -341,14 +341,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000025
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00005924} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000025
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00005924} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000033
@@ -368,14 +368,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000033
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00008767} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000033
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00008767} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000034
@@ -395,14 +395,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000034
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00009555} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000034
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00009555} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000035
@@ -422,14 +422,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000035
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010112} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000035
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010112} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000036
@@ -449,14 +449,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000036
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00010502} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000036
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00010502} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000747
@@ -476,14 +476,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000747
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00072341} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000747
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00072341} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000747
@@ -503,14 +503,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000747
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00072342} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000747
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00072342} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000074
@@ -530,14 +530,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000074
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00021235} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht000074
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00021235} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -557,14 +557,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277053} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277053} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -584,14 +584,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00277054} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00277054} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006026
@@ -609,14 +609,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006026
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00520309} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht006026
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00520309} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -636,14 +636,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423941} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423941} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -663,14 +663,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423942} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423942} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -690,14 +690,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423943} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423943} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht009761
@@ -717,14 +717,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht009761
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00423944} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht009761
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00423944} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -744,14 +744,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370119} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370119} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -771,14 +771,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370120} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370120} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -798,14 +798,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370121} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370121} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -825,14 +825,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370122} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370122} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -852,14 +852,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370123} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370123} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -879,14 +879,14 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370124} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370124} * 2.54'
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht007777
@@ -906,11 +906,11 @@
           value: 'STANDING_POSITION'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht007777
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00370125} * 2.54'
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht007777
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00370125} * 2.54'
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/FHS-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/FHS-ingest/whtbld_ct.yaml
@@ -15,14 +15,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000031
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00008108
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht000031
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00008108
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002889
@@ -40,14 +40,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002889
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00172178
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht002889
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00172178
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004802
@@ -65,14 +65,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004802
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227025
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004802
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227025
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001045
@@ -90,14 +90,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001045
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00081030
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001045
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00081030
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006018
@@ -113,14 +113,14 @@
           value: 'blood assay'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006018
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00276855
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht006018
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00276855
+                unit:
+                  value: 10*3/uL
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -137,11 +137,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000030
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00007640
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht000030
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00007640
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/FHS-ingest/willeb_fac.yaml
+++ b/priority_variables_transform/FHS-ingest/willeb_fac.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000198
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00024571
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht000198
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00024571
+                unit:
+                  value: '%{Normal}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004806
@@ -41,11 +41,11 @@
           value: 'platelet aggregation'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004806
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00227097
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht004806
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00227097
+                unit:
+                  value: '%{Normal}'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/albumin_creatinine.yaml
+++ b/priority_variables_transform/HCHS-ingest/albumin_creatinine.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226309
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226309
+                unit:
+                  value: mg/g{creat}
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/HCHS-ingest/albumin_urine.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00253233} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00253233} * 10'
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/apnea_hypop_index.yaml
+++ b/priority_variables_transform/HCHS-ingest/apnea_hypop_index.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226392
-              unit:
-                value: /h
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226392
+                unit:
+                  value: /h
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/basophil_ncnc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/basophil_ncnc_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226301
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226301
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_hgt.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226281
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226281
+                unit:
+                  value: cm
+                  range: string
 # Block 2: Recalled height at age 21 -- uses WHEA2A_CM (phv00527446), the derived/unified
 # variable combining metric + imperial respondents (n=9,555). The raw metric-only variable
 # WHEA2A (phv00527433, n=3,232) was removed as a strict subset to avoid duplicate records.
@@ -49,11 +49,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00527446
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00527446
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/HCHS-ingest/bdy_wgt.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253218
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253218
+                unit:
+                  value: kg
+                  range: string
 # Block 2: Recalled weight at age 21 -- WHEA3A_KG (phv00527442)
 - class_derivations:
     MeasurementObservation:
@@ -47,14 +47,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00527442
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00527442
+                unit:
+                  value: kg
+                  range: string
 # Block 3: Recalled weight at age 45 -- WHEA4A_KG (phv00527443)
 - class_derivations:
     MeasurementObservation:
@@ -75,14 +75,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00527443
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00527443
+                unit:
+                  value: kg
+                  range: string
 # Block 4: Recalled weight at age 65 -- WHEA5A_KG (phv00527444)
 - class_derivations:
     MeasurementObservation:
@@ -103,11 +103,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00527444
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00527444
+                unit:
+                  value: kg
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/HCHS-ingest/blood_pressure.yaml
@@ -8,57 +8,57 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "oscillometric average"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00226390
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "oscillometric average"
-                range: string
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00226391
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "oscillometric average"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00226390
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "oscillometric average"
+                  range: string
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00226391
+                        unit:
+                          value: mm[Hg]
+                          range: string

--- a/priority_variables_transform/HCHS-ingest/bmi.yaml
+++ b/priority_variables_transform/HCHS-ingest/bmi.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226255
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226255
+                unit:
+                  value: kg/m2
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/cesd_score.yaml
+++ b/priority_variables_transform/HCHS-ingest/cesd_score.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_integer:
-                populated_from: phv00258051
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00258051
+                unit:
+                  value: '{score}'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/creat_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226307
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226307
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/creat_urin.yaml
+++ b/priority_variables_transform/HCHS-ingest/creat_urin.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253232
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253232
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/crp.yaml
+++ b/priority_variables_transform/HCHS-ingest/crp.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00258066
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00258066
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/cysc_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00526584
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00526584
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/egfr.yaml
+++ b/priority_variables_transform/HCHS-ingest/egfr.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253222
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253222
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -42,11 +42,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253223
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253223
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/eosinophil_ncnc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/eosinophil_ncnc_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226300
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226300
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/fam_income.yaml
+++ b/priority_variables_transform/HCHS-ingest/fam_income.yaml
@@ -14,22 +14,22 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_concept:
-                populated_from: phv00526188
-                value_mappings:
-                  '1': "Less than $10,000"
-                  '2': "$10,001-$15,000"
-                  '3': "$15,001-$20,000"
-                  '4': "$20,001-$25,000"
-                  '5': "$25,001-$29,999"
-                  '6': "$30,000-$40,000"
-                  '7': "$40,001-$50,000"
-                  '8': "$50,001-$75,000"
-                  '9': "$75,001-$100,000"
-                  '10': "More than $100,000"
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00526188
+                  value_mappings:
+                    '1': "Less than $10,000"
+                    '2': "$10,001-$15,000"
+                    '3': "$15,001-$20,000"
+                    '4': "$20,001-$25,000"
+                    '5': "$25,001-$29,999"
+                    '6': "$30,000-$40,000"
+                    '7': "$40,001-$50,000"
+                    '8': "$50,001-$75,000"
+                    '9': "$75,001-$100,000"
+                    '10': "More than $100,000"
+                unit:
+                  value: USD
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/fasting_blood_gluc.yaml
+++ b/priority_variables_transform/HCHS-ingest/fasting_blood_gluc.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253229
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253229
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/ferritin.yaml
+++ b/priority_variables_transform/HCHS-ingest/ferritin.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00258067
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00258067
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/hdl.yaml
+++ b/priority_variables_transform/HCHS-ingest/hdl.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253239
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253239
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/hemat.yaml
+++ b/priority_variables_transform/HCHS-ingest/hemat.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226303
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226303
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/hemo.yaml
+++ b/priority_variables_transform/HCHS-ingest/hemo.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226302
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226302
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/HCHS-ingest/hemo_a1c.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253231
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253231
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/hip_circ.yaml
+++ b/priority_variables_transform/HCHS-ingest/hip_circ.yaml
@@ -19,11 +19,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253220
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253220
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/hrtrt.yaml
+++ b/priority_variables_transform/HCHS-ingest/hrtrt.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226274
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226274
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -42,11 +42,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00258056
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00258056
+                unit:
+                  value: '{beats}/min'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/HCHS-ingest/insulin_blood.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00253227} * 6'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00253227} * 6'
+                unit:
+                  value: pmol/L
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/ldl.yaml
+++ b/priority_variables_transform/HCHS-ingest/ldl.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253241
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253241
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/lympho_ct.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226298
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226298
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/lympho_pct.yaml
+++ b/priority_variables_transform/HCHS-ingest/lympho_pct.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226285
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226285
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/mch.yaml
+++ b/priority_variables_transform/HCHS-ingest/mch.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226305
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226305
+                unit:
+                  value: pg/{cell}
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/mchc.yaml
+++ b/priority_variables_transform/HCHS-ingest/mchc.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226306
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226306
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/mcv.yaml
+++ b/priority_variables_transform/HCHS-ingest/mcv.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226304
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226304
+                unit:
+                  value: fL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/monocyte_ncnc_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226299
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226299
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/neutro_ct.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226297
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226297
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/neutro_pct.yaml
+++ b/priority_variables_transform/HCHS-ingest/neutro_pct.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226284
-              unit:
-                value: '%{WBCs}'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226284
+                unit:
+                  value: '%{WBCs}'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/platelet_ct.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226310
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226310
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/pr_ekg.yaml
+++ b/priority_variables_transform/HCHS-ingest/pr_ekg.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226275
-              unit:
-                value: "ms"
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226275
+                unit:
+                  value: "ms"
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/HCHS-ingest/qrs_ekg.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226263
-              unit:
-                value: "ms"
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226263
+                unit:
+                  value: "ms"
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/HCHS-ingest/qt_ekg.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226265
-              unit:
-                value: "ms"
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226265
+                unit:
+                  value: "ms"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004715
@@ -42,11 +42,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226266
-              unit:
-                value: "ms"
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226266
+                unit:
+                  value: "ms"
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/rdbld_ct.yaml
@@ -16,10 +16,10 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226294
-              unit:
-                value: 10*6/uL
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226294
+                unit:
+                  value: 10*6/uL

--- a/priority_variables_transform/HCHS-ingest/rdw.yaml
+++ b/priority_variables_transform/HCHS-ingest/rdw.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226308
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226308
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/HCHS-ingest/sleep_duration_daily.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00258046
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00258046
+                unit:
+                  value: h
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/spirometry.yaml
+++ b/priority_variables_transform/HCHS-ingest/spirometry.yaml
@@ -8,165 +8,165 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00226250}) + ":HCHS EXAM")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "spirometry"
-                range: string
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00226383} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "spirometry"
-                range: string
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00226384} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "calculated"
-                range: string
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00226278
-                    unit:
-                      value: '%'
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00258076} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00526840} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht004715
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-                range: string
-              age_at_observation:
-                expr: '{phv00226251} * 365'
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht004715
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00526841
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "spirometry"
+                  range: string
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00226383} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "spirometry"
+                  range: string
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00226384} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "calculated"
+                  range: string
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00226278
+                        unit:
+                          value: '%'
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00258076} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00526840} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht004715
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                  range: string
+                age_at_observation:
+                  expr: '{phv00226251} * 365'
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht004715
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00526841
+                        unit:
+                          value: '%'
+                          range: string

--- a/priority_variables_transform/HCHS-ingest/spo2.yaml
+++ b/priority_variables_transform/HCHS-ingest/spo2.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226395
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226395
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/tot_chol_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253238
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253238
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/HCHS-ingest/triglyc_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253240
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253240
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/waist_circ.yaml
+++ b/priority_variables_transform/HCHS-ingest/waist_circ.yaml
@@ -19,11 +19,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00253219
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00253219
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/waist_hip.yaml
+++ b/priority_variables_transform/HCHS-ingest/waist_hip.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226399
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226399
+                unit:
+                  value: '{ratio}'
+                  range: string

--- a/priority_variables_transform/HCHS-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/HCHS-ingest/whtbld_ct.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004715
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00226283
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004715
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00226283
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/JHS-ingest/albumin_creatinine.yaml
+++ b/priority_variables_transform/JHS-ingest/albumin_creatinine.yaml
@@ -14,13 +14,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401721
-              unit:
-                value: "mg/g"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401721
+                unit:
+                  value: "mg/g"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -37,10 +37,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401740
-              unit:
-                value: "mg/g"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401740
+                unit:
+                  value: "mg/g"

--- a/priority_variables_transform/JHS-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/JHS-ingest/albumin_urine.yaml
@@ -12,13 +12,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401741
-              unit: 
-                value: mg/L
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401741
+                unit: 
+                  value: mg/L
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -33,13 +33,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401742
-              unit: 
-                value: mg/L
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401742
+                unit: 
+                  value: mg/L
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008741
@@ -54,25 +54,25 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401722
-              unit: 
-                value: mg/L
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401722
+                unit: 
+                  value: mg/L
 # phv00401723 indicates if the continuous measurement recorded in phv00401722 fell below 2, the lower limit of detection
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                value: '2'
-                range: string
-              unit:
-                value: mg/L
-                range: string    
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  value: '2'
+                  range: string
+                unit:
+                  value: mg/L
+                  range: string    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -87,17 +87,17 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401329
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit: 
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401329
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit: 
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001960
@@ -112,17 +112,17 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001960
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127646
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit: 
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001960
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127646
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit: 
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -137,17 +137,17 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401152
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit: 
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401152
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit: 
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -162,17 +162,17 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401436
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit: 
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401436
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit: 
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008759
@@ -187,11 +187,11 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008759
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00403004} / {phv00403006} * 1000"
-              unit: 
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht008759
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00403004} / {phv00403006} * 1000"
+                unit: 
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/JHS-ingest/alcohol_servings.yaml
+++ b/priority_variables_transform/JHS-ingest/alcohol_servings.yaml
@@ -17,13 +17,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401384
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401384
+                unit:
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -40,10 +40,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401090
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401090
+                unit:
+                  value: "{#}/wk"

--- a/priority_variables_transform/JHS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/JHS-ingest/bdy_hgt.yaml
@@ -14,14 +14,14 @@
           value: "Tanita"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008737
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00401596} <= 0, None),(True, {phv00401596} * 30.48 + {phv00401597} * 2.54))'
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht008737
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00401596} <= 0, None),(True, {phv00401596} * 30.48 + {phv00401597} * 2.54))'
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008737
@@ -38,14 +38,14 @@
           value: "Balance Beam"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008737
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00401616} <= 0, None),(True, {phv00401616} * 30.48 + {phv00401618} * 2.54))'
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht008737
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00401616} <= 0, None),(True, {phv00401616} * 30.48 + {phv00401618} * 2.54))'
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -62,13 +62,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401387
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401387
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008738
@@ -85,13 +85,13 @@
           value: "Tanita"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008738
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401635
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008738
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401635
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -108,13 +108,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401286
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401286
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -131,13 +131,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401094
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401094
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008738
@@ -154,13 +154,13 @@
           value: "Balance Beam"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008738
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401631
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008738
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401631
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001940
@@ -177,10 +177,10 @@
           value: "Anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001940
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125860
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001940
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125860
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/JHS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/JHS-ingest/bdy_wgt.yaml
@@ -14,13 +14,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401093
-              unit:
-                value: "kg"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401093
+                unit:
+                  value: "kg"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -37,13 +37,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401386
-              unit:
-                value: "kg"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401386
+                unit:
+                  value: "kg"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -60,13 +60,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401285
-              unit:
-                value: "kg"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401285
+                unit:
+                  value: "kg"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001940
@@ -83,10 +83,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001940
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125861
-              unit:
-                value: "kg"
+          - Quantity:
+              populated_from: pht001940
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125861
+                unit:
+                  value: "kg"

--- a/priority_variables_transform/JHS-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/JHS-ingest/blood_pressure.yaml
@@ -8,46 +8,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403830}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008783
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008783
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403851
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008783
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008783
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403852
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008783
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008783
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403851
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008783
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008783
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403852
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008731
@@ -58,50 +58,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00401370}) + ":JHS Exam 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008731
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Analysis derived"
-              age_at_observation:
-                expr: "{phv00401379} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008731
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401409
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008731
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron derived"
-              age_at_observation:
-                expr: "{phv00401379} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008731
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401410
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008731
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Analysis derived"
+                age_at_observation:
+                  expr: "{phv00401379} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008731
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401409
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008731
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron derived"
+                age_at_observation:
+                  expr: "{phv00401379} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008731
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401410
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001974
@@ -112,46 +112,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00128355}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001974
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001974
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128376
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001974
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001974
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128377
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001974
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001974
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128376
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001974
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001974
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128377
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008782
@@ -162,46 +162,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403792}) + ":JHS Exam 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Random zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403819
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Random zero average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403820
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Random zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403819
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Random zero average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403820
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008782
@@ -212,46 +212,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403792}) + ":JHS Exam 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403826
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403827
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403826
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403827
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008729
@@ -262,50 +262,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00401078}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008729
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Analysis derived"
-              age_at_observation:
-                expr: "{phv00401085} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008729
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401118
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008729
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron derived"
-              age_at_observation:
-                expr: "{phv00401085} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008729
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401119
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008729
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Analysis derived"
+                age_at_observation:
+                  expr: "{phv00401085} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008729
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401118
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008729
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron derived"
+                age_at_observation:
+                  expr: "{phv00401085} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008729
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401119
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001974
@@ -316,46 +316,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00128355}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001974
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Sphygmomanometer reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001974
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128373
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001974
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Sphygmomanometer reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001974
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128374
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001974
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Sphygmomanometer reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001974
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128373
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001974
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Sphygmomanometer reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001974
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128374
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001974
@@ -366,46 +366,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00128355}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001974
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Sphygmomanometer reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001974
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128370
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001974
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Sphygmomanometer reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001974
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128371
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001974
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Sphygmomanometer reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001974
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128370
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001974
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Sphygmomanometer reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001974
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128371
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008783
@@ -416,46 +416,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403830}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008783
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008783
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403854
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008783
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008783
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403855
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008783
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008783
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403854
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008783
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008783
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403855
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008783
@@ -466,46 +466,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403830}) + ":JHS Exam 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008783
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008783
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403848
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008783
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008783
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403849
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008783
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008783
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403848
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008783
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008783
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403849
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008730
@@ -516,50 +516,50 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00401273}) + ":JHS Exam 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008730
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Analysis derived"
-              age_at_observation:
-                expr: "{phv00401282} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008730
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401308
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008730
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron derived"
-              age_at_observation:
-                expr: "{phv00401282} * 365"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008730
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401309
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008730
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Analysis derived"
+                age_at_observation:
+                  expr: "{phv00401282} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008730
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401308
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008730
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron derived"
+                age_at_observation:
+                  expr: "{phv00401282} * 365"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008730
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401309
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008782
@@ -570,46 +570,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403792}) + ":JHS Exam 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Random zero reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403816
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Random zero reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403817
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Random zero reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403816
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Random zero reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403817
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008782
@@ -620,46 +620,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403792}) + ":JHS Exam 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403822
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403823
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403822
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403823
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008782
@@ -670,46 +670,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403792}) + ":JHS Exam 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403824
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Omron automated reading 2"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403825
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403824
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Omron automated reading 2"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403825
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008782
@@ -720,43 +720,43 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00403792}) + ":JHS Exam 6")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Random zero reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403813
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht008782
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Random zero reading 1"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008782
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00403814
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Random zero reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403813
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht008782
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Random zero reading 1"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008782
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00403814
+                        unit:
+                          value: "mm[Hg]"

--- a/priority_variables_transform/JHS-ingest/bmi.yaml
+++ b/priority_variables_transform/JHS-ingest/bmi.yaml
@@ -14,13 +14,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401097
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401097
+                unit:
+                  value: "kg/m2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -37,13 +37,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401289
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401289
+                unit:
+                  value: "kg/m2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -60,10 +60,10 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401390
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401390
+                unit:
+                  value: "kg/m2"

--- a/priority_variables_transform/JHS-ingest/bnp.yaml
+++ b/priority_variables_transform/JHS-ingest/bnp.yaml
@@ -12,33 +12,33 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008733
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401563
-              unit: 
-                value: pg/mL
+          - Quantity:
+              populated_from: pht008733
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401563
+                unit: 
+                  value: pg/mL
 # phv00401564 is a categorical var indicating if bnp fell below detection limit or was an abnormally high value
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008733
-            slot_derivations:
-              value_decimal:
-                value: '2'
-                range: string
-              unit:
-                value: pg/mL
-                range: string 
+          - Quantity:
+              populated_from: pht008733
+              slot_derivations:
+                value_decimal:
+                  value: '2'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string 
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008733
-            slot_derivations:
-              value_decimal:
-                value: '100'
-                range: string
-              unit:
-                value: pg/mL
-                range: string   
+          - Quantity:
+              populated_from: pht008733
+              slot_derivations:
+                value_decimal:
+                  value: '100'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string   

--- a/priority_variables_transform/JHS-ingest/bun.yaml
+++ b/priority_variables_transform/JHS-ingest/bun.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401727
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401727
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/cac_score.yaml
+++ b/priority_variables_transform/JHS-ingest/cac_score.yaml
@@ -14,10 +14,10 @@
           value: "CT scan"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001948
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00126002
-              unit:
-                value: "{score}"
+          - Quantity:
+              populated_from: pht001948
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00126002
+                unit:
+                  value: "{score}"

--- a/priority_variables_transform/JHS-ingest/carotid_imt.yaml
+++ b/priority_variables_transform/JHS-ingest/carotid_imt.yaml
@@ -14,13 +14,13 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008791
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404198
-              unit:
-                value: "mm"
+          - Quantity:
+              populated_from: pht008791
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404198
+                unit:
+                  value: "mm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008791
@@ -37,13 +37,13 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008791
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404197
-              unit:
-                value: "mm"
+          - Quantity:
+              populated_from: pht008791
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404197
+                unit:
+                  value: "mm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008791
@@ -60,13 +60,13 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008791
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404199
-              unit:
-                value: "mm"
+          - Quantity:
+              populated_from: pht008791
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404199
+                unit:
+                  value: "mm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008791
@@ -83,13 +83,13 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008791
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404195
-              unit:
-                value: "mm"
+          - Quantity:
+              populated_from: pht008791
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404195
+                unit:
+                  value: "mm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008791
@@ -106,13 +106,13 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008791
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404196
-              unit:
-                value: "mm"
+          - Quantity:
+              populated_from: pht008791
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404196
+                unit:
+                  value: "mm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008791
@@ -129,10 +129,10 @@
           value: "carotid ultrasound"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008791
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404200
-              unit:
-                value: "mm"
+          - Quantity:
+              populated_from: pht008791
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404200
+                unit:
+                  value: "mm"

--- a/priority_variables_transform/JHS-ingest/cesd_score.yaml
+++ b/priority_variables_transform/JHS-ingest/cesd_score.yaml
@@ -14,10 +14,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_integer:
-                populated_from: phv00401225
-              unit:
-                value: "{score}"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00401225
+                unit:
+                  value: "{score}"

--- a/priority_variables_transform/JHS-ingest/chloride_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/chloride_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127611
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127611
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/JHS-ingest/creat_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/creat_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127612
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127612
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401154
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401154
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401437
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401437
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401153
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401153
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -106,10 +106,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401730
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401730
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/creat_urin.yaml
+++ b/priority_variables_transform/JHS-ingest/creat_urin.yaml
@@ -14,13 +14,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008759
-            slot_derivations:
-              value_decimal:
-                expr: "({phv00403005} * 100000) / {phv00403006}"
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008759
+              slot_derivations:
+                value_decimal:
+                  expr: "({phv00403005} * 100000) / {phv00403006}"
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -37,13 +37,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401729
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401729
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -60,13 +60,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401328
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401328
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008741
@@ -83,13 +83,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401714
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401714
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -106,13 +106,13 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401151
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401151
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -129,10 +129,10 @@
           value: "urine assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401435
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401435
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/crp.yaml
+++ b/priority_variables_transform/JHS-ingest/crp.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401715
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401715
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401731
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401731
+                unit:
+                  value: "mg/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -60,17 +60,17 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401434
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401434
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit:
+                  value: "mg/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001945
@@ -87,17 +87,17 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125941
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125941
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit:
+                  value: "mg/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -114,17 +114,17 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401327
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401327
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit:
+                  value: "mg/L"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -141,14 +141,14 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401142
-                unit_conversion:
-                  source_unit: "mg/dL"
-                  target_unit: "mg/L"
-              unit:
-                value: "mg/L"
-                range: string
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401142
+                  unit_conversion:
+                    source_unit: "mg/dL"
+                    target_unit: "mg/L"
+                unit:
+                  value: "mg/L"
+                  range: string

--- a/priority_variables_transform/JHS-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/cysc_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401705
-              unit:
-                value: "mg/L"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401705
+                unit:
+                  value: "mg/L"

--- a/priority_variables_transform/JHS-ingest/egfr.yaml
+++ b/priority_variables_transform/JHS-ingest/egfr.yaml
@@ -14,13 +14,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401155
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401155
+                unit:
+                  value: "mL/min/{1.73_m2}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -37,10 +37,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401156
-              unit:
-                value: "mL/min/{1.73_m2}"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401156
+                unit:
+                  value: "mL/min/{1.73_m2}"

--- a/priority_variables_transform/JHS-ingest/eselectin.yaml
+++ b/priority_variables_transform/JHS-ingest/eselectin.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401432
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401432
+                unit:
+                  value: "ng/mL"

--- a/priority_variables_transform/JHS-ingest/fam_income.yaml
+++ b/priority_variables_transform/JHS-ingest/fam_income.yaml
@@ -15,24 +15,24 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001966
-            slot_derivations:
-              value_concept:
-                populated_from: phv00128078
-                value_mappings:
-                  I. $50,000 - 74,999: $50,000 - $74,999
-                  H. $35,000 - 49,999: $35,000 - $49,999
-                  G. $25,000 - 34,999: $25,000 - $34,999
-                  F. $20,000 - 24,999: $20,000 - $24,999
-                  J. $75,000 - 99,999: $75,000 - $99,999
-                  K. $100,000 or more: '> $100,000'
-                  D. $12,000 - 15,999: $12,000 - $15,999
-                  E. $16,000 - 19,999: $16,000 - $19,999
-                  C. $8,000 - 11,999: $8,000 - $11,999
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001966
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00128078
+                  value_mappings:
+                    I. $50,000 - 74,999: $50,000 - $74,999
+                    H. $35,000 - 49,999: $35,000 - $49,999
+                    G. $25,000 - 34,999: $25,000 - $34,999
+                    F. $20,000 - 24,999: $20,000 - $24,999
+                    J. $75,000 - 99,999: $75,000 - $99,999
+                    K. $100,000 or more: '> $100,000'
+                    D. $12,000 - 15,999: $12,000 - $15,999
+                    E. $16,000 - 19,999: $16,000 - $19,999
+                    C. $8,000 - 11,999: $8,000 - $11,999
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008729
@@ -50,26 +50,26 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_concept:
-                populated_from: phv00401228
-                value_mappings:
-                  I: $50,000 - $74,999
-                  H: $35,000 - $49,999
-                  G: $25,000 - $34,999
-                  F: $20,000 - $24,999
-                  J: $75,000 - $99,999
-                  K: '> $100,000'
-                  D: $12,000 - $15,999
-                  E: $16,000 - $19,999
-                  C: $8,000 - $11,999
-                  A: < $5,000
-                  B: $5,000 - $7,999
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00401228
+                  value_mappings:
+                    I: $50,000 - $74,999
+                    H: $35,000 - $49,999
+                    G: $25,000 - $34,999
+                    F: $20,000 - $24,999
+                    J: $75,000 - $99,999
+                    K: '> $100,000'
+                    D: $12,000 - $15,999
+                    E: $16,000 - $19,999
+                    C: $8,000 - $11,999
+                    A: < $5,000
+                    B: $5,000 - $7,999
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008731
@@ -87,26 +87,26 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_concept:
-                populated_from: phv00401479
-                value_mappings:
-                  I: $50,000 - $74,999
-                  H: $35,000 - $49,999
-                  G: $25,000 - $34,999
-                  F: $20,000 - $24,999
-                  J: $75,000 - $99,999
-                  K: '> $100,000'
-                  D: $12,000 - $15,999
-                  E: $16,000 - $19,999
-                  C: $8,000 - $11,999
-                  A: < $5,000
-                  B: $5,000 - $7,999
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00401479
+                  value_mappings:
+                    I: $50,000 - $74,999
+                    H: $35,000 - $49,999
+                    G: $25,000 - $34,999
+                    F: $20,000 - $24,999
+                    J: $75,000 - $99,999
+                    K: '> $100,000'
+                    D: $12,000 - $15,999
+                    E: $16,000 - $19,999
+                    C: $8,000 - $11,999
+                    A: < $5,000
+                    B: $5,000 - $7,999
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008776
@@ -124,16 +124,16 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008776
-            slot_derivations:
-              value_concept:
-                populated_from: phv00403608
-                value_mappings:
-                  1. Yes: '> $35,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008776
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00403608
+                  value_mappings:
+                    1. Yes: '> $35,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008776
@@ -151,16 +151,16 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008776
-            slot_derivations:
-              value_concept:
-                populated_from: phv00403609
-                value_mappings:
-                  1. Yes: '> $50,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008776
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00403609
+                  value_mappings:
+                    1. Yes: '> $50,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008776
@@ -178,16 +178,16 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008776
-            slot_derivations:
-              value_concept:
-                populated_from: phv00403610
-                value_mappings:
-                  1. Yes: '> $75,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008776
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00403610
+                  value_mappings:
+                    1. Yes: '> $75,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008776
@@ -205,16 +205,16 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008776
-            slot_derivations:
-              value_concept:
-                populated_from: phv00403611
-                value_mappings:
-                  1. Yes: '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008776
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00403611
+                  value_mappings:
+                    1. Yes: '> $100,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008776
@@ -232,16 +232,16 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008776
-            slot_derivations:
-              value_concept:
-                populated_from: phv00403612
-                value_mappings:
-                  1. Yes: '> $10,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008776
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00403612
+                  value_mappings:
+                    1. Yes: '> $10,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht008776
@@ -259,13 +259,13 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008776
-            slot_derivations:
-              value_concept:
-                populated_from: phv00403613
-                value_mappings:
-                  1. Yes: '> $25,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht008776
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00403613
+                  value_mappings:
+                    1. Yes: '> $25,000'
+                unit:
+                  value: USD
+                  range: string

--- a/priority_variables_transform/JHS-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/fast_gluc_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401313
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401313
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401415
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401415
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -60,10 +60,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401124
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401124
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/ferritin.yaml
+++ b/priority_variables_transform/JHS-ingest/ferritin.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125944
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125944
+                unit:
+                  value: "ng/mL"

--- a/priority_variables_transform/JHS-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/glucose_bld.yaml
@@ -14,17 +14,17 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401733
-                unit_conversion:
-                  source_unit: "mg/L"
-                  target_unit: "mg/dL"
-              unit:
-                value: "mg/dL"
-                range: string
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401733
+                  unit_conversion:
+                    source_unit: "mg/L"
+                    target_unit: "mg/dL"
+                unit:
+                  value: "mg/dL"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008741
@@ -41,17 +41,17 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401716
-                unit_conversion:
-                  source_unit: "mg/L"
-                  target_unit: "mg/dL"
-              unit:
-                value: "mg/dL"
-                range: string
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401716
+                  unit_conversion:
+                    source_unit: "mg/L"
+                    target_unit: "mg/dL"
+                unit:
+                  value: "mg/dL"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001959
@@ -68,13 +68,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127613
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127613
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008748
@@ -91,10 +91,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008748
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402738
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008748
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402738
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/hdl.yaml
+++ b/priority_variables_transform/JHS-ingest/hdl.yaml
@@ -14,13 +14,13 @@
           value: "Fasting lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401718
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401718
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008734
@@ -37,13 +37,13 @@
           value: "Ancillary study lab"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008734
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401577
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008734
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401577
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -60,13 +60,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401321
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401321
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -83,13 +83,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401135
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401135
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008748
@@ -106,13 +106,13 @@
           value: "Fasting lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008748
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402741
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008748
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402741
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -129,13 +129,13 @@
           value: "VAP lipoprotein analysis"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404244
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404244
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -152,13 +152,13 @@
           value: "Analysis derived"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401426
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401426
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -175,13 +175,13 @@
           value: "Fasting lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401735
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401735
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001945
@@ -198,10 +198,10 @@
           value: "Fasting lab assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125930
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125930
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/hemat.yaml
+++ b/priority_variables_transform/JHS-ingest/hemat.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127614
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127614
+                unit:
+                  value: "%"

--- a/priority_variables_transform/JHS-ingest/hemo.yaml
+++ b/priority_variables_transform/JHS-ingest/hemo.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127615
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127615
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/JHS-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/JHS-ingest/hemo_a1c.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401414
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401414
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401123
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401123
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001945
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125929
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125929
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401312
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401312
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008734
@@ -106,13 +106,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008734
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401573
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht008734
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401573
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -129,13 +129,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401734
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401734
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008741
@@ -152,10 +152,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401717
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401717
+                unit:
+                  value: "%"

--- a/priority_variables_transform/JHS-ingest/hip_circ.yaml
+++ b/priority_variables_transform/JHS-ingest/hip_circ.yaml
@@ -18,17 +18,17 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008737
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401614
-                unit_conversion:
-                  source_unit: "[in_us]"
-                  target_unit: "cm"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht008737
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401614
+                  unit_conversion:
+                    source_unit: "[in_us]"
+                    target_unit: "cm"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -49,13 +49,13 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401288
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401288
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008738
@@ -76,13 +76,13 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008738
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401629
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008738
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401629
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -103,10 +103,10 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401389
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401389
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/JHS-ingest/hrtrt.yaml
+++ b/priority_variables_transform/JHS-ingest/hrtrt.yaml
@@ -16,13 +16,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401441
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401441
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008782
@@ -41,13 +41,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008782
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00403806
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht008782
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00403806
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001955
@@ -66,13 +66,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001955
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127504
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001955
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127504
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -91,13 +91,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401176
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401176
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001974
@@ -116,13 +116,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001974
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128364
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001974
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128364
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008783
@@ -141,13 +141,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008783
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00403844
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht008783
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00403844
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008783
@@ -166,13 +166,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008783
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00403850
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht008783
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00403850
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001955
@@ -191,13 +191,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001955
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127511
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht001955
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127511
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008783
@@ -216,10 +216,10 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008783
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00403853
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht008783
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00403853
+                unit:
+                  value: "{beats}/min"

--- a/priority_variables_transform/JHS-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/JHS-ingest/insulin_blood.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00125954} * 6"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00125954} * 6"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -93,13 +93,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401743
-              unit:
-                value: "pmol/L"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401743
+                unit:
+                  value: "pmol/L"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -116,10 +116,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401744
-              unit:
-                value: "pmol/L"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401744
+                unit:
+                  value: "pmol/L"

--- a/priority_variables_transform/JHS-ingest/ldl.yaml
+++ b/priority_variables_transform/JHS-ingest/ldl.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008748
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402742
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008748
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402742
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404255
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404255
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404249
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404249
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404258
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404258
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -106,13 +106,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401425
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401425
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -129,13 +129,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404248
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404248
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -152,13 +152,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401134
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401134
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -175,13 +175,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401320
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401320
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -198,13 +198,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404257
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404257
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -221,13 +221,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404256
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404256
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -244,13 +244,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401738
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401738
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008734
@@ -267,10 +267,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008734
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401578
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008734
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401578
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/lympho_pct.yaml
+++ b/priority_variables_transform/JHS-ingest/lympho_pct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127622
-              unit:
-                value: "%{WBCs}"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127622
+                unit:
+                  value: "%{WBCs}"

--- a/priority_variables_transform/JHS-ingest/mch.yaml
+++ b/priority_variables_transform/JHS-ingest/mch.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127623
-              unit:
-                value: "pg/{cell}"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127623
+                unit:
+                  value: "pg/{cell}"

--- a/priority_variables_transform/JHS-ingest/mchc.yaml
+++ b/priority_variables_transform/JHS-ingest/mchc.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127624
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127624
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/JHS-ingest/mcv.yaml
+++ b/priority_variables_transform/JHS-ingest/mcv.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127625
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127625
+                unit:
+                  value: "fL"

--- a/priority_variables_transform/JHS-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/JHS-ingest/platelet_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127616
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127616
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/JHS-ingest/pmv.yaml
+++ b/priority_variables_transform/JHS-ingest/pmv.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127627
-              unit:
-                value: "fL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127627
+                unit:
+                  value: "fL"

--- a/priority_variables_transform/JHS-ingest/potassium.yaml
+++ b/priority_variables_transform/JHS-ingest/potassium.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127617
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127617
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/JHS-ingest/pr_ekg.yaml
+++ b/priority_variables_transform/JHS-ingest/pr_ekg.yaml
@@ -16,13 +16,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402523
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402523
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -41,13 +41,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402209
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402209
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -66,13 +66,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402211
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402211
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -91,13 +91,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402208
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402208
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -116,13 +116,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402526
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402526
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -141,13 +141,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402216
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402216
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -166,13 +166,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402521
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402521
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -191,13 +191,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402519
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402519
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -216,13 +216,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402517
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402517
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -241,13 +241,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402516
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402516
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -266,13 +266,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402515
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402515
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -291,13 +291,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402524
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402524
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -316,13 +316,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402522
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402522
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -341,13 +341,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402212
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402212
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -366,13 +366,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402218
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402218
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -391,13 +391,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402217
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402217
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -416,13 +416,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402219
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402219
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -441,13 +441,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402214
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402214
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -466,13 +466,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402215
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402215
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -491,13 +491,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402210
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402210
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -516,13 +516,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402518
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402518
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -541,13 +541,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402520
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402520
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -566,13 +566,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402525
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402525
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -591,10 +591,10 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402213
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402213
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/JHS-ingest/pselectin.yaml
+++ b/priority_variables_transform/JHS-ingest/pselectin.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401433
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401433
+                unit:
+                  value: "ng/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401746
-              unit:
-                value: "ng/mL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401746
+                unit:
+                  value: "ng/mL"

--- a/priority_variables_transform/JHS-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/JHS-ingest/qrs_ekg.yaml
@@ -16,13 +16,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402345
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402345
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -41,13 +41,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402351
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402351
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -66,13 +66,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402346
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402346
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -91,13 +91,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402347
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402347
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -116,13 +116,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401177
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401177
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -141,13 +141,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402340
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402340
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -166,13 +166,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402349
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402349
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -191,13 +191,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401442
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401442
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -216,13 +216,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402348
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402348
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -241,13 +241,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402343
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402343
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -266,13 +266,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402341
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402341
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -291,13 +291,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402081
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402081
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -316,13 +316,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402344
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402344
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -341,13 +341,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402350
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402350
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -366,13 +366,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402342
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402342
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -391,10 +391,10 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402413
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402413
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/JHS-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/JHS-ingest/qt_ekg.yaml
@@ -16,13 +16,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401198
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401198
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -41,13 +41,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401460
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401460
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008746
@@ -66,13 +66,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008746
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402085
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008746
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402085
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -91,13 +91,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401196
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401196
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -116,13 +116,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401461
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401461
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -141,13 +141,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401197
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401197
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -166,13 +166,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401178
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401178
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -191,13 +191,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401462
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401462
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008747
@@ -216,13 +216,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008747
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402416
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008747
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402416
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -241,13 +241,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401443
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401443
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -266,13 +266,13 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401463
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401463
+                unit:
+                  value: "ms"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -291,10 +291,10 @@
           value: "SUPINE_BODY_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401195
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401195
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/JHS-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/JHS-ingest/rdbld_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127629
-              unit:
-                value: "10*6/uL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127629
+                unit:
+                  value: "10*6/uL"

--- a/priority_variables_transform/JHS-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/JHS-ingest/sleep_duration_daily.yaml
@@ -14,13 +14,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001963
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127678
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht001963
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127678
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008764
@@ -37,10 +37,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008764
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00403066
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht008764
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00403066
+                unit:
+                  value: "h"

--- a/priority_variables_transform/JHS-ingest/sodium_blood.yaml
+++ b/priority_variables_transform/JHS-ingest/sodium_blood.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127618
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127618
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/JHS-ingest/spirometry.yaml
+++ b/priority_variables_transform/JHS-ingest/spirometry.yaml
@@ -8,60 +8,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00128197}) + ":JHS PULMONARY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              method_type:
-                value: "spirometry"
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128209
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              method_type:
-                value: "spirometry"
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128210
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011505"
-              method_type:
-                value: "calculated"
-              qualifier:
-                value: MAXIMUM
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128214
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                method_type:
+                  value: "spirometry"
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128209
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                method_type:
+                  value: "spirometry"
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128210
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011505"
+                method_type:
+                  value: "calculated"
+                qualifier:
+                  value: MAXIMUM
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128214
+                        unit:
+                          value: "%"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001969
@@ -72,54 +72,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00128197}) + ":JHS PULMONARY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              method_type:
-                value: "spirometry, Second best curve"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128219
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              method_type:
-                value: "spirometry, Second best curve"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128220
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011505"
-              method_type:
-                value: "calculated, Second best curve"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128224
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                method_type:
+                  value: "spirometry, Second best curve"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128219
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                method_type:
+                  value: "spirometry, Second best curve"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128220
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011505"
+                method_type:
+                  value: "calculated, Second best curve"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128224
+                        unit:
+                          value: "%"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001969
@@ -130,54 +130,54 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00128197}) + ":JHS PULMONARY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              method_type:
-                value: "spirometry, Third best curve"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128229
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              method_type:
-                value: "spirometry, Third best curve"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128230
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht001969
-            slot_derivations:
-              observation_type:
-                value: "OMOP:3011505"
-              method_type:
-                value: "calculated, Third best curve"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001969
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00128234
-                    unit:
-                      value: "%"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                method_type:
+                  value: "spirometry, Third best curve"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128229
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                method_type:
+                  value: "spirometry, Third best curve"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128230
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht001969
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:3011505"
+                method_type:
+                  value: "calculated, Third best curve"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001969
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00128234
+                        unit:
+                          value: "%"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht008729
@@ -190,35 +190,35 @@
           expr: "{phv00401085} * 365"
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht008729
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4176265"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008729
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401162
-                    unit:
-                      value: "L"
-          - name: MeasurementObservation
-            populated_from: pht008729
-            slot_derivations:
-              observation_type:
-                value: "OMOP:4241837"
-              method_type:
-                value: "spirometry"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht008729
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00401163
-                    unit:
-                      value: "L"
+          - MeasurementObservation:
+              populated_from: pht008729
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4176265"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008729
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401162
+                        unit:
+                          value: "L"
+          - MeasurementObservation:
+              populated_from: pht008729
+              slot_derivations:
+                observation_type:
+                  value: "OMOP:4241837"
+                method_type:
+                  value: "spirometry"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht008729
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00401163
+                        unit:
+                          value: "L"

--- a/priority_variables_transform/JHS-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/tot_chol_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401428
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401428
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001945
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125927
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125927
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401728
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401728
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401137
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401137
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008734
@@ -106,13 +106,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008734
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401580
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008734
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401580
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -129,13 +129,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401323
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401323
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008741
@@ -152,13 +152,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401713
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401713
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008792
@@ -175,10 +175,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404243
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404243
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/JHS-ingest/triglyc_bld.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008792
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00404253
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008792
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00404253
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401136
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401136
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008741
@@ -60,13 +60,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008741
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401720
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008741
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401720
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -83,13 +83,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401427
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401427
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -106,13 +106,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401322
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401322
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001945
@@ -129,13 +129,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001945
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00125933
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht001945
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00125933
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008734
@@ -152,13 +152,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008734
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401579
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008734
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401579
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008742
@@ -175,13 +175,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008742
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401739
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008742
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401739
+                unit:
+                  value: "mg/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008748
@@ -198,10 +198,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008748
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00402740
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht008748
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00402740
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/JHS-ingest/vege_serving.yaml
+++ b/priority_variables_transform/JHS-ingest/vege_serving.yaml
@@ -14,8 +14,8 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00401250} * 7"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00401250} * 7"

--- a/priority_variables_transform/JHS-ingest/waist_circ.yaml
+++ b/priority_variables_transform/JHS-ingest/waist_circ.yaml
@@ -18,17 +18,17 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008737
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401613
-                unit_conversion:
-                  source_unit: "[in_us]"
-                  target_unit: "cm"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht008737
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401613
+                  unit_conversion:
+                    source_unit: "[in_us]"
+                    target_unit: "cm"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008729
@@ -49,13 +49,13 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008729
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401095
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008729
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401095
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -76,13 +76,13 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401388
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401388
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008730
@@ -103,13 +103,13 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401287
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401287
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008738
@@ -130,10 +130,10 @@
           value: "STANDING_POSITION"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008738
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00401628
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht008738
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00401628
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/JHS-ingest/waist_hip.yaml
+++ b/priority_variables_transform/JHS-ingest/waist_hip.yaml
@@ -12,13 +12,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008730
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00401287} / {phv00401288}"
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht008730
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00401287} / {phv00401288}"
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008731
@@ -33,13 +33,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008731
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00401388} / {phv00401389}"
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht008731
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00401388} / {phv00401389}"
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008737
@@ -54,13 +54,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008737
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00401613} / {phv00401614}"
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht008737
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00401613} / {phv00401614}"
+                unit:
+                  value: "{ratio}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht008738
@@ -75,10 +75,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht008738
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00401628} / {phv00401629}"
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht008738
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00401628} / {phv00401629}"
+                unit:
+                  value: "{ratio}"

--- a/priority_variables_transform/JHS-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/JHS-ingest/whtbld_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001959
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00127631
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht001959
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00127631
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/LTRC-ingest/alpha1_antitrypsin.yaml
+++ b/priority_variables_transform/LTRC-ingest/alpha1_antitrypsin.yaml
@@ -13,10 +13,10 @@
           value: "clinical laboratory assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010059
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429118
-              unit:
-                value: mg/dL
+          - Quantity:
+              populated_from: pht010059
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429118
+                unit:
+                  value: mg/dL

--- a/priority_variables_transform/LTRC-ingest/bmi.yaml
+++ b/priority_variables_transform/LTRC-ingest/bmi.yaml
@@ -14,10 +14,10 @@
           expr: '{phv00429049} * 365'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010057
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429058
-              unit:
-                value: kg/m2
+          - Quantity:
+              populated_from: pht010057
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429058
+                unit:
+                  value: kg/m2

--- a/priority_variables_transform/LTRC-ingest/body_measures.yaml
+++ b/priority_variables_transform/LTRC-ingest/body_measures.yaml
@@ -16,13 +16,13 @@
           expr: '{phv00429049} * 365'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010057
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429059
-              unit:
-                value: cm
+          - Quantity:
+              populated_from: pht010057
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429059
+                unit:
+                  value: cm
 - class_derivations:
     MeasurementObservation:
       populated_from: pht010057
@@ -41,10 +41,10 @@
           expr: '{phv00429049} * 365'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010057
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429060
-              unit:
-                value: kg
+          - Quantity:
+              populated_from: pht010057
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429060
+                unit:
+                  value: kg

--- a/priority_variables_transform/LTRC-ingest/labs_cbc.yaml
+++ b/priority_variables_transform/LTRC-ingest/labs_cbc.yaml
@@ -12,13 +12,13 @@
           value: "clinical laboratory assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010059
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429076
-              unit:
-                value: 10*9/L
+          - Quantity:
+              populated_from: pht010059
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429076
+                unit:
+                  value: 10*9/L
 - class_derivations:
     MeasurementObservation:
       populated_from: pht010059
@@ -33,13 +33,13 @@
           value: "clinical laboratory assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010059
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429078
-              unit:
-                value: g/dL
+          - Quantity:
+              populated_from: pht010059
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429078
+                unit:
+                  value: g/dL
 - class_derivations:
     MeasurementObservation:
       populated_from: pht010059
@@ -54,13 +54,13 @@
           value: "clinical laboratory assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010059
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429080
-              unit:
-                value: '%'
+          - Quantity:
+              populated_from: pht010059
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429080
+                unit:
+                  value: '%'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht010059
@@ -75,10 +75,10 @@
           value: "clinical laboratory assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht010059
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00429082
-              unit:
-                value: 10*9/L
+          - Quantity:
+              populated_from: pht010059
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00429082
+                unit:
+                  value: 10*9/L

--- a/priority_variables_transform/LTRC-ingest/spirometry_post_bd.yaml
+++ b/priority_variables_transform/LTRC-ingest/spirometry_post_bd.yaml
@@ -8,93 +8,93 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00429460}) + ":LTRC Baseline")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht010064
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010064
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00429464
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht010064
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010064
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00429465
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht010064
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010064
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00429466
-                    unit:
-                      value: '%'
+          - MeasurementObservation:
+              populated_from: pht010064
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010064
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00429464
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht010064
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010064
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00429465
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht010064
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010064
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00429466
+                        unit:
+                          value: '%'

--- a/priority_variables_transform/LTRC-ingest/spirometry_pre_bd.yaml
+++ b/priority_variables_transform/LTRC-ingest/spirometry_pre_bd.yaml
@@ -8,93 +8,93 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00429460}) + ":LTRC Baseline")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht010064
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010064
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00429461
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht010064
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010064
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00429462
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht010064
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht010064
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00429463
-                    unit:
-                      value: '%'
+          - MeasurementObservation:
+              populated_from: pht010064
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010064
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00429461
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht010064
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010064
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00429462
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht010064
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht010064
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00429463
+                        unit:
+                          value: '%'

--- a/priority_variables_transform/MESA-ingest/albumin_creatinine.yaml
+++ b/priority_variables_transform/MESA-ingest/albumin_creatinine.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083437
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083437
+                unit:
+                  value: mg/g{creat}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085746
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085746
+                unit:
+                  value: mg/g{creat}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085929
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085929
+                unit:
+                  value: mg/g{creat}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086412
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086412
+                unit:
+                  value: mg/g{creat}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -120,14 +120,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175607
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175607
+                unit:
+                  value: mg/g{creat}
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -146,11 +146,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177041
-              unit:
-                value: mg/g{creat}
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177041
+                unit:
+                  value: mg/g{creat}
+                  range: string

--- a/priority_variables_transform/MESA-ingest/albumin_urine.yaml
+++ b/priority_variables_transform/MESA-ingest/albumin_urine.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00083436} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00083436} * 10'
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00085745} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00085745} * 10'
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00085928} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00085928} * 10'
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00086411} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00086411} * 10'
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -120,14 +120,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00087529} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00087529} * 10'
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -146,14 +146,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00175605} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00175605} * 10'
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -172,11 +172,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00177039} * 10'
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00177039} * 10'
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/alcohol_servings.yaml
+++ b/priority_variables_transform/MESA-ingest/alcohol_servings.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00083279}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00083279}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -43,14 +43,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00085609}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00085609}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -70,14 +70,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00086119} + {phv00086120} + {phv00086121} + {phv00086122}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00086119} + {phv00086120} + {phv00086121} + {phv00086122}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -97,14 +97,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00086601} + {phv00086602} + {phv00086603} + {phv00086604}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00086601} + {phv00086602} + {phv00086603} + {phv00086604}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -124,14 +124,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00087019} + {phv00087020} + {phv00087021} + {phv00087022}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00087019} + {phv00087020} + {phv00087021} + {phv00087022}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -151,14 +151,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00087290}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00087290}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -178,14 +178,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00175424} + {phv00175425} + {phv00175426} + {phv00175427}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00175424} + {phv00175425} + {phv00175426} + {phv00175427}'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -205,11 +205,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00176858} + {phv00176859} + {phv00176860} + {phv00176861}'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00176858} + {phv00176859} + {phv00176860} + {phv00176861}'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/basophil_ncnc_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/basophil_ncnc_bld.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128700
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128700
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219002
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219002
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/MESA-ingest/bdy_hgt.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082683
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082683
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001112
@@ -48,14 +48,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001112
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083471
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001112
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083471
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001114
@@ -77,14 +77,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001114
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083706
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001114
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083706
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -106,14 +106,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084482
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084482
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -135,14 +135,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085799
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085799
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -164,14 +164,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086298
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086298
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -193,14 +193,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086751
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086751
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -222,14 +222,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087078
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087078
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001122
@@ -251,14 +251,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001122
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087697
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001122
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087697
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -280,14 +280,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174630
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174630
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -309,14 +309,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175858
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175858
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -338,14 +338,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175943
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175943
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -367,11 +367,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176053
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176053
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/MESA-ingest/bdy_temp.yaml
+++ b/priority_variables_transform/MESA-ingest/bdy_temp.yaml
@@ -13,11 +13,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001114
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083676
-              unit:
-                value: Cel
-                range: string
+          - Quantity:
+              populated_from: pht001114
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083676
+                unit:
+                  value: Cel
+                  range: string

--- a/priority_variables_transform/MESA-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/MESA-ingest/bdy_wgt.yaml
@@ -16,17 +16,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082685
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string                     
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082685
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string                     
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -46,17 +46,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083013
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083013
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -76,17 +76,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083014
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string                                       
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083014
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string                                       
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -105,17 +105,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084484
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084484
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -135,17 +135,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085249
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085249
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -165,17 +165,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085250
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string                  
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085250
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string                  
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -194,17 +194,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087079
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"
-              unit: 
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087079
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"
+                unit: 
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -224,17 +224,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087166
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"                  
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087166
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"                  
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -254,17 +254,17 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087167
-                unit_conversion:
-                  source_unit: '[lb_av]'
-                  target_unit: "kg"                    
-              unit:
-                value: kg
-                range: string                    
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087167
+                  unit_conversion:
+                    source_unit: '[lb_av]'
+                    target_unit: "kg"                    
+                unit:
+                  value: kg
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -283,14 +283,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174637
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174637
+                unit:
+                  value: kg
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -309,11 +309,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176060
-              unit:
-                value: kg
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176060
+                unit:
+                  value: kg
+                  range: string

--- a/priority_variables_transform/MESA-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/MESA-ingest/blood_pressure.yaml
@@ -8,60 +8,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00082638}) + ":MESA AIR EXAM")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001111
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00082639} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001111
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00083410
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001111
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00082639} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001111
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00083411
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001111
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00082639} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001111
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00083410
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001111
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00082639} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001111
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00083411
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001116
@@ -72,60 +72,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00084441}) + ":MESA CLASSIC EXAM 1")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001116
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00084442} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001116
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00085740
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001116
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00084442} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001116
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00085741
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001116
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00084442} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001116
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00085740
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001116
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00084442} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001116
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00085741
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001118
@@ -136,60 +136,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00085772}) + ":MESA CLASSIC EXAM 2")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001118
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00085773} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001118
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00086224
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001118
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00085773} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001118
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00086225
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001118
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00085773} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001118
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00086224
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001118
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00085773} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001118
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00086225
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001119
@@ -200,60 +200,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00086258}) + ":MESA CLASSIC EXAM 3")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001119
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00086259} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001119
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00086707
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001119
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00086259} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001119
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00086708
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001119
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00086259} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001119
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00086707
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001119
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00086259} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001119
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00086708
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001120
@@ -264,60 +264,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00086726}) + ":MESA CLASSIC EXAM 4")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001120
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00086727} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001120
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00087029
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001120
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00086727} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001120
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00087030
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001120
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00086727} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001120
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00087029
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001120
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00086727} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001120
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00087030
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001121
@@ -328,60 +328,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00087070}) + ":MESA FAMILY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001121
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00087071} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001121
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00087084
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001121
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00087071} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001121
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00087085
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001121
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087071} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001121
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00087084
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001121
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087071} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001121
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00087085
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003086
@@ -392,60 +392,60 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00174584}) + ":MESA AIR EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003086
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00174588} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003086
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00175601
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003086
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00174588} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003086
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00175602
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003086
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00174588} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003086
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00175601
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003086
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00174588} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003086
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00175602
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003087
@@ -456,33 +456,33 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00175794}) + ":MESA LUNG CT")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003087
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00175854} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003087
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00175862
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003087
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00175854} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003087
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00175862
+                        unit:
+                          value: mm[Hg]
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht003091
@@ -493,57 +493,57 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00176007}) + ":MESA CLASSIC EXAM 5")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht003091
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-                range: string
-              age_at_observation:
-                expr: '{phv00176011} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003091
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00177035
-                    unit:
-                      value: mm[Hg]
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht003091
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-                range: string
-              age_at_observation:
-                expr: '{phv00176011} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              body_site:
-                value: "Right arm"
-                range: string
-              method_type:
-                value: "oscillometric cuff"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht003091
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00177036
-                    unit:
-                      value: mm[Hg]
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht003091
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                  range: string
+                age_at_observation:
+                  expr: '{phv00176011} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003091
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00177035
+                        unit:
+                          value: mm[Hg]
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht003091
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                  range: string
+                age_at_observation:
+                  expr: '{phv00176011} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                body_site:
+                  value: "Right arm"
+                  range: string
+                method_type:
+                  value: "oscillometric cuff"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht003091
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00177036
+                        unit:
+                          value: mm[Hg]
+                          range: string

--- a/priority_variables_transform/MESA-ingest/bmi.yaml
+++ b/priority_variables_transform/MESA-ingest/bmi.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082691
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082691
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084490
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084490
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085803
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085803
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086302
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086302
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -120,14 +120,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086755
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086755
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -146,14 +146,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087080
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087080
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -172,14 +172,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174644
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174644
+                unit:
+                  value: kg/m2
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -198,11 +198,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176067
-              unit:
-                value: kg/m2
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176067
+                unit:
+                  value: kg/m2
+                  range: string

--- a/priority_variables_transform/MESA-ingest/cac_score.yaml
+++ b/priority_variables_transform/MESA-ingest/cac_score.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082657
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082657
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -48,14 +48,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082660
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082660
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -77,14 +77,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082664
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082664
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -106,14 +106,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082856
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082856
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -135,14 +135,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082857
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082857
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -164,14 +164,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082860
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082860
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -193,14 +193,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082861
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082861
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -222,14 +222,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082862
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082862
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -251,14 +251,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082863
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082863
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -280,14 +280,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082866
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082866
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -309,14 +309,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082867
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082867
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -338,14 +338,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082888
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082888
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -367,14 +367,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082889
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082889
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -396,14 +396,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082890
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082890
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -425,14 +425,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082891
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082891
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -454,14 +454,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084517
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084517
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -483,14 +483,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084519
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084519
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -512,14 +512,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084521
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084521
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -541,14 +541,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084526
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084526
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -570,14 +570,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084528
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084528
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -599,14 +599,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084530
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084530
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -628,14 +628,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084532
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084532
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -657,14 +657,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084534
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084534
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -686,14 +686,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084536
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084536
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -715,14 +715,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084538
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084538
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -744,14 +744,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084540
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084540
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -773,14 +773,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085810
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085810
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -802,14 +802,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085812
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085812
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -831,14 +831,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085813
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085813
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -860,14 +860,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085819
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085819
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -889,14 +889,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085820
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085820
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -918,14 +918,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085825
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085825
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -947,14 +947,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085826
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085826
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -976,14 +976,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086310
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086310
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -1005,14 +1005,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086312
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086312
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -1034,14 +1034,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086313
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086313
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -1063,14 +1063,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086318
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086318
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -1092,14 +1092,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086319
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086319
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -1121,14 +1121,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086324
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086324
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -1150,14 +1150,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086325
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086325
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1179,14 +1179,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086773
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086773
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1208,14 +1208,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086774
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086774
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1237,14 +1237,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086777
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086777
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1266,14 +1266,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086778
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086778
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1295,14 +1295,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086779
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086779
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1324,14 +1324,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086780
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086780
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1353,14 +1353,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086783
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086783
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1382,14 +1382,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086784
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086784
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1411,14 +1411,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087105
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087105
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1440,14 +1440,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087531
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087531
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1469,14 +1469,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087536
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087536
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1498,14 +1498,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087537
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087537
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1527,14 +1527,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087544
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087544
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1556,14 +1556,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087545
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087545
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001204
@@ -1583,14 +1583,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001204
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00090029
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001204
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00090029
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001205
@@ -1610,14 +1610,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001205
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00090113
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001205
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00090113
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001205
@@ -1637,14 +1637,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001205
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00090116
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001205
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00090116
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1666,14 +1666,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174752
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174752
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1695,14 +1695,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174753
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174753
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1724,14 +1724,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174766
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174766
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1753,14 +1753,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174767
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174767
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1782,14 +1782,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174768
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174768
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1811,14 +1811,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174769
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174769
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1840,14 +1840,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176175
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176175
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1869,14 +1869,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176176
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176176
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1898,14 +1898,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176189
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176189
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1927,14 +1927,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176190
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176190
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1956,14 +1956,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176191
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176191
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1985,11 +1985,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176192
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176192
+                unit:
+                  value: '{score}'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/cac_volume.yaml
+++ b/priority_variables_transform/MESA-ingest/cac_volume.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082658
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082658
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -48,14 +48,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082663
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082663
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -77,14 +77,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082858
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082858
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -106,14 +106,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082859
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082859
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -135,14 +135,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082864
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082864
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -164,14 +164,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082865
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082865
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -193,14 +193,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082884
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082884
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -222,14 +222,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082885
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082885
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -251,14 +251,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082886
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082886
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -280,14 +280,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082887
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082887
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -309,14 +309,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082892
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082892
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -338,14 +338,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082893
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082893
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -367,14 +367,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082894
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082894
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -396,14 +396,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082895
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082895
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -425,14 +425,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084518
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084518
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -454,14 +454,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084524
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084524
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -483,14 +483,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084527
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084527
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -512,14 +512,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084531
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084531
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -541,14 +541,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084535
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084535
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -570,14 +570,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084539
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084539
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -599,14 +599,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085811
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085811
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -628,14 +628,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085816
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085816
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -657,14 +657,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085821
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085821
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -686,14 +686,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085822
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085822
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -715,14 +715,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085827
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085827
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -744,14 +744,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085828
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085828
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -773,14 +773,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086311
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086311
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -802,14 +802,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086320
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086320
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -831,14 +831,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086321
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086321
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -860,14 +860,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086326
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086326
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -889,14 +889,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086327
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086327
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -918,14 +918,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086775
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086775
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -947,14 +947,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086776
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086776
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -976,14 +976,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086781
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086781
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -1005,14 +1005,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086782
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086782
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1034,14 +1034,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087108
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087108
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1063,14 +1063,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087532
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087532
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1092,14 +1092,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087538
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087538
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1121,14 +1121,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087539
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087539
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1150,14 +1150,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087546
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087546
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -1179,14 +1179,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087547
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087547
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001204
@@ -1206,13 +1206,13 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001204
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00090025
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
+          - Quantity:
+              populated_from: pht001204
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00090025
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001205
@@ -1232,14 +1232,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001205
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00090114
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001205
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00090114
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001205
@@ -1259,14 +1259,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001205
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00090117
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht001205
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00090117
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1288,14 +1288,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174762
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174762
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1317,14 +1317,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174763
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174763
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1346,14 +1346,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174764
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174764
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1375,14 +1375,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174765
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174765
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1404,14 +1404,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174770
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174770
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1433,14 +1433,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174771
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174771
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1462,14 +1462,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174772
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174772
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -1491,14 +1491,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174773
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174773
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1520,14 +1520,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176185
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176185
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1549,14 +1549,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176186
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176186
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1578,14 +1578,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176187
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176187
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1607,14 +1607,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176188
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176188
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1636,14 +1636,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176193
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176193
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1665,14 +1665,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176194
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176194
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1694,14 +1694,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176195
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176195
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -1723,11 +1723,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176196
-              unit:
-                value: '#reported_units: "Hounsfield units (HU)'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176196
+                unit:
+                  value: '#reported_units: "Hounsfield units (HU)'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/carotid_imt.yaml
+++ b/priority_variables_transform/MESA-ingest/carotid_imt.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                expr: '({phv00175623} + {phv00175683}) / 2'
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  expr: '({phv00175623} + {phv00175683}) / 2'
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: LT DISTAL CCA MAX CIMT (mm) AVG and RT DISTAL CCA MAX CIMT (mm) AVG
             averaged
@@ -40,14 +40,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084966
-              unit:
-                value: mm
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084966
+                unit:
+                  value: mm
+                  range: string
         method_type:
           value: MEAN OF MEAN FAR WALL IMT FOR COMMON CAROTID ARTERY
           range: string

--- a/priority_variables_transform/MESA-ingest/carotid_sten_left.yaml
+++ b/priority_variables_transform/MESA-ingest/carotid_sten_left.yaml
@@ -22,20 +22,20 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_concept:
-                populated_from: phv00084803
-                value_mappings:
-                  '1': 1-24
-                  '2': 25-49
-                  '3': 50-74
-                  '4': 75-99
-                  '5': '100'
-                  '6': '0'
-                  '7': None
-                  '8': None
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00084803
+                  value_mappings:
+                    '1': 1-24
+                    '2': 25-49
+                    '3': 50-74
+                    '4': 75-99
+                    '5': '100'
+                    '6': '0'
+                    '7': None
+                    '8': None
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/carotid_sten_right.yaml
+++ b/priority_variables_transform/MESA-ingest/carotid_sten_right.yaml
@@ -22,20 +22,20 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_concept:
-                populated_from: phv00084798
-                value_mappings:
-                  '1': 1-24
-                  '2': 25-49
-                  '3': 50-74
-                  '4': 75-99
-                  '5': '100'
-                  '6': '0'
-                  '7': None
-                  '8': None
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00084798
+                  value_mappings:
+                    '1': 1-24
+                    '2': 25-49
+                    '3': 50-74
+                    '4': 75-99
+                    '5': '100'
+                    '6': '0'
+                    '7': None
+                    '8': None
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/cd40.yaml
+++ b/priority_variables_transform/MESA-ingest/cd40.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085021
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085021
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/cesd_score.yaml
+++ b/priority_variables_transform/MESA-ingest/cesd_score.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_integer:
-                populated_from: phv00082949
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00082949
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_integer:
-                populated_from: phv00084787
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00084787
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_integer:
-                populated_from: phv00086398
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00086398
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_integer:
-                populated_from: phv00086819
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00086819
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -120,14 +120,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_integer:
-                populated_from: phv00087477
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00087477
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -146,14 +146,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_integer:
-                populated_from: phv00175236
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00175236
+                unit:
+                  value: '{score}'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -172,11 +172,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_integer:
-                populated_from: phv00176659
-              unit:
-                value: '{score}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_integer:
+                  populated_from: phv00176659
+                unit:
+                  value: '{score}'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/chloride_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/chloride_bld.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003089
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175983
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003089
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175983
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/creat_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/creat_bld.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175241
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175241
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -42,11 +42,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176664
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176664
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/creat_urin.yaml
+++ b/priority_variables_transform/MESA-ingest/creat_urin.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085748
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085748
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085930
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085930
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086413
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086413
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087530
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087530
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -120,14 +120,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175606
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175606
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -146,11 +146,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177040
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177040
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/crp.yaml
+++ b/priority_variables_transform/MESA-ingest/crp.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082967
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082967
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085015
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085015
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086825
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086825
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087661
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087661
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002198
@@ -118,11 +118,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160534
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160534
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/cysc_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/cysc_bld.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084545
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084545
+                unit:
+                  value: mg/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -42,11 +42,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00196280
-              unit:
-                value: mg/L
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00196280
+                unit:
+                  value: mg/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/d_dimer.yaml
+++ b/priority_variables_transform/MESA-ingest/d_dimer.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082971
-              unit:
-                value: ug/mL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082971
+                unit:
+                  value: ug/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085017
-              unit:
-                value: ug/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085017
+                unit:
+                  value: ug/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086829
-              unit:
-                value: ug/mL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086829
+                unit:
+                  value: ug/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -94,14 +94,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087663
-              unit:
-                value: ug/mL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087663
+                unit:
+                  value: ug/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002105
@@ -118,11 +118,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002105
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160521
-              unit:
-                value: ug/mL
-                range: string
+          - Quantity:
+              populated_from: pht002105
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160521
+                unit:
+                  value: ug/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/egfr.yaml
+++ b/priority_variables_transform/MESA-ingest/egfr.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082961
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082961
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -39,14 +39,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00195567
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00195567
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: CKD-EPI EQUATION
           range: string
@@ -65,14 +65,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084464
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084464
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -91,14 +91,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00111943
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00111943
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: CKD-EPI EQUATION
           range: string
@@ -117,14 +117,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086284
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086284
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -143,14 +143,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00111948
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00111948
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: CKD-EPI EQUATION
           range: string
@@ -169,14 +169,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00111951
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00111951
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -195,14 +195,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00111952
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00111952
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: CKD-EPI EQUATION
           range: string
@@ -221,14 +221,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087096
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087096
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -247,14 +247,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174602
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174602
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -273,14 +273,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174604
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174604
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: CKD-EPI EQUATION
           range: string
@@ -299,14 +299,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176025
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176025
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: SIMPLIFIED MDRD EQUATION
           range: string
@@ -325,14 +325,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176027
-              unit:
-                value: mL/min/{1.73_m2}
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176027
+                unit:
+                  value: mL/min/{1.73_m2}
+                  range: string
         method_type:
           value: CKD-EPI EQUATION
           range: string

--- a/priority_variables_transform/MESA-ingest/eosinophil_ncnc_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/eosinophil_ncnc_bld.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128702
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128702
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219001
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219001
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/eselectin.yaml
+++ b/priority_variables_transform/MESA-ingest/eselectin.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082969
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082969
+                unit:
+                  value: ng/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085022
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085022
+                unit:
+                  value: ng/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -68,11 +68,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086827
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086827
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/factor_8.yaml
+++ b/priority_variables_transform/MESA-ingest/factor_8.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00084463} * 0.01'
-              unit:
-                value: '[IU]/mL'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00084463} * 0.01'
+                unit:
+                  value: '[IU]/mL'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -39,14 +39,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00085019} * 0.01'
-              unit:
-                value: '[IU]/mL'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00085019} * 0.01'
+                unit:
+                  value: '[IU]/mL'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002105
@@ -60,11 +60,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002105
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00160522} * 0.01'
-              unit:
-                value: '[IU]/mL'
-                range: string
+          - Quantity:
+              populated_from: pht002105
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00160522} * 0.01'
+                unit:
+                  value: '[IU]/mL'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/fam_income.yaml
+++ b/priority_variables_transform/MESA-ingest/fam_income.yaml
@@ -16,28 +16,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_concept:
-                populated_from: phv00083226
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00083226
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': '> $100,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001116
@@ -56,28 +56,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_concept:
-                populated_from: phv00085558
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00085558
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': '> $100,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001118
@@ -94,28 +94,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_concept:
-                populated_from: phv00086087
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00086087
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': '> $100,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001121
@@ -134,28 +134,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_concept:
-                populated_from: phv00087238
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00087238
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': '> $100,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht002105
@@ -172,28 +172,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002105
-            slot_derivations:
-              value_concept:
-                populated_from: phv00160523
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht002105
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00160523
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': '> $100,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht003086
@@ -212,30 +212,30 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_concept:
-                populated_from: phv00175446
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': $100,000 - $124,999
-                  '14': $125,000 - $149,999
-                  '15': '> $150,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00175446
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': $100,000 - $124,999
+                    '14': $125,000 - $149,999
+                    '15': '> $150,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht003091
@@ -254,30 +254,30 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_concept:
-                populated_from: phv00176880
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': $100,000 - $124,999
-                  '14': $125,000 - $149,999
-                  '15': '> $150,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00176880
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': $100,000 - $124,999
+                    '14': $125,000 - $149,999
+                    '15': '> $150,000'
+                unit:
+                  value: USD
+                  range: string
 - class_derivations:
     SdohObservation:
       populated_from: pht001119
@@ -296,25 +296,25 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_concept:
-                populated_from: phv00086569
-                value_mappings:
-                  '1': < $5,000
-                  '2': $5,000 - $7,999
-                  '3': $8,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $39,999
-                  '10': $40,000 - $49,999
-                  '11': $50,000 - $74,999
-                  '12': $75,000 - $99,999
-                  '13': '> $100,000'
-              unit:
-                value: USD
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00086569
+                  value_mappings:
+                    '1': < $5,000
+                    '2': $5,000 - $7,999
+                    '3': $8,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $39,999
+                    '10': $40,000 - $49,999
+                    '11': $50,000 - $74,999
+                    '12': $75,000 - $99,999
+                    '13': '> $100,000'
+                unit:
+                  value: USD
+                  range: string

--- a/priority_variables_transform/MESA-ingest/fast_gluc_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/fast_gluc_bld.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082953
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082953
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -39,14 +39,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082954
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082954
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -62,14 +62,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084969
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084969
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -88,14 +88,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084970
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084970
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -111,14 +111,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085932
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085932
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -137,14 +137,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086415
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086415
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -163,14 +163,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086834
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086834
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -189,14 +189,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087088
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087088
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -215,14 +215,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175240
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175240
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -238,14 +238,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175863
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175863
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -264,14 +264,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175948
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175948
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string
@@ -290,14 +290,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176663
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176663
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004326
@@ -313,14 +313,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004326
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219026
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht004326
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219026
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           value: CALIBRATED
           range: string

--- a/priority_variables_transform/MESA-ingest/fibrin.yaml
+++ b/priority_variables_transform/MESA-ingest/fibrin.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082965
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082965
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085014
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085014
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -68,14 +68,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086823
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086823
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002198
@@ -92,11 +92,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160532
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160532
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/MESA-ingest/fruit_serving.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004317
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00218767} + {phv00218768}) * 7
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht004317
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00218767} + {phv00218768}) * 7
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/glucose_bld.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175887
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175887
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/hdl.yaml
+++ b/priority_variables_transform/MESA-ingest/hdl.yaml
@@ -12,14 +12,14 @@
           expr: case(({phv00083303} >= 12, 'OMOP:4041720'), (True, 'OBA:VT0000184'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082952
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082952
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00083303} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -36,14 +36,14 @@
           expr: case(({phv00084980} >= 12, 'OMOP:4041720'), (True, 'OBA:VT0000184'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084972
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084972
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00084980} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -64,14 +64,14 @@
             LIPOPROFILE-3 SPECTRAL ANALYSIS'))"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160506
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160506
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -87,14 +87,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085920
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085920
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -110,14 +110,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086402
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086402
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -133,14 +133,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086833
-              unit:
-                value: mg/dL
-                range: string                    
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086833
+                unit:
+                  value: mg/dL
+                  range: string                    
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -155,14 +155,14 @@
           expr: case(({phv00087524} >= 12, 'OMOP:4041720'), (True, 'OBA:VT0000184'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087099
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087099
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00087524} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -180,14 +180,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175239
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175239
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -203,11 +203,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176662
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176662
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/hemat.yaml
+++ b/priority_variables_transform/MESA-ingest/hemat.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128724
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128724
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218992
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218992
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/hemo.yaml
+++ b/priority_variables_transform/MESA-ingest/hemo.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128727
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128727
+                unit:
+                  value: g/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218993
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218993
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/hemo_a1c.yaml
+++ b/priority_variables_transform/MESA-ingest/hemo_a1c.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174583
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174583
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175243
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175243
+                unit:
+                  value: '%'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -68,11 +68,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176666
-              unit:
-                value: '%'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176666
+                unit:
+                  value: '%'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/hip_circ.yaml
+++ b/priority_variables_transform/MESA-ingest/hip_circ.yaml
@@ -22,14 +22,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082688
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082688
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -54,14 +54,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084489
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084489
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -86,14 +86,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085802
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085802
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -118,14 +118,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086300
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086300
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -150,14 +150,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086753
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086753
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -182,14 +182,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174635
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174635
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -214,11 +214,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176058
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176058
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/MESA-ingest/hrtrt.yaml
+++ b/priority_variables_transform/MESA-ingest/hrtrt.yaml
@@ -13,14 +13,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082700
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082700
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -36,14 +36,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083401
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083401
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -59,14 +59,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083405
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083405
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -82,14 +82,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083408
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083408
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001111
@@ -108,14 +108,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00083412
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00083412
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -131,14 +131,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085482
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085482
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -154,14 +154,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084546
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084546
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -180,14 +180,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086227
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086227
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -203,14 +203,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086239
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086239
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -226,14 +226,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086240
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086240
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -249,14 +249,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086241
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086241
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -275,14 +275,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086710
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086710
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -298,14 +298,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086723
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086723
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -321,14 +321,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086724
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086724
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -344,14 +344,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086725
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086725
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -370,14 +370,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087032
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087032
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -393,14 +393,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087045
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087045
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -416,14 +416,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087046
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087046
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -439,14 +439,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087047
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087047
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002195
@@ -460,14 +460,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002195
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00159096
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht002195
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00159096
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -486,14 +486,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174882
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174882
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -512,14 +512,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174883
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174883
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -535,14 +535,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175589
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175589
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -558,14 +558,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175593
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175593
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -581,14 +581,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175596
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175596
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -607,14 +607,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175604
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175604
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -630,14 +630,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175755
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175755
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -653,14 +653,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175758
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175758
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -676,14 +676,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175761
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175761
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -702,14 +702,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175764
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175764
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -728,14 +728,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176280
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176280
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -754,14 +754,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176305
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176305
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -780,14 +780,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176306
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176306
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -803,14 +803,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177023
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177023
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -826,14 +826,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177027
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177027
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -849,14 +849,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177030
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177030
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -875,14 +875,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177038
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177038
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -898,14 +898,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177189
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177189
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -921,14 +921,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177192
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177192
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -944,14 +944,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177195
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177195
+                unit:
+                  value: '{beats}/min'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -970,11 +970,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00177198
-              unit:
-                value: '{beats}/min'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00177198
+                unit:
+                  value: '{beats}/min'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/icam.yaml
+++ b/priority_variables_transform/MESA-ingest/icam.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082963
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082963
+                unit:
+                  value: ng/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,14 +42,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085117
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085117
+                unit:
+                  value: ng/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -68,11 +68,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086821
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086821
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/il10.yaml
+++ b/priority_variables_transform/MESA-ingest/il10.yaml
@@ -14,36 +14,36 @@
           range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002099
-            slot_derivations:
-              value_decimal:
-                value: '10000'
-                range: string
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002099
+              slot_derivations:
+                value_decimal:
+                  value: '10000'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002099
-            slot_derivations:
-              value_decimal:
-                value: '0.13'
-                range: string
-              unit:
-                value: pg/mL
-                range: string                      
+          - Quantity:
+              populated_from: pht002099
+              slot_derivations:
+                value_decimal:
+                  value: '0.13'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string                      
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002099
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00142667
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002099
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00142667
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002105
@@ -60,11 +60,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002105
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160519
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002105
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160519
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/il6.yaml
+++ b/priority_variables_transform/MESA-ingest/il6.yaml
@@ -16,36 +16,36 @@
           range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                value: '0.09'
-                range: string
-              unit:
-                value: pg/mL
-                range: string          
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  value: '0.09'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string          
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                value: '13'
-                range: string
-              unit:
-                value: pg/mL
-                range: string                     
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  value: '13'
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string                     
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085009
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085009
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002105
@@ -62,14 +62,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002105
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160518
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002105
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160518
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002198
@@ -86,14 +86,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160530
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160530
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004326
@@ -112,11 +112,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004326
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219027
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht004326
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219027
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/MESA-ingest/insulin_blood.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00160488} * 5.975'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00160488} * 5.975'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002198
@@ -40,14 +40,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00160542} * 0.172'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00160542} * 0.172'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -66,14 +66,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00175251} * 5.975'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00175251} * 5.975'
+                unit:
+                  value: pmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -92,11 +92,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00176674} * 5.975'
-              unit:
-                value: pmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00176674} * 5.975'
+                unit:
+                  value: pmol/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/isoprostane_8_epi_pgf2a.yaml
+++ b/priority_variables_transform/MESA-ingest/isoprostane_8_epi_pgf2a.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085074
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085074
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/ldl.yaml
+++ b/priority_variables_transform/MESA-ingest/ldl.yaml
@@ -12,14 +12,14 @@
           expr: case(({phv00083303} >= 12, 'OMOP:4041721'), (True, 'OBA:VT0000181'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082951
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082951
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00083303} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -36,14 +36,14 @@
           expr: case(({phv00084980} >= 12, 'OMOP:4041721'), (True, 'OBA:VT0000181'))
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084971
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084971
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00084980} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -61,14 +61,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085919
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085919
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -84,14 +84,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086401
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086401
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -107,14 +107,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086832
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086832
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -130,14 +130,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087098
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087098
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: case(({phv00087524} >= 12, 'Fasted minimum 12 hours'))
 - class_derivations:
@@ -155,14 +155,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175238
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175238
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -178,14 +178,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175866
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175866
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -201,14 +201,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175885
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175885
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -224,14 +224,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175950
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175950
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -247,11 +247,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176661
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176661
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/lppla2_act.yaml
+++ b/priority_variables_transform/MESA-ingest/lppla2_act.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002512
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00165052
-              unit:
-                value: nmol/min/mL
-                range: string
+          - Quantity:
+              populated_from: pht002512
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00165052
+                unit:
+                  value: nmol/min/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/lppla2_mass.yaml
+++ b/priority_variables_transform/MESA-ingest/lppla2_mass.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002512
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00165050
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht002512
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00165050
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/lympho_ct.yaml
+++ b/priority_variables_transform/MESA-ingest/lympho_ct.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218998
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218998
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/mch.yaml
+++ b/priority_variables_transform/MESA-ingest/mch.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218994
-              unit:
-                value: pg/{cell}
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218994
+                unit:
+                  value: pg/{cell}
+                  range: string

--- a/priority_variables_transform/MESA-ingest/mchc.yaml
+++ b/priority_variables_transform/MESA-ingest/mchc.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218995
-              unit:
-                value: g/dL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218995
+                unit:
+                  value: g/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/mcv.yaml
+++ b/priority_variables_transform/MESA-ingest/mcv.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                expr: "case(({phv00218996} < 50, None), ({phv00218996} > 130, None), (True, {phv00218996}))"
-              unit:
-                value: fL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  expr: "case(({phv00218996} < 50, None), ({phv00218996} > 130, None), (True, {phv00218996}))"
+                unit:
+                  value: fL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/mmp9.yaml
+++ b/priority_variables_transform/MESA-ingest/mmp9.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085027
-              unit:
-                value: ng/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085027
+                unit:
+                  value: ng/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/mn_art_pres.yaml
+++ b/priority_variables_transform/MESA-ingest/mn_art_pres.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085705
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085705
+                unit:
+                  value: mm[Hg]
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -42,11 +42,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085710
-              unit:
-                value: mm[Hg]
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085710
+                unit:
+                  value: mm[Hg]
+                  range: string

--- a/priority_variables_transform/MESA-ingest/monocyte_ncnc_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/monocyte_ncnc_bld.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128706
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128706
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219000
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219000
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/neutro_ct.yaml
+++ b/priority_variables_transform/MESA-ingest/neutro_ct.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218999
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218999
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/nt_bnp.yaml
+++ b/priority_variables_transform/MESA-ingest/nt_bnp.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002140
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00156621
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002140
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00156621
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002140
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002140
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00156622
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002140
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00156622
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/person.yaml
+++ b/priority_variables_transform/MESA-ingest/person.yaml
@@ -16,14 +16,14 @@
           expr: 'case(({pht001123.phv00087882} == 0, "OMOP:4230556"), ({pht001123.phv00087882} == 1, "OMOP:434489"))'
         cause_of_death:
           class_derivations:
-          - name: CauseOfDeath
-            populated_from: pht001116
-            joins:
-              pht001123:
-                source_key: phv00084441
-                lookup_key: phv00087848
-            slot_derivations:
-              cause:
-                expr: 'case(({pht001123.phv00087882} != 1, None), ({pht001123.phv00087883} == 1, "ICD10CM:I20-I25"), ({pht001123.phv00087883} == 2, "ICD10CM:I63.9"), ({pht001123.phv00087883} == 3, "ICD10CM:I70"), ({pht001123.phv00087883} == 4, "ICD10CM:I00-I99"), ({pht001123.phv00087883} == 5, "ICD10CM:R99"), ({pht001123.phv00087883} == 6, "ICD10CM:R99"), ({pht001123.phv00087883} == 9, "ICD10CM:R99"), ({pht001123.phv00087883} == 999, "ICD10CM:R99"))'
-              order:
-                expr: 'case(({pht001123.phv00087882} == 1, 1))'
+          - CauseOfDeath:
+              populated_from: pht001116
+              joins:
+                pht001123:
+                  source_key: phv00084441
+                  lookup_key: phv00087848
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht001123.phv00087882} != 1, None), ({pht001123.phv00087883} == 1, "ICD10CM:I20-I25"), ({pht001123.phv00087883} == 2, "ICD10CM:I63.9"), ({pht001123.phv00087883} == 3, "ICD10CM:I70"), ({pht001123.phv00087883} == 4, "ICD10CM:I00-I99"), ({pht001123.phv00087883} == 5, "ICD10CM:R99"), ({pht001123.phv00087883} == 6, "ICD10CM:R99"), ({pht001123.phv00087883} == 9, "ICD10CM:R99"), ({pht001123.phv00087883} == 999, "ICD10CM:R99"))'
+                order:
+                  expr: 'case(({pht001123.phv00087882} == 1, 1))'

--- a/priority_variables_transform/MESA-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/MESA-ingest/platelet_ct.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128760
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128760
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218991
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218991
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/potassium.yaml
+++ b/priority_variables_transform/MESA-ingest/potassium.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00191191
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00191191
+                unit:
+                  value: mmol/L
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003089
@@ -40,11 +40,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003089
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175982
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003089
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175982
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/pr_ekg.yaml
+++ b/priority_variables_transform/MESA-ingest/pr_ekg.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082714
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082714
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -49,14 +49,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084566
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084566
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -79,14 +79,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174884
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174884
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -109,11 +109,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176307
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176307
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/MESA-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/MESA-ingest/qrs_ekg.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082715
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082715
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -49,14 +49,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084567
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084567
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -79,14 +79,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174885
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174885
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -109,11 +109,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176308
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176308
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/MESA-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/MESA-ingest/qt_ekg.yaml
@@ -19,14 +19,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082716
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082716
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -49,14 +49,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084568
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084568
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -79,14 +79,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174886
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174886
+                unit:
+                  value: ms
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -109,11 +109,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176309
-              unit:
-                value: ms
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176309
+                unit:
+                  value: ms
+                  range: string

--- a/priority_variables_transform/MESA-ingest/rdbld_ct.yaml
+++ b/priority_variables_transform/MESA-ingest/rdbld_ct.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128762
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128762
+                unit:
+                  value: 10*6/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218990
-              unit:
-                value: 10*6/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218990
+                unit:
+                  value: 10*6/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/MESA-ingest/sleep_duration_daily.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087048
-              unit:
-                value: h
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087048
+                unit:
+                  value: h
+                  range: string

--- a/priority_variables_transform/MESA-ingest/sodium_blood.yaml
+++ b/priority_variables_transform/MESA-ingest/sodium_blood.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003089
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175981
-              unit:
-                value: mmol/L
-                range: string
+          - Quantity:
+              populated_from: pht003089
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175981
+                unit:
+                  value: mmol/L
+                  range: string

--- a/priority_variables_transform/MESA-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/MESA-ingest/sodium_intak.yaml
@@ -14,11 +14,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004317
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218866
-              unit:
-                value: mg/d
-                range: string
+          - Quantity:
+              populated_from: pht004317
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218866
+                unit:
+                  value: mg/d
+                  range: string

--- a/priority_variables_transform/MESA-ingest/spirometry.yaml
+++ b/priority_variables_transform/MESA-ingest/spirometry.yaml
@@ -8,150 +8,150 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00083440}) + ":MESA AIR SPIROMETRY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001112
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              age_at_observation:
-                expr: '{phv00083452} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001112
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083474} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001112
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              age_at_observation:
-                expr: '{phv00083452} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001112
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083475} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001112
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              age_at_observation:
-                expr: '{phv00083452} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001112
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083482} * 100'
-                    unit:
-                      value: '%'
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001112
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-                range: string
-              age_at_observation:
-                expr: '{phv00083452} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001112
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083605} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001112
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-                range: string
-              age_at_observation:
-                expr: '{phv00083452} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001112
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083604} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001112
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-                range: string
-              age_at_observation:
-                expr: '{phv00083452} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001112
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00083612
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001112
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083452} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001112
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083474} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001112
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083452} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001112
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083475} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001112
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083452} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001112
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083482} * 100'
+                        unit:
+                          value: '%'
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001112
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083452} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001112
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083605} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001112
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083452} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001112
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083604} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001112
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083452} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001112
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00083612
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001114
@@ -162,150 +162,150 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00083675}) + ":MESA LUNG SPIROMETRY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001114
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              age_at_observation:
-                expr: '{phv00083687} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001114
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083709} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001114
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              age_at_observation:
-                expr: '{phv00083687} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001114
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083710} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001114
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              age_at_observation:
-                expr: '{phv00083687} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001114
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083717} * 100'
-                    unit:
-                      value: '%'
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001114
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-                range: string
-              age_at_observation:
-                expr: '{phv00083687} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001114
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083835} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001114
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-                range: string
-              age_at_observation:
-                expr: '{phv00083687} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001114
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00083834} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001114
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-                range: string
-              age_at_observation:
-                expr: '{phv00083687} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001114
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00083842
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001114
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083687} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001114
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083709} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001114
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083687} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001114
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083710} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001114
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083687} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001114
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083717} * 100'
+                        unit:
+                          value: '%'
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001114
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083687} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001114
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083835} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001114
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083687} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001114
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00083834} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001114
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                  range: string
+                age_at_observation:
+                  expr: '{phv00083687} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001114
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00083842
+                        unit:
+                          value: '%'
+                          range: string
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001122
@@ -316,163 +316,163 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00087666}) + ":MESA FAMILY SPIROMETRY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00087700} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "spirometry"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00087701} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              method_type:
-                value: calculated
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00087708} * 100'
-                    unit:
-                      value: '%'
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              method_type:
-                value: calculated
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00087833
-                    unit:
-                      value: '%'
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00087831} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00087830} / 1000'
-                    unit:
-                      value: L
-                      range: string
-          - name: MeasurementObservation
-            populated_from: pht001122
-            slot_derivations:
-              observation_type:
-                value: OMOP:4196583
-                range: string
-              age_at_observation:
-                expr: '{phv00087678} * 365'
-              body_position:
-                value: "SITTING_POSITION"
-                range: string
-              method_type:
-                value: "calculated"
-                range: string
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001122
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00087838
-                    unit:
-                      value: '%'
-                      range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00087700} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "spirometry"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00087701} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                method_type:
+                  value: calculated
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00087708} * 100'
+                        unit:
+                          value: '%'
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                method_type:
+                  value: calculated
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00087833
+                        unit:
+                          value: '%'
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00087831} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00087830} / 1000'
+                        unit:
+                          value: L
+                          range: string
+          - MeasurementObservation:
+              populated_from: pht001122
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4196583
+                  range: string
+                age_at_observation:
+                  expr: '{phv00087678} * 365'
+                body_position:
+                  value: "SITTING_POSITION"
+                  range: string
+                method_type:
+                  value: "calculated"
+                  range: string
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001122
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00087838
+                        unit:
+                          value: '%'
+                          range: string

--- a/priority_variables_transform/MESA-ingest/tnfa.yaml
+++ b/priority_variables_transform/MESA-ingest/tnfa.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002105
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00160520
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002105
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00160520
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002198
@@ -38,38 +38,38 @@
           range: string
         range_low:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                value: 0.16
-                range: string
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  value: 0.16
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string
         range_high:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                value: 12.0
-                range: string
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  value: 12.0
+                  range: string
+                unit:
+                  value: pg/mL
+                  range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002198
-            slot_derivations:
-              value_decimal:
-                expr: 'case(({phv00160540} != None and {phv00160541} != -333 and {phv00160541} != -555, {phv00160540}), ({phv00160541} == -333, 0.16), ({phv00160541} == -555, 12.0))'
-              operator:
-                expr: 'case(({phv00160541} == -333, "LESS_THAN"), ({phv00160541} == -555, "GREATER_THAN"))'
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht002198
+              slot_derivations:
+                value_decimal:
+                  expr: 'case(({phv00160540} != None and {phv00160541} != -333 and {phv00160541} != -555, {phv00160540}), ({phv00160541} == -333, 0.16), ({phv00160541} == -555, 12.0))'
+                operator:
+                  expr: 'case(({phv00160541} == -333, "LESS_THAN"), ({phv00160541} == -555, "GREATER_THAN"))'
+                unit:
+                  value: pg/mL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004326
@@ -88,11 +88,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004326
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00219028
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht004326
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00219028
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/tnfa_r1.yaml
+++ b/priority_variables_transform/MESA-ingest/tnfa_r1.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085029
-              unit:
-                value: pg/mL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085029
+                unit:
+                  value: pg/mL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/tot_chol_bld.yaml
@@ -12,14 +12,14 @@
           expr: 'case(({phv00083303} >= 12, "OBA:VT0000180"), (True, "OBA:VT0000180"))'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082956
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082956
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: 'case(({phv00083303} >= 12, "Fasted minimum 12 hours"))'
 - class_derivations:
@@ -36,14 +36,14 @@
           expr: 'case(({phv00084980} >= 12, "OBA:VT0000180"), (True, "OBA:VT0000180"))'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084974
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084974
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: 'case(({phv00084980} >= 12, "Fasted minimum 12 hours"))'
 - class_derivations:
@@ -61,14 +61,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085921
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085921
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -84,14 +84,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086404
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086404
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -107,14 +107,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086836
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086836
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -129,14 +129,14 @@
           expr: 'case(({phv00087524} >= 12, "OBA:VT0000180"), (True, "OBA:VT0000180"))'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087100
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087100
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: 'case(({phv00087524} >= 12, "Fasted minimum 12 hours"))'
 - class_derivations:
@@ -154,14 +154,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175242
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175242
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003087
@@ -177,14 +177,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003087
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175867
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003087
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175867
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -200,11 +200,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176665
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176665
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/MESA-ingest/triglyc_bld.yaml
@@ -12,14 +12,14 @@
           expr: 'case(({phv00083303} >= 12, "OMOP:4041722"), (True, "OBA:VT0002644"))'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082950
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082950
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: 'case(({phv00083303} >= 12, "Fasted minimum 12 hours"))'
 - class_derivations:
@@ -36,14 +36,14 @@
           expr: 'case(({phv00084980} >= 12, "OMOP:4041722"), (True, "OBA:VT0002644"))'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084968
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084968
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: 'case(({phv00084980} >= 12, "Fasted minimum 12 hours-CALCULATED FROM
             NMR LIPOPROFILE-3 SPECTRAL ANALYSIS"), (True, "CALCULATED FROM NMR
@@ -63,14 +63,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085918
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085918
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -86,14 +86,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086400
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086400
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -109,14 +109,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086831
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086831
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001121
@@ -131,14 +131,14 @@
           expr: 'case(({phv00087524} >= 12, "OMOP:4041722"), (True, "OBA:VT0002644"))'
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00087101
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00087101
+                unit:
+                  value: mg/dL
+                  range: string
         method_type:
           expr: 'case(({phv00087524} >= 12, "Fasted minimum 12 hours"))'
 - class_derivations:
@@ -156,14 +156,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00175237
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00175237
+                unit:
+                  value: mg/dL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -179,11 +179,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176660
-              unit:
-                value: mg/dL
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176660
+                unit:
+                  value: mg/dL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/vege_serving.yaml
+++ b/priority_variables_transform/MESA-ingest/vege_serving.yaml
@@ -14,12 +14,12 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004317
-            slot_derivations:
-              value_decimal:
-                expr: ({phv00218787} + {phv00218788} + {phv00218789} + {phv00218790}
-                  + {phv00218791} + {phv00218792} + {phv00218793}) * 7
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht004317
+              slot_derivations:
+                value_decimal:
+                  expr: ({phv00218787} + {phv00218788} + {phv00218789} + {phv00218790}
+                    + {phv00218791} + {phv00218792} + {phv00218793}) * 7
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/waist_circ.yaml
+++ b/priority_variables_transform/MESA-ingest/waist_circ.yaml
@@ -22,14 +22,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00082687
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00082687
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001116
@@ -54,14 +54,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00084486
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00084486
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001118
@@ -86,14 +86,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085801
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085801
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001119
@@ -118,14 +118,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086301
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086301
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001120
@@ -150,14 +150,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00086754
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00086754
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003086
@@ -182,14 +182,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00174634
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00174634
+                unit:
+                  value: cm
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht003091
@@ -214,11 +214,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00176057
-              unit:
-                value: cm
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00176057
+                unit:
+                  value: cm
+                  range: string

--- a/priority_variables_transform/MESA-ingest/waist_hip.yaml
+++ b/priority_variables_transform/MESA-ingest/waist_hip.yaml
@@ -16,14 +16,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001111
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00082688} or not {phv00082687} else {phv00082687} / {phv00082688}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht001111
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00082688} or not {phv00082687} else {phv00082687} / {phv00082688}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -43,14 +43,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00084489} or not {phv00084486} else {phv00084486} / {phv00084489}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00084489} or not {phv00084486} else {phv00084486} / {phv00084489}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -70,14 +70,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001118
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00085802} or not {phv00085801} else {phv00085801} / {phv00085802}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht001118
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00085802} or not {phv00085801} else {phv00085801} / {phv00085802}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -97,14 +97,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001119
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00086300} or not {phv00086301} else {phv00086301} / {phv00086300}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht001119
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00086300} or not {phv00086301} else {phv00086301} / {phv00086300}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -124,14 +124,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001120
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00086753} or not {phv00086754} else {phv00086754} / {phv00086753}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht001120
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00086753} or not {phv00086754} else {phv00086754} / {phv00086753}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -151,14 +151,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001121
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00087518} or not {phv00087519} else {phv00087519} / {phv00087518}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht001121
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00087518} or not {phv00087519} else {phv00087519} / {phv00087518}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -178,14 +178,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003086
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00174635} or not {phv00174634} else {phv00174634} / {phv00174635}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht003086
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00174635} or not {phv00174634} else {phv00174634} / {phv00174635}'
+                unit:
+                  value: '{ratio}'
+                  range: string
 
 - class_derivations:
     MeasurementObservation:
@@ -205,11 +205,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht003091
-            slot_derivations:
-              value_decimal:
-                expr: 'None if not {phv00176058} or not {phv00176057} else {phv00176057} / {phv00176058}'
-              unit:
-                value: '{ratio}'
-                range: string
+          - Quantity:
+              populated_from: pht003091
+              slot_derivations:
+                value_decimal:
+                  expr: 'None if not {phv00176058} or not {phv00176057} else {phv00176057} / {phv00176058}'
+                unit:
+                  value: '{ratio}'
+                  range: string

--- a/priority_variables_transform/MESA-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/MESA-ingest/whtbld_ct.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001984
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00128764
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht001984
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00128764
+                unit:
+                  value: 10*3/uL
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht004319
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004319
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00218997
-              unit:
-                value: 10*3/uL
-                range: string
+          - Quantity:
+              populated_from: pht004319
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00218997
+                unit:
+                  value: 10*3/uL
+                  range: string

--- a/priority_variables_transform/MESA-ingest/willeb_fac.yaml
+++ b/priority_variables_transform/MESA-ingest/willeb_fac.yaml
@@ -16,11 +16,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001116
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00085076
-              unit:
-                value: '%{Normal}'
-                range: string
+          - Quantity:
+              populated_from: pht001116
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00085076
+                unit:
+                  value: '%{Normal}'
+                  range: string

--- a/priority_variables_transform/SPIROMICS-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/bdy_hgt.yaml
@@ -19,10 +19,10 @@
           value: anthropometry
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht013308
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00528781
-              unit:
-                value: cm
+          - Quantity:
+              populated_from: pht013308
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00528781
+                unit:
+                  value: cm

--- a/priority_variables_transform/SPIROMICS-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/bdy_wgt.yaml
@@ -19,10 +19,10 @@
           value: anthropometry
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht013308
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00528954
-              unit:
-                value: kg
+          - Quantity:
+              populated_from: pht013308
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00528954
+                unit:
+                  value: kg

--- a/priority_variables_transform/SPIROMICS-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/blood_pressure.yaml
@@ -11,47 +11,47 @@
             == ''VISIT_4'', ''SPIROMICS Visit 4'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: average
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528715
-                    unit:
-                      value: 'mm[Hg]'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: SITTING_POSITION
-              body_site:
-                value: Right arm
-              method_type:
-                value: average
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528713
-                    unit:
-                      value: 'mm[Hg]'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: average
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528715
+                        unit:
+                          value: 'mm[Hg]'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: SITTING_POSITION
+                body_site:
+                  value: Right arm
+                method_type:
+                  value: average
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528713
+                        unit:
+                          value: 'mm[Hg]'

--- a/priority_variables_transform/SPIROMICS-ingest/bmi.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/bmi.yaml
@@ -17,10 +17,10 @@
           value: calculated
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht013308
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00528720
-              unit:
-                value: kg/m2
+          - Quantity:
+              populated_from: pht013308
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00528720
+                unit:
+                  value: kg/m2

--- a/priority_variables_transform/SPIROMICS-ingest/hrt_rt.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/hrt_rt.yaml
@@ -19,10 +19,10 @@
           value: average
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht013308
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00528714
-              unit:
-                value: '{beats}/min'
+          - Quantity:
+              populated_from: pht013308
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00528714
+                unit:
+                  value: '{beats}/min'

--- a/priority_variables_transform/SPIROMICS-ingest/spirometry_post_bd.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/spirometry_post_bd.yaml
@@ -11,255 +11,255 @@
             == ''VISIT_4'', ''SPIROMICS Visit 4'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528858
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528856
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      expr: '{phv00528854} * 100'
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-              body_position:
-                value: SITTING_POSITION
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              method_type:
-                value: calculated
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528867
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-              body_position:
-                value: SITTING_POSITION
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              method_type:
-                value: calculated
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528863
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-              body_position:
-                value: SITTING_POSITION
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              method_type:
-                value: calculated
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528864
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3005600
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528825
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011708
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528821
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4196583
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: AFTER
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528822
-                    unit:
-                      value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528858
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528856
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          expr: '{phv00528854} * 100'
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                body_position:
+                  value: SITTING_POSITION
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                method_type:
+                  value: calculated
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528867
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                body_position:
+                  value: SITTING_POSITION
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                method_type:
+                  value: calculated
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528863
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                body_position:
+                  value: SITTING_POSITION
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                method_type:
+                  value: calculated
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528864
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3005600
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528825
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011708
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528821
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4196583
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: AFTER
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528822
+                        unit:
+                          value: '%'

--- a/priority_variables_transform/SPIROMICS-ingest/spirometry_pre_bd.yaml
+++ b/priority_variables_transform/SPIROMICS-ingest/spirometry_pre_bd.yaml
@@ -11,249 +11,249 @@
             == ''VISIT_4'', ''SPIROMICS Visit 4'')))'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4176265
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528883
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4241837
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: spirometry
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528882
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011505
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528880
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3002094
-              body_position:
-                value: SITTING_POSITION
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528867
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3022891
-              body_position:
-                value: SITTING_POSITION
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528863
-                    unit:
-                      value: L
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3024594
-              body_position:
-                value: SITTING_POSITION
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528864
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3005600
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528837
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:3011708
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528833
-                    unit:
-                      value: '%'
-          - name: MeasurementObservation
-            populated_from: pht013308
-            slot_derivations:
-              observation_type:
-                value: OMOP:4196583
-              body_position:
-                value: SITTING_POSITION
-              method_type:
-                value: calculated
-              age_at_observation:
-                expr: '{phv00528706} * 365'
-              context:
-                class_derivations:
-                  Context:
-                    slot_derivations:
-                      activity:
-                        class_derivations:
-                          Activity:
-                            slot_derivations:
-                              activity_type:
-                                value: BRONCHODILATOR_MEDICATION_USE
-                      relative_timing:
-                        value: BEFORE
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht013308
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00528834
-                    unit:
-                      value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4176265
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528883
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4241837
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: spirometry
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528882
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011505
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528880
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3002094
+                body_position:
+                  value: SITTING_POSITION
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528867
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3022891
+                body_position:
+                  value: SITTING_POSITION
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528863
+                        unit:
+                          value: L
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3024594
+                body_position:
+                  value: SITTING_POSITION
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528864
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3005600
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528837
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:3011708
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528833
+                        unit:
+                          value: '%'
+          - MeasurementObservation:
+              populated_from: pht013308
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4196583
+                body_position:
+                  value: SITTING_POSITION
+                method_type:
+                  value: calculated
+                age_at_observation:
+                  expr: '{phv00528706} * 365'
+                context:
+                  class_derivations:
+                    Context:
+                      slot_derivations:
+                        activity:
+                          class_derivations:
+                            Activity:
+                              slot_derivations:
+                                activity_type:
+                                  value: BRONCHODILATOR_MEDICATION_USE
+                        relative_timing:
+                          value: BEFORE
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht013308
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00528834
+                        unit:
+                          value: '%'

--- a/priority_variables_transform/WHI-ingest/alcohol_servings.yaml
+++ b/priority_variables_transform/WHI-ingest/alcohol_servings.yaml
@@ -14,13 +14,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001003
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00078826
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht001003
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00078826
+                unit:
+                  value: "{#}/wk"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002125
@@ -37,10 +37,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002125
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00156410
-              unit:
-                value: "{#}/wk"
+          - Quantity:
+              populated_from: pht002125
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00156410
+                unit:
+                  value: "{#}/wk"

--- a/priority_variables_transform/WHI-ingest/bdy_hgt.yaml
+++ b/priority_variables_transform/WHI-ingest/bdy_hgt.yaml
@@ -16,17 +16,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006217
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283311
-                unit_conversion:
-                  source_unit: "[in_us]"
-                  target_unit: "cm"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht006217
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283311
+                  unit_conversion:
+                    source_unit: "[in_us]"
+                    target_unit: "cm"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -45,13 +45,13 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283539
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283539
+                unit:
+                  value: "cm"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001019
@@ -70,10 +70,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079858
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079858
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/WHI-ingest/bdy_wgt.yaml
+++ b/priority_variables_transform/WHI-ingest/bdy_wgt.yaml
@@ -16,17 +16,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000995
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00078235
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht000995
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00078235
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001014
@@ -45,17 +45,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001014
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079558
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht001014
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079558
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000991
@@ -74,17 +74,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000991
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077673
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht000991
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077673
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000992
@@ -103,17 +103,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000992
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077799
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht000992
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077799
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000994
@@ -132,17 +132,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000994
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00078111
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht000994
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00078111
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000993
@@ -161,17 +161,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000993
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077909
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht000993
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077909
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006215
@@ -190,17 +190,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006215
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283190
-                unit_conversion:
-                  source_unit: "[lb_av]"
-                  target_unit: "kg"
-              unit:
-                value: "kg"
-                range: string
+          - Quantity:
+              populated_from: pht006215
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283190
+                  unit_conversion:
+                    source_unit: "[lb_av]"
+                    target_unit: "kg"
+                unit:
+                  value: "kg"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001019
@@ -219,10 +219,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079859
-              unit:
-                value: "kg"
+          - Quantity:
+              populated_from: pht001019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079859
+                unit:
+                  value: "kg"

--- a/priority_variables_transform/WHI-ingest/blood_pressure.yaml
+++ b/priority_variables_transform/WHI-ingest/blood_pressure.yaml
@@ -8,46 +8,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00283451}) + ":WHI UNC HEART FAILURE DETAILS")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006223
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006223
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00283536
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006223
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer average"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006223
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00283537
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006223
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006223
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00283536
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006223
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer average"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006223
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00283537
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001019
@@ -58,46 +58,46 @@
           expr: "case(({phv00079850} == 1, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI SCREENING')), ({phv00079850} == 3 and {phv00079851} == 1, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 1')), ({phv00079850} == 3 and {phv00079851} == 2, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 2')), ({phv00079850} == 3 and {phv00079851} == 3, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 3')), ({phv00079850} == 3 and {phv00079851} == 4, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 4')), ({phv00079850} == 3 and {phv00079851} == 5, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 5')), ({phv00079850} == 3 and {phv00079851} == 6, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 6')), ({phv00079850} == 3 and {phv00079851} == 7, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 7')), ({phv00079850} == 3 and {phv00079851} == 8, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 8')), ({phv00079850} == 3 and {phv00079851} == 9, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 9')), (True, None))"
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001019
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001019
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00079856
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001019
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001019
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00079857
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001019
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001019
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00079856
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001019
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001019
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00079857
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht001019
@@ -108,46 +108,46 @@
           expr: "case(({phv00079850} == 1, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI SCREENING')), ({phv00079850} == 3 and {phv00079851} == 1, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 1')), ({phv00079850} == 3 and {phv00079851} == 2, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 2')), ({phv00079850} == 3 and {phv00079851} == 3, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 3')), ({phv00079850} == 3 and {phv00079851} == 4, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 4')), ({phv00079850} == 3 and {phv00079851} == 5, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 5')), ({phv00079850} == 3 and {phv00079851} == 6, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 6')), ({phv00079850} == 3 and {phv00079851} == 7, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 7')), ({phv00079850} == 3 and {phv00079851} == 8, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 8')), ({phv00079850} == 3 and {phv00079851} == 9, uuid5('https://w3id.org/bdchm/Visit', str({phv00079849}) + ':WHI YEAR 9')), (True, None))"
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht001019
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001019
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00079854
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht001019
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht001019
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00079855
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001019
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001019
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00079854
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht001019
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht001019
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00079855
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006217
@@ -158,46 +158,46 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00283284}) + ":WHI LONG LIFE STUDY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006217
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006217
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00283297
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006217
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006217
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00283298
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006217
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006217
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00283297
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006217
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006217
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00283298
+                        unit:
+                          value: "mm[Hg]"
 - class_derivations:
     MeasurementObservationSet:
       populated_from: pht006217
@@ -208,43 +208,43 @@
           expr: 'uuid5("https://w3id.org/bdchm/Visit", str({phv00283284}) + ":WHI LONG LIFE STUDY")'
         observations:
           class_derivations:
-          - name: MeasurementObservation
-            populated_from: pht006217
-            slot_derivations:
-              observation_type:
-                value: OMOP:4152194
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006217
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00283299
-                    unit:
-                      value: "mm[Hg]"
-          - name: MeasurementObservation
-            populated_from: pht006217
-            slot_derivations:
-              observation_type:
-                value: OMOP:4154790
-              body_position:
-                value: "SITTING_POSITION"
-              body_site:
-                value: "Right arm"
-              method_type:
-                value: "Seated sphygmomanometer reading"
-              value_quantity:
-                class_derivations:
-                - name: Quantity
-                  populated_from: pht006217
-                  slot_derivations:
-                    value_decimal:
-                      populated_from: phv00283300
-                    unit:
-                      value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006217
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4152194
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006217
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00283299
+                        unit:
+                          value: "mm[Hg]"
+          - MeasurementObservation:
+              populated_from: pht006217
+              slot_derivations:
+                observation_type:
+                  value: OMOP:4154790
+                body_position:
+                  value: "SITTING_POSITION"
+                body_site:
+                  value: "Right arm"
+                method_type:
+                  value: "Seated sphygmomanometer reading"
+                value_quantity:
+                  class_derivations:
+                  - Quantity:
+                      populated_from: pht006217
+                      slot_derivations:
+                        value_decimal:
+                          populated_from: phv00283300
+                        unit:
+                          value: "mm[Hg]"

--- a/priority_variables_transform/WHI-ingest/bmi.yaml
+++ b/priority_variables_transform/WHI-ingest/bmi.yaml
@@ -14,13 +14,13 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079867
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht001019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079867
+                unit:
+                  value: "kg/m2"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006217
@@ -37,10 +37,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006217
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283344
-              unit:
-                value: "kg/m2"
+          - Quantity:
+              populated_from: pht006217
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283344
+                unit:
+                  value: "kg/m2"

--- a/priority_variables_transform/WHI-ingest/bnp.yaml
+++ b/priority_variables_transform/WHI-ingest/bnp.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283648
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283648
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283646
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283646
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -60,10 +60,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283647
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283647
+                unit:
+                  value: "pg/mL"

--- a/priority_variables_transform/WHI-ingest/bun.yaml
+++ b/priority_variables_transform/WHI-ingest/bun.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283660
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283660
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/creat_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/creat_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283659
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283659
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/factor_7.yaml
+++ b/priority_variables_transform/WHI-ingest/factor_7.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077382
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077382
+                unit:
+                  value: "%{normal}"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000987
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077381
-              unit:
-                value: "%{normal}"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077381
+                unit:
+                  value: "%{normal}"

--- a/priority_variables_transform/WHI-ingest/fam_income.yaml
+++ b/priority_variables_transform/WHI-ingest/fam_income.yaml
@@ -17,23 +17,23 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000990
-            slot_derivations:
-              value_concept:
-                populated_from: phv00077579
-                value_mappings:
-                  '1': < $10,000
-                  '2': $10,000 - $19,999
-                  '3': $20,000 - $34,999
-                  '4': $35,000 - $49,999
-                  '5': $50,000 - $74,999
-                  '6': $75,000 - $99,999
-                  '7': $100,000 - $149,999
-                  '8': '> $150,000'
-                  '9': None
-              unit:
-                value: USD
+          - Quantity:
+              populated_from: pht000990
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00077579
+                  value_mappings:
+                    '1': < $10,000
+                    '2': $10,000 - $19,999
+                    '3': $20,000 - $34,999
+                    '4': $35,000 - $49,999
+                    '5': $50,000 - $74,999
+                    '6': $75,000 - $99,999
+                    '7': $100,000 - $149,999
+                    '8': '> $150,000'
+                    '9': None
+                unit:
+                  value: USD
 - class_derivations:
     SdohObservation:
       populated_from: pht000993
@@ -53,28 +53,28 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000993
-            slot_derivations:
-              value_concept:
-                populated_from: phv00078072
-                value_mappings:
-                  '1': < $7,000
-                  '2': $7,000 - $9,999
-                  '3': $10,000 - $11,999
-                  '4': $12,000 - $15,999
-                  '5': $16,000 - $19,999
-                  '6': $20,000 - $24,999
-                  '7': $25,000 - $29,999
-                  '8': $30,000 - $34,999
-                  '9': $35,000 - $49,999
-                  '10': $50,000 - $74,999
-                  '11': $75,000 - $99,999
-                  '12': $100,000 - $149,999
-                  '13': '> $150,000'
-                  '99': None
-              unit:
-                value: USD
+          - Quantity:
+              populated_from: pht000993
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00078072
+                  value_mappings:
+                    '1': < $7,000
+                    '2': $7,000 - $9,999
+                    '3': $10,000 - $11,999
+                    '4': $12,000 - $15,999
+                    '5': $16,000 - $19,999
+                    '6': $20,000 - $24,999
+                    '7': $25,000 - $29,999
+                    '8': $30,000 - $34,999
+                    '9': $35,000 - $49,999
+                    '10': $50,000 - $74,999
+                    '11': $75,000 - $99,999
+                    '12': $100,000 - $149,999
+                    '13': '> $150,000'
+                    '99': None
+                unit:
+                  value: USD
 - class_derivations:
     SdohObservation:
       populated_from: pht000997
@@ -94,20 +94,20 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000997
-            slot_derivations:
-              value_concept:
-                populated_from: phv00078409
-                value_mappings:
-                  '1': < $10,000
-                  '2': $10,000 - $19,999
-                  '3': $20,000 - $34,999
-                  '4': $35,000 - $49,999
-                  '5': $50,000 - $74,999
-                  '6': $75,000 - $99,999
-                  '7': $100,000 - $149,999
-                  '8': '> $150,000'
-                  '9': None
-              unit:
-                value: USD
+          - Quantity:
+              populated_from: pht000997
+              slot_derivations:
+                value_concept:
+                  populated_from: phv00078409
+                  value_mappings:
+                    '1': < $10,000
+                    '2': $10,000 - $19,999
+                    '3': $20,000 - $34,999
+                    '4': $35,000 - $49,999
+                    '5': $50,000 - $74,999
+                    '6': $75,000 - $99,999
+                    '7': $100,000 - $149,999
+                    '8': '> $150,000'
+                    '9': None
+                unit:
+                  value: USD

--- a/priority_variables_transform/WHI-ingest/fibrin.yaml
+++ b/priority_variables_transform/WHI-ingest/fibrin.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077383
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077383
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/fruit_serving.yaml
+++ b/priority_variables_transform/WHI-ingest/fruit_serving.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001517
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00111870} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001517
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00111870} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002125
@@ -38,14 +38,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002125
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00156402} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht002125
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00156402} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006218
@@ -62,11 +62,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006218
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00283389} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht006218
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00283389} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/WHI-ingest/glucose_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/glucose_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077384
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077384
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/hdl.yaml
+++ b/priority_variables_transform/WHI-ingest/hdl.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077388
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077388
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/hemat.yaml
+++ b/priority_variables_transform/WHI-ingest/hemat.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000986
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077365
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht000986
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077365
+                unit:
+                  value: "%"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283662
-              unit:
-                value: "%"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283662
+                unit:
+                  value: "%"

--- a/priority_variables_transform/WHI-ingest/hemo.yaml
+++ b/priority_variables_transform/WHI-ingest/hemo.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000986
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077366
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht000986
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077366
+                unit:
+                  value: "g/dL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -37,10 +37,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283661
-              unit:
-                value: "g/dL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283661
+                unit:
+                  value: "g/dL"

--- a/priority_variables_transform/WHI-ingest/hip_circ.yaml
+++ b/priority_variables_transform/WHI-ingest/hip_circ.yaml
@@ -18,10 +18,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079861
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079861
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/WHI-ingest/hrtrt.yaml
+++ b/priority_variables_transform/WHI-ingest/hrtrt.yaml
@@ -16,13 +16,13 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283538
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283538
+                unit:
+                  value: "{beats}/min"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht002118
@@ -41,10 +41,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00155154
-              unit:
-                value: "{beats}/min"
+          - Quantity:
+              populated_from: pht002118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00155154
+                unit:
+                  value: "{beats}/min"

--- a/priority_variables_transform/WHI-ingest/insulin_blood.yaml
+++ b/priority_variables_transform/WHI-ingest/insulin_blood.yaml
@@ -14,11 +14,11 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                expr: "{phv00077389} * 6.945"
-              unit:
-                value: "pmol/L"
-                range: string
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  expr: "{phv00077389} * 6.945"
+                unit:
+                  value: "pmol/L"
+                  range: string

--- a/priority_variables_transform/WHI-ingest/ldl.yaml
+++ b/priority_variables_transform/WHI-ingest/ldl.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077391
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077391
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/nt_bnp.yaml
+++ b/priority_variables_transform/WHI-ingest/nt_bnp.yaml
@@ -14,13 +14,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283651
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283651
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -37,13 +37,13 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283649
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283649
+                unit:
+                  value: "pg/mL"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006223
@@ -60,10 +60,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283650
-              unit:
-                value: "pg/mL"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283650
+                unit:
+                  value: "pg/mL"

--- a/priority_variables_transform/WHI-ingest/person.yaml
+++ b/priority_variables_transform/WHI-ingest/person.yaml
@@ -18,14 +18,14 @@
           expr: 'case(({pht006220.phv00283413} == 1, ({phv00078437} * 365) + {pht006220.phv00283414}), (True, None))'
         cause_of_death:
           class_derivations:
-          - name: CauseOfDeath
-            populated_from: pht000998
-            joins:
-              pht006220:
-                source_key: phv00078435
-                lookup_key: phv00283412
-            slot_derivations:
-              cause:
-                expr: 'case(({pht006220.phv00283416} == 1, "ICD10CM:C50"), ({pht006220.phv00283416} == 2, "ICD10CM:C56"), ({pht006220.phv00283416} == 3, "ICD10CM:C54"), ({pht006220.phv00283416} == 4, "ICD10CM:C18"), ({pht006220.phv00283416} == 5, "ICD10CM:C19"), ({pht006220.phv00283416} == 6, "ICD10CM:C20"), ({pht006220.phv00283416} == 7, "ICD10CM:C55"), ({pht006220.phv00283416} == 10, "ICD10CM:C34"), ({pht006220.phv00283416} == 11, "ICD10CM:I20-I25"), ({pht006220.phv00283416} == 12, "ICD10CM:I60-I69"), ({pht006220.phv00283416} == 13, "ICD10CM:I26"), ({pht006220.phv00283416} == 14, "ICD10CM:I20-I25"), ({pht006220.phv00283416} == 18, "ICD10CM:I00-I99"), ({pht006220.phv00283416} == 31, "ICD10CM:G30"), ({pht006220.phv00283416} == 32, "ICD10CM:J44"), ({pht006220.phv00283416} == 33, "ICD10CM:J18"), ({pht006220.phv00283416} == 34, "ICD10CM:J84.10"), ({pht006220.phv00283416} == 35, "ICD10CM:N18"), ({pht006220.phv00283416} == 36, "ICD10CM:A41"), ({pht006220.phv00283416} == 37, "ICD10CM:C25"), ({pht006220.phv00283416} == 38, "ICD10CM:C85"), ({pht006220.phv00283416} == 39, "ICD10CM:C95"), ({pht006220.phv00283416} == 40, "ICD10CM:C71"), ({pht006220.phv00283416} == 41, "ICD10CM:C90.0"), ({pht006220.phv00283416} == 42, "ICD10CM:F03"), ({pht006220.phv00283416} == 43, "ICD10CM:G12.21"), ({pht006220.phv00283416} == 44, "ICD10CM:G20"), ({pht006220.phv00283416} == 45, "ICD10CM:K74"), (True, None))'
-              order:
-                expr: 'case(({pht006220.phv00283413} == 1, 1), (True, None))'
+          - CauseOfDeath:
+              populated_from: pht000998
+              joins:
+                pht006220:
+                  source_key: phv00078435
+                  lookup_key: phv00283412
+              slot_derivations:
+                cause:
+                  expr: 'case(({pht006220.phv00283416} == 1, "ICD10CM:C50"), ({pht006220.phv00283416} == 2, "ICD10CM:C56"), ({pht006220.phv00283416} == 3, "ICD10CM:C54"), ({pht006220.phv00283416} == 4, "ICD10CM:C18"), ({pht006220.phv00283416} == 5, "ICD10CM:C19"), ({pht006220.phv00283416} == 6, "ICD10CM:C20"), ({pht006220.phv00283416} == 7, "ICD10CM:C55"), ({pht006220.phv00283416} == 10, "ICD10CM:C34"), ({pht006220.phv00283416} == 11, "ICD10CM:I20-I25"), ({pht006220.phv00283416} == 12, "ICD10CM:I60-I69"), ({pht006220.phv00283416} == 13, "ICD10CM:I26"), ({pht006220.phv00283416} == 14, "ICD10CM:I20-I25"), ({pht006220.phv00283416} == 18, "ICD10CM:I00-I99"), ({pht006220.phv00283416} == 31, "ICD10CM:G30"), ({pht006220.phv00283416} == 32, "ICD10CM:J44"), ({pht006220.phv00283416} == 33, "ICD10CM:J18"), ({pht006220.phv00283416} == 34, "ICD10CM:J84.10"), ({pht006220.phv00283416} == 35, "ICD10CM:N18"), ({pht006220.phv00283416} == 36, "ICD10CM:A41"), ({pht006220.phv00283416} == 37, "ICD10CM:C25"), ({pht006220.phv00283416} == 38, "ICD10CM:C85"), ({pht006220.phv00283416} == 39, "ICD10CM:C95"), ({pht006220.phv00283416} == 40, "ICD10CM:C71"), ({pht006220.phv00283416} == 41, "ICD10CM:C90.0"), ({pht006220.phv00283416} == 42, "ICD10CM:F03"), ({pht006220.phv00283416} == 43, "ICD10CM:G12.21"), ({pht006220.phv00283416} == 44, "ICD10CM:G20"), ({pht006220.phv00283416} == 45, "ICD10CM:K74"), (True, None))'
+                order:
+                  expr: 'case(({pht006220.phv00283413} == 1, 1), (True, None))'

--- a/priority_variables_transform/WHI-ingest/platelet_ct.yaml
+++ b/priority_variables_transform/WHI-ingest/platelet_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000986
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077367
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht000986
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077367
+                unit:
+                  value: "10*3/uL"

--- a/priority_variables_transform/WHI-ingest/pr_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/pr_ekg.yaml
@@ -16,10 +16,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00155286
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht002118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00155286
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/WHI-ingest/qrs_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/qrs_ekg.yaml
@@ -16,10 +16,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00155364
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht002118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00155364
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/WHI-ingest/qt_ekg.yaml
+++ b/priority_variables_transform/WHI-ingest/qt_ekg.yaml
@@ -16,10 +16,10 @@
           value: "Electrocardiogram"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002118
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00155366
-              unit:
-                value: "ms"
+          - Quantity:
+              populated_from: pht002118
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00155366
+                unit:
+                  value: "ms"

--- a/priority_variables_transform/WHI-ingest/sleep_duration_daily.yaml
+++ b/priority_variables_transform/WHI-ingest/sleep_duration_daily.yaml
@@ -14,13 +14,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000990
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077490
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht000990
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077490
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006214
@@ -37,13 +37,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006214
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283093
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht006214
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283093
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht000993
@@ -60,13 +60,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000993
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077943
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht000993
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077943
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001010
@@ -83,13 +83,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001010
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079391
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht001010
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079391
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001006
@@ -106,13 +106,13 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001006
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079193
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht001006
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079193
+                unit:
+                  value: "h"
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001005
@@ -129,10 +129,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001005
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079041
-              unit:
-                value: "h"
+          - Quantity:
+              populated_from: pht001005
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079041
+                unit:
+                  value: "h"

--- a/priority_variables_transform/WHI-ingest/sodium_blood.yaml
+++ b/priority_variables_transform/WHI-ingest/sodium_blood.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283658
-              unit:
-                value: "mmol/L"
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283658
+                unit:
+                  value: "mmol/L"

--- a/priority_variables_transform/WHI-ingest/sodium_intak.yaml
+++ b/priority_variables_transform/WHI-ingest/sodium_intak.yaml
@@ -14,10 +14,10 @@
           value: "questionnaire"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht002125
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00156452
-              unit:
-                value: "mg/d"
+          - Quantity:
+              populated_from: pht002125
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00156452
+                unit:
+                  value: "mg/d"

--- a/priority_variables_transform/WHI-ingest/tot_chol_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/tot_chol_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077396
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077396
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/triglyc_bld.yaml
+++ b/priority_variables_transform/WHI-ingest/triglyc_bld.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000987
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077397
-              unit:
-                value: "mg/dL"
+          - Quantity:
+              populated_from: pht000987
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077397
+                unit:
+                  value: "mg/dL"

--- a/priority_variables_transform/WHI-ingest/troponin.yaml
+++ b/priority_variables_transform/WHI-ingest/troponin.yaml
@@ -12,8 +12,8 @@
           value: "blood assay worst value"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006223
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283653
+          - Quantity:
+              populated_from: pht006223
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283653

--- a/priority_variables_transform/WHI-ingest/vege_serving.yaml
+++ b/priority_variables_transform/WHI-ingest/vege_serving.yaml
@@ -14,14 +14,14 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001517
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00111871} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht001517
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00111871} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht006218
@@ -38,11 +38,11 @@
           range: string
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006218
-            slot_derivations:
-              value_decimal:
-                expr: '{phv00283395} * 7'
-              unit:
-                value: '{#}/wk'
-                range: string
+          - Quantity:
+              populated_from: pht006218
+              slot_derivations:
+                value_decimal:
+                  expr: '{phv00283395} * 7'
+                unit:
+                  value: '{#}/wk'
+                  range: string

--- a/priority_variables_transform/WHI-ingest/waist_circ.yaml
+++ b/priority_variables_transform/WHI-ingest/waist_circ.yaml
@@ -18,17 +18,17 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht006217
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00283313
-                unit_conversion:
-                  source_unit: "[in_us]"
-                  target_unit: "cm"
-              unit:
-                value: "cm"
-                range: string
+          - Quantity:
+              populated_from: pht006217
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00283313
+                  unit_conversion:
+                    source_unit: "[in_us]"
+                    target_unit: "cm"
+                unit:
+                  value: "cm"
+                  range: string
 - class_derivations:
     MeasurementObservation:
       populated_from: pht001019
@@ -49,10 +49,10 @@
           value: "anthropometry"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079860
-              unit:
-                value: "cm"
+          - Quantity:
+              populated_from: pht001019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079860
+                unit:
+                  value: "cm"

--- a/priority_variables_transform/WHI-ingest/waist_hip.yaml
+++ b/priority_variables_transform/WHI-ingest/waist_hip.yaml
@@ -14,10 +14,10 @@
           value: "calculated"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht001019
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00079869
-              unit:
-                value: "{ratio}"
+          - Quantity:
+              populated_from: pht001019
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00079869
+                unit:
+                  value: "{ratio}"

--- a/priority_variables_transform/WHI-ingest/whtbld_ct.yaml
+++ b/priority_variables_transform/WHI-ingest/whtbld_ct.yaml
@@ -14,10 +14,10 @@
           value: "blood assay"
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht000986
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00077368
-              unit:
-                value: "10*3/uL"
+          - Quantity:
+              populated_from: pht000986
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00077368
+                unit:
+                  value: "10*3/uL"


### PR DESCRIPTION
Converts nested `class_derivations` list items from `- name: X` to dict-keyed `- X:`, so the class name is always a mapping key — matching the top-level form — instead of a `name:` field.

Applies to `Quantity` (3,223), `MeasurementObservation` (528), and `CauseOfDeath` (23) across all `*-ingest` specs: **3,774 items in 484 files**. This restores the dict-keyed convention that the object_derivations migration (#696) inadvertently flattened to `- name:` during a mechanical pass.

**Purely cosmetic.** Both forms load identically in linkml-map. No expression, PHV, concept, or unit is touched.

---

## Depends on #733 (merged)

This PR is mechanically generated, but it could not be safely verified until #733 landed. The spec readers resolved nested class names with `cd.get("name")`, which is `None` for a dict-keyed item — so every nested derivation was skipped. On this tree, before #733:

```
Found 1 unique value-PHVs across 836 files    # main reports 2049
```

`check_phv_dedup` still printed "No duplicates found" and CI still passed, because there was nothing left to compare. Had this PR merged on that green CI, PHV-duplication coverage would have dropped to nothing with no signal.

With #733 merged, the same check on this tree now reports:

```
Found 2049 unique value-PHVs across 836 files
```

— identical to main. **The green CI on this PR is now meaningful rather than vacuous**, which was the point of splitting the two changes.

## Parity verification

Every block was canonicalized on both sides so `- name: X`, `- X:`, and pure-dict `X:` reduce to one shape, then compared against `main`:

- **0** semantic mismatches across 836 files
- **0** `validate_spec` failures, **0** `object_derivations`
- **2049** value-PHVs, matching main exactly
- All 836 specs parse; `validate_ingest_yamls` passes

The 33,833/33,833 insert/delete count is symmetric because it is a 1:1 reshape (`- name: X` → `- X:` plus a two-space reindent of the body).

## Example

```diff
         value_quantity:
           class_derivations:
-          - name: Quantity
-            populated_from: pht004051
-            slot_derivations:
-              value_decimal:
-                populated_from: phv00203866
+          - Quantity:
+              populated_from: pht004051
+              slot_derivations:
+                value_decimal:
+                  populated_from: phv00203866
```

## Rebuild note

Regenerated from scratch on top of `main` after the cohort PRs landed (#686, #688, #689, #693, #694, #713, #714, #715) and after #733, rather than merged forward — a clean re-run of the same script over settled content. Counts differ slightly from the original posting (3,807 items / 486 files) because those PRs deleted several spec files.
