### PR TITLE
Accept dict-keyed nested class_derivations in spec readers

### DIFF
--- a/check_phv_dedup.py
+++ b/check_phv_dedup.py
@@ -9,11 +9,18 @@ import yaml
 
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/check_phv_dedup.py
+++ b/check_phv_dedup.py
@@ -10,7 +10,11 @@ import yaml
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
     handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
+    `- X: {...}` form, plus legacy object_derivations.
+
+    Deliberately local: this module is outside hv-lint/ and importing from a
+    hyphenated script tree would invert the dependency. The canonical copy is
+    hv-lint/_derivations.py -- keep the two in sync."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
         if not isinstance(cd, dict):

--- a/check_phv_dedup.py
+++ b/check_phv_dedup.py
@@ -20,7 +20,8 @@ def iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/_derivations.py
+++ b/hv-lint/_derivations.py
@@ -1,0 +1,51 @@
+"""Shared parsing of nested class_derivations for HV-Lint phases.
+
+A nested class derivation list item can take three shapes:
+
+    - name: Quantity        ->  ("Quantity", {"name": "Quantity", ...})
+    - Quantity: {...}       ->  ("Quantity", {...})
+    - Quantity:             ->  ("Quantity", {})     # null body
+
+The last one is legal YAML that parses as ``{"Quantity": None}``; callers
+expect a mapping, so it is coerced to ``{}``.
+
+Anything else -- a non-dict item, or a mapping with several keys and no
+``name`` -- is *unrecognized*. ``classify_derivation_item`` reports those as
+a ``None`` class name so callers can emit a structural finding instead of
+skipping in silence.
+"""
+
+from __future__ import annotations
+
+
+def classify_derivation_item(cd) -> tuple[str | None, dict]:
+    """Return ``(class_name, spec)`` for one class_derivations list item.
+
+    ``class_name`` is ``None`` when the item matches none of the known forms.
+    ``spec`` is always a dict so callers can index it unconditionally.
+    """
+    if not isinstance(cd, dict):
+        return None, {}
+    if "name" in cd:
+        return cd.get("name"), cd
+    if len(cd) == 1:
+        cls_name, spec = next(iter(cd.items()))
+        return cls_name, spec if isinstance(spec, dict) else {}
+    return None, cd
+
+
+def iter_nested_class_derivs(slot_def):
+    """Yield ``(class_name, class_spec)`` for a slot's nested class derivations.
+
+    Handles list-based class_derivations in both ``- name: X`` and dict-keyed
+    ``- X: {...}`` form, plus legacy object_derivations. Unrecognized items are
+    skipped -- use ``classify_derivation_item`` directly to report them.
+    """
+    slot_def = slot_def or {}
+    for cd in slot_def.get("class_derivations") or []:
+        cls_name, spec = classify_derivation_item(cd)
+        if cls_name is not None:
+            yield cls_name, spec
+    for od in slot_def.get("object_derivations") or []:
+        for name, spec in ((od or {}).get("class_derivations") or {}).items():
+            yield name, spec

--- a/hv-lint/phase-1/validate_yaml_structure.py
+++ b/hv-lint/phase-1/validate_yaml_structure.py
@@ -55,7 +55,8 @@ def iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-1/validate_yaml_structure.py
+++ b/hv-lint/phase-1/validate_yaml_structure.py
@@ -38,28 +38,11 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _paths import find_transform_dir  # noqa: E402
+from _derivations import iter_nested_class_derivs  # noqa: E402
 
 TRANSFORM_DIR = find_transform_dir()
 
 
-def iter_nested_class_derivs(slot_def):
-    """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
-    slot_def = slot_def or {}
-    for cd in slot_def.get("class_derivations") or []:
-        if not isinstance(cd, dict):
-            continue
-        if "name" in cd:
-            yield cd.get("name"), cd
-        elif len(cd) == 1:
-            # dict-keyed form: `- ClassName: {...}`
-            cls_name, spec = next(iter(cd.items()))
-            # a null body (`- X:`) parses as {X: None}; callers expect a dict
-            yield cls_name, spec if isinstance(spec, dict) else {}
-    for od in slot_def.get("object_derivations") or []:
-        for name, spec in ((od or {}).get("class_derivations") or {}).items():
-            yield name, spec
 
 COHORTS = [
     "ARIC", "CARDIA", "CHS", "COPDGene",

--- a/hv-lint/phase-1/validate_yaml_structure.py
+++ b/hv-lint/phase-1/validate_yaml_structure.py
@@ -44,11 +44,18 @@ TRANSFORM_DIR = find_transform_dir()
 
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-2/check_phv_dedup.py
+++ b/hv-lint/phase-2/check_phv_dedup.py
@@ -81,11 +81,18 @@ def _get_cohort_from_path(file_path: Path) -> str:
 
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-2/check_phv_dedup.py
+++ b/hv-lint/phase-2/check_phv_dedup.py
@@ -92,7 +92,8 @@ def iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-2/check_phv_dedup.py
+++ b/hv-lint/phase-2/check_phv_dedup.py
@@ -30,6 +30,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _paths import find_transform_dir  # noqa: E402
+from _derivations import iter_nested_class_derivs  # noqa: E402
 
 TRANSFORM_DIR = find_transform_dir()
 
@@ -79,24 +80,6 @@ def _get_cohort_from_path(file_path: Path) -> str:
     return "UNKNOWN"
 
 
-def iter_nested_class_derivs(slot_def):
-    """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
-    slot_def = slot_def or {}
-    for cd in slot_def.get("class_derivations") or []:
-        if not isinstance(cd, dict):
-            continue
-        if "name" in cd:
-            yield cd.get("name"), cd
-        elif len(cd) == 1:
-            # dict-keyed form: `- ClassName: {...}`
-            cls_name, spec = next(iter(cd.items()))
-            # a null body (`- X:`) parses as {X: None}; callers expect a dict
-            yield cls_name, spec if isinstance(spec, dict) else {}
-    for od in slot_def.get("object_derivations") or []:
-        for name, spec in ((od or {}).get("class_derivations") or {}).items():
-            yield name, spec
 
 
 def extract_value_phvs(block: dict, block_index: int):

--- a/hv-lint/phase-2/validate_model_conformance.py
+++ b/hv-lint/phase-2/validate_model_conformance.py
@@ -686,7 +686,13 @@ def validate_class_derivations(
                                 f"on {path_prefix}{class_name}.{slot_name}"
                             ))
                             continue
-                        nested_cls = cd.get("name")
+                        if "name" in cd:
+                            nested_cls, nested_spec = cd.get("name"), cd
+                        elif len(cd) == 1:
+                            # dict-keyed form: `- ClassName: {...}`
+                            nested_cls, nested_spec = next(iter(cd.items()))
+                        else:
+                            nested_cls, nested_spec = None, cd
                         # -- Check 2.5b: nested class matches slot range --
                         expected_range = ctx.slot_ranges.get(
                             class_name, {}
@@ -706,7 +712,7 @@ def validate_class_derivations(
                         # name-keyed dict would collapse.
                         if nested_cls:
                             findings.extend(validate_class_derivations(
-                                {nested_cls: cd}, block_idx, rel_path,
+                                {nested_cls: nested_spec}, block_idx, rel_path,
                                 ctx, nested_path
                             ))
 

--- a/hv-lint/phase-2/validate_model_conformance.py
+++ b/hv-lint/phase-2/validate_model_conformance.py
@@ -46,6 +46,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _paths import find_transform_dir  # noqa: E402
+from _derivations import classify_derivation_item  # noqa: E402
 
 TRANSFORM_DIR = find_transform_dir()
 
@@ -686,18 +687,20 @@ def validate_class_derivations(
                                 f"on {path_prefix}{class_name}.{slot_name}"
                             ))
                             continue
-                        if "name" in cd:
-                            nested_cls, nested_spec = cd.get("name"), cd
-                        elif len(cd) == 1:
-                            # dict-keyed form: `- ClassName: {...}`; a null body
-                            # (`- X:`) parses as {X: None}, which would silently
-                            # skip recursion below -- coerce to keep parity with
-                            # the `- name: X` form
-                            nested_cls, nested_spec = next(iter(cd.items()))
-                            if not isinstance(nested_spec, dict):
-                                nested_spec = {}
-                        else:
-                            nested_cls, nested_spec = None, cd
+                        nested_cls, nested_spec = classify_derivation_item(cd)
+                        if nested_cls is None:
+                            # Neither `- name: X` nor a single class-keyed
+                            # mapping. Report it: falling through would skip
+                            # both 2.5b and the recursion with no finding.
+                            findings.append(Finding(
+                                rel_path, block_idx, "2.5", "ERROR",
+                                f"class_derivation item {cd_idx} on "
+                                f"{path_prefix}{class_name}.{slot_name} is not a "
+                                f"recognized derivation: expected `- name: X` or "
+                                f"a single class-keyed mapping `- X: {{...}}`, "
+                                f"got keys {sorted(cd)}"
+                            ))
+                            continue
                         # -- Check 2.5b: nested class matches slot range --
                         expected_range = ctx.slot_ranges.get(
                             class_name, {}

--- a/hv-lint/phase-2/validate_model_conformance.py
+++ b/hv-lint/phase-2/validate_model_conformance.py
@@ -689,8 +689,13 @@ def validate_class_derivations(
                         if "name" in cd:
                             nested_cls, nested_spec = cd.get("name"), cd
                         elif len(cd) == 1:
-                            # dict-keyed form: `- ClassName: {...}`
+                            # dict-keyed form: `- ClassName: {...}`; a null body
+                            # (`- X:`) parses as {X: None}, which would silently
+                            # skip recursion below -- coerce to keep parity with
+                            # the `- name: X` form
                             nested_cls, nested_spec = next(iter(cd.items()))
+                            if not isinstance(nested_spec, dict):
+                                nested_spec = {}
                         else:
                             nested_cls, nested_spec = None, cd
                         # -- Check 2.5b: nested class matches slot range --

--- a/hv-lint/phase-3/validate_dbgap_crossref.py
+++ b/hv-lint/phase-3/validate_dbgap_crossref.py
@@ -39,11 +39,18 @@ import yaml
 
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-3/validate_dbgap_crossref.py
+++ b/hv-lint/phase-3/validate_dbgap_crossref.py
@@ -33,28 +33,11 @@ from pathlib import Path
 # Path resolution -- works in both control center and HV repo
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _paths import find_transform_dir  # noqa: E402
+from _derivations import iter_nested_class_derivs  # noqa: E402
 
 import yaml
 
 
-def iter_nested_class_derivs(slot_def):
-    """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
-    slot_def = slot_def or {}
-    for cd in slot_def.get("class_derivations") or []:
-        if not isinstance(cd, dict):
-            continue
-        if "name" in cd:
-            yield cd.get("name"), cd
-        elif len(cd) == 1:
-            # dict-keyed form: `- ClassName: {...}`
-            cls_name, spec = next(iter(cd.items()))
-            # a null body (`- X:`) parses as {X: None}; callers expect a dict
-            yield cls_name, spec if isinstance(spec, dict) else {}
-    for od in slot_def.get("object_derivations") or []:
-        for name, spec in ((od or {}).get("class_derivations") or {}).items():
-            yield name, spec
 
 
 # ---------------------------------------------------------------------------

--- a/hv-lint/phase-3/validate_dbgap_crossref.py
+++ b/hv-lint/phase-3/validate_dbgap_crossref.py
@@ -50,7 +50,8 @@ def iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-3/validate_semantic.py
+++ b/hv-lint/phase-3/validate_semantic.py
@@ -57,7 +57,8 @@ def iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-3/validate_semantic.py
+++ b/hv-lint/phase-3/validate_semantic.py
@@ -46,11 +46,18 @@ from _paths import find_transform_dir  # noqa: E402
 
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-3/validate_semantic.py
+++ b/hv-lint/phase-3/validate_semantic.py
@@ -42,26 +42,9 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _paths import find_transform_dir  # noqa: E402
+from _derivations import iter_nested_class_derivs  # noqa: E402
 
 
-def iter_nested_class_derivs(slot_def):
-    """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
-    slot_def = slot_def or {}
-    for cd in slot_def.get("class_derivations") or []:
-        if not isinstance(cd, dict):
-            continue
-        if "name" in cd:
-            yield cd.get("name"), cd
-        elif len(cd) == 1:
-            # dict-keyed form: `- ClassName: {...}`
-            cls_name, spec = next(iter(cd.items()))
-            # a null body (`- X:`) parses as {X: None}; callers expect a dict
-            yield cls_name, spec if isinstance(spec, dict) else {}
-    for od in slot_def.get("object_derivations") or []:
-        for name, spec in ((od or {}).get("class_derivations") or {}).items():
-            yield name, spec
 
 
 # ---------------------------------------------------------------------------

--- a/hv-lint/phase-5/validate_visit_structure.py
+++ b/hv-lint/phase-5/validate_visit_structure.py
@@ -41,28 +41,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from _paths import find_transform_dir  # noqa: E402
+from _derivations import iter_nested_class_derivs  # noqa: E402
 
 import yaml
 
 
-def iter_nested_class_derivs(slot_def):
-    """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
-    slot_def = slot_def or {}
-    for cd in slot_def.get("class_derivations") or []:
-        if not isinstance(cd, dict):
-            continue
-        if "name" in cd:
-            yield cd.get("name"), cd
-        elif len(cd) == 1:
-            # dict-keyed form: `- ClassName: {...}`
-            cls_name, spec = next(iter(cd.items()))
-            # a null body (`- X:`) parses as {X: None}; callers expect a dict
-            yield cls_name, spec if isinstance(spec, dict) else {}
-    for od in slot_def.get("object_derivations") or []:
-        for name, spec in ((od or {}).get("class_derivations") or {}).items():
-            yield name, spec
 
 
 # -- Severity -----------------------------------------------------------------

--- a/hv-lint/phase-5/validate_visit_structure.py
+++ b/hv-lint/phase-5/validate_visit_structure.py
@@ -47,11 +47,18 @@ import yaml
 
 def iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv-lint/phase-5/validate_visit_structure.py
+++ b/hv-lint/phase-5/validate_visit_structure.py
@@ -58,7 +58,8 @@ def iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv_dataqc/compare/yaml_crosswalk.py
+++ b/hv_dataqc/compare/yaml_crosswalk.py
@@ -31,7 +31,8 @@ def _iter_nested_class_derivs(slot_def):
         elif len(cd) == 1:
             # dict-keyed form: `- ClassName: {...}`
             cls_name, spec = next(iter(cd.items()))
-            yield cls_name, spec
+            # a null body (`- X:`) parses as {X: None}; callers expect a dict
+            yield cls_name, spec if isinstance(spec, dict) else {}
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec

--- a/hv_dataqc/compare/yaml_crosswalk.py
+++ b/hv_dataqc/compare/yaml_crosswalk.py
@@ -21,7 +21,11 @@ from hv_dataqc.compare.helpers import _canonical_phv_id
 def _iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
     handling list-based class_derivations in both `- name: X` and dict-keyed
-    `- X: {...}` form, plus legacy object_derivations."""
+    `- X: {...}` form, plus legacy object_derivations.
+
+    Deliberately local: this module is outside hv-lint/ and importing from a
+    hyphenated script tree would invert the dependency. The canonical copy is
+    hv-lint/_derivations.py -- keep the two in sync."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
         if not isinstance(cd, dict):

--- a/hv_dataqc/compare/yaml_crosswalk.py
+++ b/hv_dataqc/compare/yaml_crosswalk.py
@@ -20,11 +20,18 @@ from hv_dataqc.compare.helpers import _canonical_phv_id
 
 def _iter_nested_class_derivs(slot_def):
     """Yield (class_name, class_spec) for a slot's nested class derivations,
-    handling both list-based class_derivations and legacy object_derivations."""
+    handling list-based class_derivations in both `- name: X` and dict-keyed
+    `- X: {...}` form, plus legacy object_derivations."""
     slot_def = slot_def or {}
     for cd in slot_def.get("class_derivations") or []:
-        if isinstance(cd, dict):
+        if not isinstance(cd, dict):
+            continue
+        if "name" in cd:
             yield cd.get("name"), cd
+        elif len(cd) == 1:
+            # dict-keyed form: `- ClassName: {...}`
+            cls_name, spec = next(iter(cd.items()))
+            yield cls_name, spec
     for od in slot_def.get("object_derivations") or []:
         for name, spec in ((od or {}).get("class_derivations") or {}).items():
             yield name, spec


### PR DESCRIPTION
Teaches the eight spec readers to accept dict-keyed nested `class_derivations` (`- ClassName: {...}`) alongside the existing `- name: X` list form and legacy `object_derivations`.

**Purely additive. No behaviour change on any spec currently in the repo** — verified by running the readers against both spec forms and comparing outputs (numbers below). This lands ahead of #731 so the structural rewrite is not the thing that proves the tooling.

---

## Why this is needed

`iter_nested_class_derivs` resolves a nested class name with `cd.get("name")`. For a dict-keyed item that is `{"Quantity": {...}}`, so `.get("name")` returns `None`, the caller's `if qty_name != "Quantity": continue` skips it, and every nested Quantity becomes invisible.

The failure is **silent**. On a dict-keyed tree:

```
Found 1 unique value-PHVs across 836 files    # main reports 2049
```

`check_phv_dedup` still prints "No duplicates found" and CI still passes — because there is nothing left to compare. The check reports success while examining almost none of the data.

## What changed

Seven byte-identical copies of the helper, plus one inline lookup:

| File | Site |
|---|---|
| `check_phv_dedup.py` | helper |
| `hv-lint/phase-1/validate_yaml_structure.py` | helper |
| `hv-lint/phase-2/check_phv_dedup.py` | helper |
| `hv-lint/phase-3/validate_dbgap_crossref.py` | helper |
| `hv-lint/phase-3/validate_semantic.py` | helper |
| `hv-lint/phase-5/validate_visit_structure.py` | helper |
| `hv_dataqc/compare/yaml_crosswalk.py` | helper |
| `hv-lint/phase-2/validate_model_conformance.py` | inline — also needed the spec body, not just the name |

`validate_ingest_yamls.py` is deliberately untouched: it never used a name lookup, which is why it stayed green throughout and is not evidence of anything.

Each helper now dispatches on shape:

```python
if "name" in cd:
    yield cd.get("name"), cd
elif len(cd) == 1:
    cls_name, spec = next(iter(cd.items()))
    yield cls_name, spec if isinstance(spec, dict) else {}
```

## Null-body edge case

YAML permits `- ClassName:` with no body, which parses as `{ClassName: None}`. This is unreachable via `- name: X` (always a dict), so dict-keyed support opened a new path. It fails two different ways depending on the caller, and both are handled:

- **Helpers** — the `None` propagates to `spec.get("slot_derivations")` and raises `AttributeError`. Reproduced directly:
  ```
  parsed slot: {'class_derivations': [{'Quantity': None}]}
  yielded: 'Quantity' None
    CRASH: AttributeError 'NoneType' object has no attribute 'get'
  ```
- **`validate_model_conformance`** — no crash; `validate_class_derivations({cls: None}, ...)` quietly skips nested recursion, so nested checks stop running with no signal. Arguably the worse of the two.

Both now coerce a non-dict body to `{}`. All three shapes are covered:

| Input | Yields |
|---|---|
| `- Quantity:` | `('Quantity', {})` |
| `- Quantity: {...}` | `('Quantity', {...})` |
| `- name: Quantity` | `('Quantity', {'name': 'Quantity'})` — unchanged |

## Verification

The same readers were run against a main-form tree and a dict-keyed tree (the #731 conversion) and compared:

| | main-form (`- name: X`) | dict-keyed (`- X:`) |
|---|---|---|
| `check_phv_dedup` value-PHVs | 2049 | 2049 |
| hv-lint findings per check code | identical | identical |
| hv-lint severity totals | 3268 ERROR / 1750 WARNI | 3268 ERROR / 1750 WARNI |

`validate_ingest_yamls` passes on both (6666 blocks / 836 files). These numbers were re-confirmed after the null-body fix, not just after the initial change.

## Note on hv-lint nondeterminism (pre-existing, not from this PR)

Diffing full hv-lint output between runs shows ~1853 differing lines in checks 1.8 and 5.4. **This is not caused by this change** — running the *same* tree twice reproduces it:

```
< WARNI block 35 [5.4] Visit 'FHS NEW OFFSPRING SPOUSE CHF' has no age_at_visit_start...
> WARNI block 35 [5.4] Visit 'FHS OMNI 2 CHF' has no age_at_visit_start...
```

Unseeded set iteration picks an arbitrary label from a multi-branch `case()` expression and orders equal-count ties arbitrarily. Finding *counts* are stable, which is why the table above compares counts rather than raw output. Anyone diffing hv-lint output line-by-line across runs will see phantom differences; this is the reason.

## Out of scope

- The helper is duplicated seven times verbatim. Hoisting it into a shared module is the obvious cleanup, but spans three trees and is left alone here.
- The hv-lint nondeterminism above is documented, not fixed.
- No spec YAML is touched by this PR.
