### PR TITLE
Check PHVs nested in MeasurementObservationSet

### DIFF
--- a/check_phv_dedup.py
+++ b/check_phv_dedup.py
@@ -32,17 +32,37 @@ def iter_nested_class_derivs(slot_def):
 
 
 # Known duplicates tracked in #455. Remove entries as they are fixed.
+#
+# Re-triaged in #735 once this check could see MeasurementObservationSet.
+# Seven entries were dropped as genuinely resolved; the two below are still
+# live and were only invisible because they sit inside a Set.
 KNOWN_ISSUES = {
-    "phv00001581",  # FHS tot_chol_bld.yaml — missing observation_type in block 60
-    "phv00079854",  # WHI bp_diastolic / bp_systolic
-    "phv00079855",  # WHI bp_diastolic / bp_systolic
-    "phv00079856",  # WHI bp_diastolic / bp_systolic
-    "phv00079857",  # WHI bp_diastolic / bp_systolic
-    "phv00100046",  # CHS albumin_bld / mch
-    "phv00112688",  # CARDIA hemo / mchc
-    "phv00210286",  # ARIC bp_diastolic / bp_systolic
-    "phv00210289",  # ARIC bp_diastolic / bp_systolic
+    # ARIC blood_pressure.yaml emits the same random-zero "zero reading"
+    # (SBPA17 / SBPA20) twice, typed as both OMOP:4152194 (systolic) and
+    # OMOP:4154790 (diastolic), distinguished only by method_type. Whether
+    # a calibration offset should carry a BP concept at all is open in #735.
+    "phv00210286",
+    "phv00210289",
 }
+
+
+def _measurement_value_phvs(slots, block_index):
+    """Yield (phv, concept, block_index) for one MeasurementObservation's slots.
+
+    Shared by top-level MeasurementObservation derivations and those nested
+    inside a MeasurementObservationSet.
+    """
+    concept = (slots.get("observation_type") or {}).get("value")
+    for qty_name, qty in iter_nested_class_derivs(slots.get("value_quantity")):
+        if qty_name != "Quantity":
+            continue
+        qty_slots = qty.get("slot_derivations") or {}
+        for val_slot in ("value_decimal", "value_integer", "value_string"):
+            slot_def = qty_slots.get(val_slot) or {}
+            if "populated_from" in slot_def and "value_mappings" not in slot_def and "expr" not in slot_def:
+                phv = slot_def["populated_from"]
+                if phv and str(phv).startswith("phv"):
+                    yield phv, concept, block_index
 
 
 def extract_value_phvs(block, block_index):
@@ -66,17 +86,19 @@ def extract_value_phvs(block, block_index):
                     yield phv, concept, block_index
 
         elif class_name == "MeasurementObservation":
-            concept = (slots.get("observation_type") or {}).get("value")
-            for qty_name, qty in iter_nested_class_derivs(slots.get("value_quantity")):
-                if qty_name != "Quantity":
+            yield from _measurement_value_phvs(slots, block_index)
+
+        elif class_name == "MeasurementObservationSet":
+            # Measurements bundled in a Set hang off `observations` rather than
+            # sitting at the top level, but they are value-bearing in exactly
+            # the same way -- skipping them left blood_pressure and spirometry
+            # specs unchecked.
+            for obs_name, obs in iter_nested_class_derivs(slots.get("observations")):
+                if obs_name != "MeasurementObservation":
                     continue
-                qty_slots = qty.get("slot_derivations") or {}
-                for val_slot in ("value_decimal", "value_integer", "value_string"):
-                    slot_def = qty_slots.get(val_slot) or {}
-                    if "populated_from" in slot_def and "value_mappings" not in slot_def and "expr" not in slot_def:
-                        phv = slot_def["populated_from"]
-                        if phv and str(phv).startswith("phv"):
-                            yield phv, concept, block_index
+                yield from _measurement_value_phvs(
+                    obs.get("slot_derivations") or {}, block_index
+                )
 
 
 def main() -> int:

--- a/check_phv_dedup.py
+++ b/check_phv_dedup.py
@@ -57,7 +57,10 @@ def _measurement_value_phvs(slots, block_index):
         if qty_name != "Quantity":
             continue
         qty_slots = qty.get("slot_derivations") or {}
-        for val_slot in ("value_decimal", "value_integer", "value_string"):
+        # value_concept carries the measured value for coded quantities; slots
+        # that also declare value_mappings or expr are skipped below, so only
+        # raw populated_from concepts are counted.
+        for val_slot in ("value_decimal", "value_integer", "value_string", "value_concept"):
             slot_def = qty_slots.get(val_slot) or {}
             if "populated_from" in slot_def and "value_mappings" not in slot_def and "expr" not in slot_def:
                 phv = slot_def["populated_from"]

--- a/hv-lint/phase-2/check_phv_dedup.py
+++ b/hv-lint/phase-2/check_phv_dedup.py
@@ -82,6 +82,25 @@ def _get_cohort_from_path(file_path: Path) -> str:
 
 
 
+def _measurement_value_phvs(slots, block_index):
+    """Yield (phv, concept, block_index) for one MeasurementObservation's slots.
+
+    Shared by top-level MeasurementObservation derivations and those nested
+    inside a MeasurementObservationSet.
+    """
+    concept = (slots.get("observation_type") or {}).get("value")
+    for qty_name, qty in iter_nested_class_derivs(slots.get("value_quantity")):
+        if qty_name != "Quantity":
+            continue
+        qty_slots = qty.get("slot_derivations") or {}
+        for val_slot in ("value_decimal", "value_integer", "value_string"):
+            slot_def = qty_slots.get(val_slot) or {}
+            if "populated_from" in slot_def and "value_mappings" not in slot_def and "expr" not in slot_def:
+                phv = slot_def["populated_from"]
+                if phv and str(phv).startswith("phv"):
+                    yield phv, concept, block_index
+
+
 def extract_value_phvs(block: dict, block_index: int):
     """Yield (phv, concept, block_index) for value-bearing populated_from fields.
 
@@ -107,17 +126,19 @@ def extract_value_phvs(block: dict, block_index: int):
                     yield phv, concept, block_index
 
         elif class_name == "MeasurementObservation":
-            concept = (slots.get("observation_type") or {}).get("value")
-            for qty_name, qty in iter_nested_class_derivs(slots.get("value_quantity")):
-                if qty_name != "Quantity":
+            yield from _measurement_value_phvs(slots, block_index)
+
+        elif class_name == "MeasurementObservationSet":
+            # Measurements bundled in a Set hang off `observations` rather than
+            # sitting at the top level, but they are value-bearing in exactly
+            # the same way -- skipping them left blood_pressure and spirometry
+            # specs unchecked.
+            for obs_name, obs in iter_nested_class_derivs(slots.get("observations")):
+                if obs_name != "MeasurementObservation":
                     continue
-                qty_slots = qty.get("slot_derivations") or {}
-                for val_slot in ("value_decimal", "value_integer", "value_string"):
-                    slot_def = qty_slots.get(val_slot) or {}
-                    if "populated_from" in slot_def and "value_mappings" not in slot_def and "expr" not in slot_def:
-                        phv = slot_def["populated_from"]
-                        if phv and str(phv).startswith("phv"):
-                            yield phv, concept, block_index
+                yield from _measurement_value_phvs(
+                    obs.get("slot_derivations") or {}, block_index
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/hv-lint/phase-2/check_phv_dedup.py
+++ b/hv-lint/phase-2/check_phv_dedup.py
@@ -93,7 +93,10 @@ def _measurement_value_phvs(slots, block_index):
         if qty_name != "Quantity":
             continue
         qty_slots = qty.get("slot_derivations") or {}
-        for val_slot in ("value_decimal", "value_integer", "value_string"):
+        # value_concept carries the measured value for coded quantities; slots
+        # that also declare value_mappings or expr are skipped below, so only
+        # raw populated_from concepts are counted.
+        for val_slot in ("value_decimal", "value_integer", "value_string", "value_concept"):
             slot_def = qty_slots.get(val_slot) or {}
             if "populated_from" in slot_def and "value_mappings" not in slot_def and "expr" not in slot_def:
                 phv = slot_def["populated_from"]


### PR DESCRIPTION
Teaches both copies of the PHV dedup check to descend into `MeasurementObservationSet.observations`, and re-triages `KNOWN_ISSUES` now that the re-triage can be done honestly.

Closes #735.

## The gap

`extract_value_phvs` branched on top-level `Condition` and `MeasurementObservation` only. Measurements bundled inside a `MeasurementObservationSet` hang off an `observations` slot, so they were never inspected:

| | value-bearing observations |
|---|---|
| top-level (seen) | 2061 |
| inside a Set (**not** seen) | **473** |
| coverage | **81.3%** |

The report still printed "Found 2049 unique value-PHVs / No duplicates found", which reads like full coverage. This affected `blood_pressure.yaml`, `spirometry.yaml`, `spirometry_pre_bd.yaml` and `spirometry_post_bd.yaml` across cohorts — and mattered more over time, since `MeasurementObservationSet` is the pattern we're standardising on for bundled measurements.

## After

| | before | after |
|---|---|---|
| unique value-PHVs | 2049 | **2517** |
| measurement PHVs missed (independent walk) | 468 | **0** |

The `MeasurementObservation` body moved into a small `_measurement_value_phvs` helper so the top-level and in-Set paths share one implementation rather than diverging.

## Two real duplications surface

Restoring coverage exposes what was hiding in the gap — ARIC `blood_pressure.yaml` emits the same random-zero *zero reading* twice, typed as both systolic and diastolic:

```
phv00210286 mapped to 2 concepts:
  OMOP:4152194 in ARIC-ingest/blood_pressure.yaml (block 3)
  OMOP:4154790 in ARIC-ingest/blood_pressure.yaml (block 3)
phv00210289  (same shape, block 5)
```

Both were already in `KNOWN_ISSUES`, so the root check stays green. phase-2 has no suppression list and reports them as `WARNING`, below its `--fail-on error` gate, so hv-lint also stays green while making them visible.

Whether a calibration offset should carry a BP concept at all is a modelling question, left open in #735 rather than decided here.

## KNOWN_ISSUES re-triage

CLAUDE.md asks us to check whether entries can be dropped when pulling from main. That check could not be answered honestly while the gap was open: emptying `KNOWN_ISSUES` still reported "No duplicates found", so all nine entries looked stale and removable.

With coverage restored:

- **7 dropped** — genuinely resolved (`phv00001581`, `phv00079854`–`57`, `phv00100046`, `phv00112688`)
- **2 kept** — `phv00210286`, `phv00210289`, still live, and only ever looked resolved because the check couldn't see them

Removing those two would have looked like routine cleanup while discarding the record of a live issue.

## Note

There's no test suite covering the root `check_phv_dedup.py`, so this fix is verified empirically (counts above, plus an independent structural walk) rather than by a regression test. Adding one would mean introducing test infrastructure for a root-level script — happy to do it if we want that, but it seemed like a separate decision.
