### PR TITLE
Switch expr->value in COPDGene hrt_rt spec unit

### DIFF
--- a/priority_variables_transform/COPDGene-ingest/hrt_rt.yaml
+++ b/priority_variables_transform/COPDGene-ingest/hrt_rt.yaml
@@ -27,4 +27,4 @@
                 value_decimal:
                   populated_from: phv00159584
                 unit:
-                  expr: '{beats}/min'
+                  value: '{beats}/min'


### PR DESCRIPTION
This matches all the other hrt_rt/hrtrt specs.